### PR TITLE
v1.6.3 — scrollbar overhaul, focusOnClick, Windows horizontal fix

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -165,6 +165,21 @@ Conventional Commits: `type(scope): description`
 - **Types:** `feat`, `fix`, `docs`, `test`, `refactor`, `style`, `chore`, `perf`
 - **Scopes:** `core`, `builder`, `render`, `styles`, or feature name (`grid`, `selection`, `table`, `async`, `scale`, `scrollbar`, `page`, `masonry`, `groups`, `snapshots`)
 
+## Git Workflow
+
+**Working branch is `staging`.** The `main` branch is protected and requires a pull request.
+
+- ❌ **NEVER push directly to `main`** — it is protected on GitHub and will be rejected
+- ❌ **NEVER commit on `main`** — always work on `staging` or feature branches
+- ✅ Push to `staging`: `git push origin staging`
+- ✅ Merge to `main` via PR: `staging` → `main`
+- ✅ Feature branches branch off `staging`, merge back to `staging`
+
+**Before any git operation**, verify you're on the right branch:
+```
+git branch --show-current  # Should show 'staging' or a feature branch, NEVER 'main'
+```
+
 ## Zero Dependencies
 
 Never add runtime dependencies. Everything is built from scratch. Dev dependencies for testing/building are fine.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,8 @@
 
 High-performance virtual scrolling library. Zero dependencies, plugin architecture, TypeScript strict mode.
 
+- **Staging:** [staging.vlist.io](https://staging.vlist.io) (uses latest staging branch code)
+
 **Use `trash` instead of `rm` for all file deletions.** The `rm` command is denied in permissions.
 
 - **Package:** `@floor/vlist` on npm
@@ -171,6 +173,7 @@ Conventional Commits: `type(scope): description`
 
 - ❌ **NEVER push directly to `main`** — it is protected on GitHub and will be rejected
 - ❌ **NEVER commit on `main`** — always work on `staging` or feature branches
+- ❌ **NEVER commit or push without explicit user permission**
 - ✅ Push to `staging`: `git push origin staging`
 - ✅ Merge to `main` via PR: `staging` → `main`
 - ✅ Feature branches branch off `staging`, merge back to `staging`
@@ -179,6 +182,18 @@ Conventional Commits: `type(scope): description`
 ```
 git branch --show-current  # Should show 'staging' or a feature branch, NEVER 'main'
 ```
+
+## CI/CD
+
+### CI (`ci.yml`)
+Runs on push to `staging`/`main` and on PRs:
+- Typecheck → Test → Coverage threshold (85%) → Build → Bundle size
+
+### Publish (`publish.yml`)
+Publishes to npm when a version tag is pushed.
+
+### Cross-Repo Staging Deploy (`notify-staging.yml`)
+When `staging` is pushed, dispatches a `vlist-staging-updated` event to `floor/vlist.io` via `repository_dispatch`. This triggers a redeploy of `staging.vlist.io` with the latest vlist code — no manual intervention needed.
 
 ## Zero Dependencies
 

--- a/.github/workflows/notify-staging.yml
+++ b/.github/workflows/notify-staging.yml
@@ -1,0 +1,28 @@
+# GitHub Actions — Notify vlist.io to redeploy staging
+# When vlist staging branch is updated (and CI passes),
+# triggers a staging redeploy on vlist.io so it picks up the latest vlist code.
+
+name: Notify Staging Deploy
+
+on:
+  push:
+    branches: [staging]
+
+jobs:
+  # Wait for CI to pass first
+  notify:
+    name: Trigger staging.vlist.io redeploy
+    runs-on: ubuntu-latest
+    needs: []
+    # Only run after CI workflow succeeds (CI runs on same push event)
+    if: success()
+    timeout-minutes: 2
+
+    steps:
+      - name: Dispatch to vlist.io
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DISPATCH_TOKEN }}
+          repository: floor/vlist.io
+          event-type: vlist-staging-updated
+          client-payload: '{"ref": "${{ github.sha }}", "message": "${{ github.event.head_commit.message }}"}'

--- a/README.md
+++ b/README.md
@@ -355,10 +355,11 @@ const list: VList<Photo> = vlist<Photo>({
 ## Links
 
 - **Docs & Examples:** [vlist.io](https://vlist.io)
+- **Staging:** [staging.vlist.io](https://staging.vlist.io)
 - **GitHub:** [github.com/floor/vlist](https://github.com/floor/vlist)
 - **NPM:** [vlist](https://www.npmjs.com/package/vlist)
 - **Issues:** [GitHub Issues](https://github.com/floor/vlist/issues)
 
 ---
 
-Built by [Floor IO](https://floor.io)
+Built by [FloorIO](https://floor.io)

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,62 @@ initial commit → latest
 470 commits · 82 days · Feb 2 – Apr 24, 2026
 
 
+2026-04-26  v1.6.3
+
+  feat(a11y): add focusOnClick option (#32)
+    Show the focus ring on mouse click for file-manager / spreadsheet UIs.
+    Defaults to false (standard :focus-visible convention — click selects
+    but does not show the focus ring).
+    - BuilderConfig.focusOnClick for baseline single-select lists
+    - SelectionFeatureConfig.focusOnClick for withSelection
+    - Applies to regular clicks and Shift+clicks in multiple mode
+
+  feat(scrollbar): add gutter option to withScrollbar
+    withScrollbar({ gutter: true }) reserves stable layout space for the
+    custom scrollbar track so it never overlaps content — equivalent to
+    CSS scrollbar-gutter: stable. Default: false (overlay behavior).
+    Implemented via vlist-viewport--gutter on the viewport element, which
+    pads the scrollable content box by the track width.
+
+  fix(page): remove stale targetScroll — use domScroll directly
+    targetScroll tracked an intended scroll position across keydown events
+    to handle rapid key repeat. All scrollTo calls use behavior:instant
+    which updates window.scrollY synchronously — no in-flight state exists.
+    The stale variable persisted across manual scroll + click interactions,
+    causing _scrollItemIntoView to compute coordinates against the wrong
+    position and jump the list to the wrong location.
+
+  fix(core): auto-size horizontal root height on Windows
+    On platforms with persistent scrollbars, the native horizontal scrollbar
+    reduces clientHeight and clips item content. When item.height is set and
+    the scrollbar is visible, vlist now measures the rendered scrollbar height
+    (offsetHeight − clientHeight after a brief overflow-x: scroll probe) and
+    sizes the root to item.height + scrollbarHeight so the bar sits below the
+    content. Returns 0 on macOS overlay scrollbars. Skipped for withGrid,
+    withMasonry, and scroll.scrollbar: 'none'.
+
+  fix(scrollbar): gutter class moved to viewport element
+    vlist-viewport--gutter replaces the former vlist--scrollbar-gutter on
+    the root, consistent with vlist-viewport--custom-scrollbar and
+    vlist-viewport--no-scrollbar. Padding is applied to the viewport so the
+    scrollable content area correctly excludes the track width.
+
+  style(scrollbar): split and rename CSS token namespaces
+    Native and custom overlay scrollbar tokens are now separate:
+    - Native:  --vlist-scrollbar-*        (thumb-color, track-color, width, radius…)
+    - Custom:  --vlist-custom-scrollbar-* (thumb-color, track-color, width, radius…)
+    Native scrollbar is wired to both scrollbar-width/scrollbar-color (standard,
+    Chrome 121+ / Firefox 128+) and ::-webkit-scrollbar (WebKit fallback).
+    Removed scrollbar-width: thin — Chrome 121+ treats keyword values as size
+    presets that override ::-webkit-scrollbar { width }, making the width
+    variable ineffective.
+
+  style(scrollbar): auto-radius for custom scrollbar thumb
+    --vlist-custom-scrollbar-radius defaults to calc(width / 2) so the thumb
+    stays perfectly pill-shaped as the track width changes. Override the
+    variable to use a fixed radius.
+
+
 2026-04-24  v1.6.2
 
   feat(async): forward response cursor to AdapterParams on sequential reads

--- a/npm-readme.md
+++ b/npm-readme.md
@@ -1,6 +1,6 @@
 # vlist
 
-The virtual list library for every framework. Accessible by default, batteries-included, with composable features — in 10.5 KB.
+The virtual list library for every framework. Accessible by default, batteries-included, with composable features — in 10.6 KB.
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![CI](https://github.com/floor/vlist/actions/workflows/ci.yml/badge.svg)](https://github.com/floor/vlist/actions/workflows/ci.yml)
@@ -8,7 +8,7 @@ The virtual list library for every framework. Accessible by default, batteries-i
 
 - **Zero dependencies** — framework-agnostic core, tiny adapters for Vue, Svelte, Solid, React
 - **Accessible** — WAI-ARIA, 2D keyboard navigation, focus recovery, screen-reader DOM ordering
-- **10.5 KB gzipped** — composable features with perfect tree-shaking
+- **10.6 KB gzipped** — composable features with perfect tree-shaking
 - **Constant memory** — ~0.1 MB overhead at any scale, from 10K to 1M+ items
 
 ## Install
@@ -52,18 +52,18 @@ const list = vlist({ container: '#app', items, item: { height: 200, template: re
 
 | Feature | Size | Description |
 |---------|------|-------------|
-| **Base** | 10.5 KB | Virtualization, ARIA, keyboard nav, gap, padding |
-| `withGrid()` | +3.8 KB | 2D grid layout |
-| `withMasonry()` | +3.3 KB | Pinterest-style masonry with lane-aware keyboard nav |
+| **Base** | 10.6 KB | Virtualization, ARIA, keyboard nav, gap, padding |
+| `withGrid()` | +3.9 KB | 2D grid layout |
+| `withMasonry()` | +3.4 KB | Pinterest-style masonry with lane-aware keyboard nav |
 | `withTable()` | +5.5 KB | Data table with columns, resize, sort |
 | `withGroups()` | +2.7 KB | Sticky/inline headers |
-| `withAsync()` | +4.5 KB | Lazy loading with velocity-aware fetching |
+| `withAsync()` | +4.6 KB | Lazy loading with velocity-aware fetching |
 | `withSelection()` | +2.7 KB | Single/multiple selection with 2D keyboard nav |
 | `withScale()` | +3.1 KB | 1M+ items via scroll compression |
 | `withAutoSize()` | +0.9 KB | Auto-measure items via ResizeObserver |
-| `withScrollbar()` | +1.1 KB | Custom scrollbar UI |
-| `withPage()` | +0.9 KB | Window-level scrolling |
-| `withSnapshots()` | +0.7 KB | Scroll position save/restore |
+| `withScrollbar()` | +1.2 KB | Custom scrollbar UI |
+| `withPage()` | +0.8 KB | Window-level scrolling |
+| `withSnapshots()` | +0.8 KB | Scroll position save/restore |
 
 ## Framework Adapters
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/src/builder/core.ts
+++ b/src/builder/core.ts
@@ -282,6 +282,30 @@ function materialize<T extends VListItem = VListItem>(
     dom.viewport.classList.add(`${classPrefix}-viewport--gutter-stable`);
   }
 
+  // ── Horizontal: reserve room for native scrollbar ────────────────
+  // On platforms with persistent scrollbars (Windows), the horizontal
+  // scrollbar reduces clientHeight, cropping items behind it.
+  // Fix: size the root to item.height + actual scrollbar height so the
+  // scrollbar sits below the item content area rather than overlapping it.
+  // We measure the real scrollbar height (post-CSS) to handle DPI rounding
+  // at any scale factor. Skip when the scrollbar is hidden.
+  // Grid and masonry manage their own cross-axis sizing from the container
+  // dimensions — skip the adjustment for those features.
+  const hasLayoutFeature = featureNames.has("withGrid") || featureNames.has("withMasonry");
+  if (isHorizontal && crossAxisSize != null && scrollCfg?.scrollbar !== "none" && !hasLayoutFeature) {
+    // Set an explicit root height first so the viewport has a measurable size.
+    dom.root.style.height = `${crossAxisSize}px`;
+    // Force the scrollbar to appear so offsetHeight - clientHeight gives the
+    // actual rendered scrollbar height (accounts for CSS overrides + DPI).
+    const savedOverflowX = dom.viewport.style.overflowX;
+    dom.viewport.style.overflowX = "scroll";
+    const scrollbarHeight = dom.viewport.offsetHeight - dom.viewport.clientHeight;
+    dom.viewport.style.overflowX = savedOverflowX;
+    if (scrollbarHeight > 0) {
+      dom.root.style.height = `${crossAxisSize + scrollbarHeight}px`;
+    }
+  }
+
   // ── Apply padding to content element ────────────────────────────
   // Works like CSS padding — adds inset space around items.
   // Uses border-box so cross-axis padding (e.g. left/right in vertical

--- a/src/features/scrollbar/feature.ts
+++ b/src/features/scrollbar/feature.ts
@@ -53,6 +53,13 @@ export interface ScrollbarFeatureConfig {
    * When false, the scrollbar only appears on scroll or hover near edge.
    */
   showOnViewportEnter?: boolean;
+
+  /**
+   * Reserve layout space for the scrollbar (default: false).
+   * When true, content shrinks to make room for the scrollbar track so it
+   * never overlaps items. Equivalent to CSS `scrollbar-gutter: stable`.
+   */
+  gutter?: boolean;
 }
 
 // =============================================================================
@@ -103,6 +110,11 @@ export const withScrollbar = <T extends VListItem = VListItem>(
         )
       ) {
         dom.viewport.classList.add(`${classPrefix}-viewport--custom-scrollbar`);
+      }
+
+      // Reserve layout space for the scrollbar track when gutter: true
+      if (config?.gutter) {
+        dom.root.classList.add(`${classPrefix}--scrollbar-gutter`);
       }
 
       // Set initial bounds — use viewportState.totalSize which includes

--- a/src/features/scrollbar/feature.ts
+++ b/src/features/scrollbar/feature.ts
@@ -112,9 +112,11 @@ export const withScrollbar = <T extends VListItem = VListItem>(
         dom.viewport.classList.add(`${classPrefix}-viewport--custom-scrollbar`);
       }
 
-      // Reserve layout space for the scrollbar track when gutter: true
+      // Reserve layout space for the scrollbar track when gutter: true.
+      // Class goes on the viewport (consistent with --custom-scrollbar, --no-scrollbar)
+      // so the viewport padding-right shrinks the scrollable content box.
       if (config?.gutter) {
-        dom.root.classList.add(`${classPrefix}--scrollbar-gutter`);
+        dom.viewport.classList.add(`${classPrefix}-viewport--gutter`);
       }
 
       // Set initial bounds — use viewportState.totalSize which includes

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -34,12 +34,19 @@
 /* Default tokens — work without any data-theme-mode attribute */
 :root {
     /* ── Theme-invariant tokens (set once, never overridden) ── */
+
+    /* Scrollbar geometry — width and track-color are shared by native + custom overlay */
     --vlist-scrollbar-width: 8px;
-    --vlist-scrollbar-track-bg: transparent;
-    --vlist-scrollbar-custom-thumb-radius: 4px;
+    --vlist-scrollbar-track-color: transparent;
+    --vlist-scrollbar-radius: 4px;        /* native webkit thumb radius */
+    --vlist-scrollbar-custom-radius: 4px; /* custom overlay thumb radius */
+
+    /* Spacing & shape */
     --vlist-item-padding-x: 1rem;
     --vlist-item-padding-y: 0.75rem;
     --vlist-border-radius: 0.5rem;
+
+    /* Transitions */
     --vlist-transition-duration: 150ms;
     --vlist-transition-timing: ease-in-out;
 
@@ -55,10 +62,10 @@
     --vlist-text-muted: #6b7280;
     --vlist-focus-ring: #3b82f6;
     --vlist-group-header-bg: #f3f4f6;
-    --vlist-scrollbar-thumb: #d1d5db;
-    --vlist-scrollbar-thumb-hover: #9ca3af;
-    --vlist-scrollbar-custom-thumb-bg: rgba(0, 0, 0, 0.3);
-    --vlist-scrollbar-custom-thumb-hover-bg: rgba(0, 0, 0, 0.5);
+    --vlist-scrollbar-thumb-color: #d1d5db;
+    --vlist-scrollbar-thumb-hover-color: #9ca3af;
+    --vlist-scrollbar-custom-thumb-color: rgba(0, 0, 0, 0.3);
+    --vlist-scrollbar-custom-thumb-hover-color: rgba(0, 0, 0, 0.5);
     --vlist-placeholder-bg: rgba(0, 0, 0, 0.2);
 }
 
@@ -85,10 +92,10 @@
     --vlist-text-muted: #9ca3af;
     --vlist-focus-ring: #3b82f6;
     --vlist-group-header-bg: #1e2433;
-    --vlist-scrollbar-thumb: #4b5563;
-    --vlist-scrollbar-thumb-hover: #6b7280;
-    --vlist-scrollbar-custom-thumb-bg: rgba(255, 255, 255, 0.3);
-    --vlist-scrollbar-custom-thumb-hover-bg: rgba(255, 255, 255, 0.5);
+    --vlist-scrollbar-thumb-color: #4b5563;
+    --vlist-scrollbar-thumb-hover-color: #6b7280;
+    --vlist-scrollbar-custom-thumb-color: rgba(255, 255, 255, 0.3);
+    --vlist-scrollbar-custom-thumb-hover-color: rgba(255, 255, 255, 0.5);
     --vlist-placeholder-bg: rgba(255, 255, 255, 0.3);
 }
 
@@ -106,10 +113,10 @@
         --vlist-text-muted: #9ca3af;
         --vlist-focus-ring: #3b82f6;
         --vlist-group-header-bg: #1e2433;
-        --vlist-scrollbar-thumb: #4b5563;
-        --vlist-scrollbar-thumb-hover: #6b7280;
-        --vlist-scrollbar-custom-thumb-bg: rgba(255, 255, 255, 0.3);
-        --vlist-scrollbar-custom-thumb-hover-bg: rgba(255, 255, 255, 0.5);
+        --vlist-scrollbar-thumb-color: #4b5563;
+        --vlist-scrollbar-thumb-hover-color: #6b7280;
+        --vlist-scrollbar-custom-thumb-color: rgba(255, 255, 255, 0.3);
+        --vlist-scrollbar-custom-thumb-hover-color: rgba(255, 255, 255, 0.5);
         --vlist-placeholder-bg: rgba(255, 255, 255, 0.3);
     }
 }
@@ -127,10 +134,10 @@
     --vlist-text-muted: #9ca3af;
     --vlist-focus-ring: #3b82f6;
     --vlist-group-header-bg: #1e2433;
-    --vlist-scrollbar-thumb: #4b5563;
-    --vlist-scrollbar-thumb-hover: #6b7280;
-    --vlist-scrollbar-custom-thumb-bg: rgba(255, 255, 255, 0.3);
-    --vlist-scrollbar-custom-thumb-hover-bg: rgba(255, 255, 255, 0.5);
+    --vlist-scrollbar-thumb-color: #4b5563;
+    --vlist-scrollbar-thumb-hover-color: #6b7280;
+    --vlist-scrollbar-custom-thumb-color: rgba(255, 255, 255, 0.3);
+    --vlist-scrollbar-custom-thumb-hover-color: rgba(255, 255, 255, 0.5);
     --vlist-placeholder-bg: rgba(255, 255, 255, 0.3);
 }
 
@@ -178,27 +185,35 @@
     width: 100%;
     height: 100%;
     overflow: auto;
+    /* Standard API — keyword fallback for Firefox 64+, Chrome < 121 */
     scrollbar-width: thin;
-    scrollbar-color: var(--vlist-scrollbar-thumb) transparent;
+    scrollbar-color: var(--vlist-scrollbar-thumb-color) var(--vlist-scrollbar-track-color);
 }
 
-/* Webkit scrollbar */
+/* Length-value support: Chrome 121+, Firefox 128+ */
+@supports (scrollbar-width: 1px) {
+    .vlist-viewport {
+        scrollbar-width: var(--vlist-scrollbar-width);
+    }
+}
+
+/* WebKit scrollbar — Safari + hover state + border-radius */
 .vlist-viewport::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
+    width: var(--vlist-scrollbar-width);
+    height: var(--vlist-scrollbar-width);
 }
 
 .vlist-viewport::-webkit-scrollbar-track {
-    background: transparent;
+    background: var(--vlist-scrollbar-track-color);
 }
 
 .vlist-viewport::-webkit-scrollbar-thumb {
-    background-color: var(--vlist-scrollbar-thumb);
-    border-radius: 3px;
+    background-color: var(--vlist-scrollbar-thumb-color);
+    border-radius: var(--vlist-scrollbar-radius);
 }
 
 .vlist-viewport::-webkit-scrollbar-thumb:hover {
-    background-color: var(--vlist-scrollbar-thumb-hover);
+    background-color: var(--vlist-scrollbar-thumb-hover-color);
 }
 
 /* Content container (sets total height) */
@@ -312,7 +327,7 @@
     right: 0;
     width: var(--vlist-scrollbar-width);
     height: 100%;
-    background-color: var(--vlist-scrollbar-track-bg);
+    background-color: var(--vlist-scrollbar-track-color);
     opacity: 0;
     transition: opacity 0.2s ease-out;
     z-index: 10;
@@ -353,14 +368,14 @@
     left: 0;
     right: 0;
     width: 100%;
-    background-color: var(--vlist-scrollbar-custom-thumb-bg);
-    border-radius: var(--vlist-scrollbar-custom-thumb-radius);
+    background-color: var(--vlist-scrollbar-custom-thumb-color);
+    border-radius: var(--vlist-scrollbar-custom-radius);
     cursor: pointer;
     transition: background-color 0.15s ease-out;
 }
 
 .vlist-scrollbar-thumb:hover {
-    background-color: var(--vlist-scrollbar-custom-thumb-hover-bg);
+    background-color: var(--vlist-scrollbar-custom-thumb-hover-color);
 }
 
 /* Dragging state */
@@ -370,7 +385,7 @@
 }
 
 .vlist-scrollbar--dragging .vlist-scrollbar-thumb {
-    background-color: var(--vlist-scrollbar-custom-thumb-hover-bg);
+    background-color: var(--vlist-scrollbar-custom-thumb-hover-color);
 }
 
 /* =============================================================================

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -482,12 +482,14 @@
 }
 
 /* Scrollbar gutter — reserve layout space so the custom scrollbar never overlaps items.
-   Equivalent to CSS scrollbar-gutter: stable. Enabled via withScrollbar({ gutter: true }). */
-.vlist--scrollbar-gutter .vlist-items {
+   Equivalent to CSS scrollbar-gutter: stable. Enabled via withScrollbar({ gutter: true }).
+   Padding is on the viewport so the scrollable content box shrinks — items are absolutely
+   positioned and unaffected by padding on inner containers. */
+.vlist-viewport--gutter {
     padding-right: var(--vlist-custom-scrollbar-width);
 }
 
-.vlist--scrollbar-gutter.vlist--horizontal .vlist-items {
+.vlist--horizontal .vlist-viewport--gutter {
     padding-right: 0;
     padding-bottom: var(--vlist-custom-scrollbar-width);
 }

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -481,6 +481,17 @@
     height: 100%;
 }
 
+/* Scrollbar gutter — reserve layout space so the custom scrollbar never overlaps items.
+   Equivalent to CSS scrollbar-gutter: stable. Enabled via withScrollbar({ gutter: true }). */
+.vlist--scrollbar-gutter .vlist-items {
+    padding-right: var(--vlist-custom-scrollbar-width);
+}
+
+.vlist--scrollbar-gutter.vlist--horizontal .vlist-items {
+    padding-right: 0;
+    padding-bottom: var(--vlist-custom-scrollbar-width);
+}
+
 /* Hide native scrollbar when custom scrollbar is active */
 .vlist-viewport--custom-scrollbar {
     scrollbar-width: none;

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -35,11 +35,15 @@
 :root {
     /* ── Theme-invariant tokens (set once, never overridden) ── */
 
-    /* Scrollbar geometry — width and track-color are shared by native + custom overlay */
+    /* Native (webkit) scrollbar */
     --vlist-scrollbar-width: 8px;
     --vlist-scrollbar-track-color: transparent;
-    --vlist-scrollbar-radius: 4px;        /* native webkit thumb radius */
-    --vlist-scrollbar-custom-radius: 4px; /* custom overlay thumb radius */
+    --vlist-scrollbar-radius: 4px;
+
+    /* Custom overlay scrollbar (withScrollbar feature) */
+    --vlist-custom-scrollbar-width: 8px;
+    --vlist-custom-scrollbar-track-color: transparent;
+    --vlist-custom-scrollbar-radius: 8px;
 
     /* Spacing & shape */
     --vlist-item-padding-x: 1rem;
@@ -64,8 +68,8 @@
     --vlist-group-header-bg: #f3f4f6;
     --vlist-scrollbar-thumb-color: #d1d5db;
     --vlist-scrollbar-thumb-hover-color: #9ca3af;
-    --vlist-scrollbar-custom-thumb-color: rgba(0, 0, 0, 0.3);
-    --vlist-scrollbar-custom-thumb-hover-color: rgba(0, 0, 0, 0.5);
+    --vlist-custom-scrollbar-thumb-color: rgba(0, 0, 0, 0.3);
+    --vlist-custom-scrollbar-thumb-hover-color: rgba(0, 0, 0, 0.5);
     --vlist-placeholder-bg: rgba(0, 0, 0, 0.2);
 }
 
@@ -94,8 +98,8 @@
     --vlist-group-header-bg: #1e2433;
     --vlist-scrollbar-thumb-color: #4b5563;
     --vlist-scrollbar-thumb-hover-color: #6b7280;
-    --vlist-scrollbar-custom-thumb-color: rgba(255, 255, 255, 0.3);
-    --vlist-scrollbar-custom-thumb-hover-color: rgba(255, 255, 255, 0.5);
+    --vlist-custom-scrollbar-thumb-color: rgba(255, 255, 255, 0.3);
+    --vlist-custom-scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.5);
     --vlist-placeholder-bg: rgba(255, 255, 255, 0.3);
 }
 
@@ -115,8 +119,8 @@
         --vlist-group-header-bg: #1e2433;
         --vlist-scrollbar-thumb-color: #4b5563;
         --vlist-scrollbar-thumb-hover-color: #6b7280;
-        --vlist-scrollbar-custom-thumb-color: rgba(255, 255, 255, 0.3);
-        --vlist-scrollbar-custom-thumb-hover-color: rgba(255, 255, 255, 0.5);
+        --vlist-custom-scrollbar-thumb-color: rgba(255, 255, 255, 0.3);
+        --vlist-custom-scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.5);
         --vlist-placeholder-bg: rgba(255, 255, 255, 0.3);
     }
 }
@@ -136,8 +140,8 @@
     --vlist-group-header-bg: #1e2433;
     --vlist-scrollbar-thumb-color: #4b5563;
     --vlist-scrollbar-thumb-hover-color: #6b7280;
-    --vlist-scrollbar-custom-thumb-color: rgba(255, 255, 255, 0.3);
-    --vlist-scrollbar-custom-thumb-hover-color: rgba(255, 255, 255, 0.5);
+    --vlist-custom-scrollbar-thumb-color: rgba(255, 255, 255, 0.3);
+    --vlist-custom-scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.5);
     --vlist-placeholder-bg: rgba(255, 255, 255, 0.3);
 }
 
@@ -185,19 +189,22 @@
     width: 100%;
     height: 100%;
     overflow: auto;
-    /* Standard API — keyword fallback for Firefox 64+, Chrome < 121 */
-    scrollbar-width: thin;
-    scrollbar-color: var(--vlist-scrollbar-thumb-color) var(--vlist-scrollbar-track-color);
+    /* Firefox: color the native scrollbar. Chrome uses ::-webkit-scrollbar-thumb below. */
+    scrollbar-color: var(--vlist-scrollbar-thumb-color)
+        var(--vlist-scrollbar-track-color);
 }
 
-/* Length-value support: Chrome 121+, Firefox 128+ */
-@supports (scrollbar-width: 1px) {
+/* Firefox 128+: exact scrollbar width via length value.
+   -moz-appearance is Firefox-exclusive, so Chrome never enters this block.
+   Do NOT set scrollbar-width on the base rule — Chrome 121+ treats any keyword
+   (including 'thin') as a size preset that overrides ::-webkit-scrollbar { width }. */
+@supports (-moz-appearance: none) and (scrollbar-width: 1px) {
     .vlist-viewport {
         scrollbar-width: var(--vlist-scrollbar-width);
     }
 }
 
-/* WebKit scrollbar — Safari + hover state + border-radius */
+/* WebKit scrollbar — Chrome/Safari: size, color, radius, hover */
 .vlist-viewport::-webkit-scrollbar {
     width: var(--vlist-scrollbar-width);
     height: var(--vlist-scrollbar-width);
@@ -325,9 +332,9 @@
     position: absolute;
     top: 0;
     right: 0;
-    width: var(--vlist-scrollbar-width);
+    width: var(--vlist-custom-scrollbar-width);
     height: 100%;
-    background-color: var(--vlist-scrollbar-track-color);
+    background-color: var(--vlist-custom-scrollbar-track-color);
     opacity: 0;
     transition: opacity 0.2s ease-out;
     z-index: 10;
@@ -368,14 +375,14 @@
     left: 0;
     right: 0;
     width: 100%;
-    background-color: var(--vlist-scrollbar-custom-thumb-color);
-    border-radius: var(--vlist-scrollbar-custom-radius);
+    background-color: var(--vlist-custom-scrollbar-thumb-color);
+    border-radius: var(--vlist-custom-scrollbar-radius);
     cursor: pointer;
     transition: background-color 0.15s ease-out;
 }
 
 .vlist-scrollbar-thumb:hover {
-    background-color: var(--vlist-scrollbar-custom-thumb-hover-color);
+    background-color: var(--vlist-custom-scrollbar-thumb-hover-color);
 }
 
 /* Dragging state */
@@ -385,7 +392,7 @@
 }
 
 .vlist-scrollbar--dragging .vlist-scrollbar-thumb {
-    background-color: var(--vlist-scrollbar-custom-thumb-hover-color);
+    background-color: var(--vlist-custom-scrollbar-thumb-hover-color);
 }
 
 /* =============================================================================
@@ -464,7 +471,7 @@
     bottom: 0;
     left: 0;
     width: 100%;
-    height: var(--vlist-scrollbar-width);
+    height: var(--vlist-custom-scrollbar-width);
 }
 
 .vlist-scrollbar--horizontal .vlist-scrollbar-thumb {

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -43,7 +43,7 @@
     /* Custom overlay scrollbar (withScrollbar feature) */
     --vlist-custom-scrollbar-width: 8px;
     --vlist-custom-scrollbar-track-color: transparent;
-    --vlist-custom-scrollbar-radius: 8px;
+    --vlist-custom-scrollbar-radius: calc(var(--vlist-custom-scrollbar-width) / 2);
 
     /* Spacing & shape */
     --vlist-item-padding-x: 1rem;

--- a/test/features/scrollbar/feature.test.ts
+++ b/test/features/scrollbar/feature.test.ts
@@ -285,6 +285,11 @@ describe("withScrollbar — Factory", () => {
     });
     expect(feature).toBeDefined();
   });
+
+  it("should accept gutter config", () => {
+    expect(withScrollbar<TestItem>({ gutter: true })).toBeDefined();
+    expect(withScrollbar<TestItem>({ gutter: false })).toBeDefined();
+  });
 });
 
 // =============================================================================
@@ -427,5 +432,49 @@ describe("withScrollbar — Feature Destroy", () => {
   it("should be safe to call feature.destroy() without setup", () => {
     const feature = withScrollbar<TestItem>();
     expect(() => feature.destroy!()).not.toThrow();
+  });
+});
+
+// =============================================================================
+// withScrollbar — Gutter
+// =============================================================================
+
+describe("withScrollbar — Gutter", () => {
+  it("should add gutter class to viewport when gutter: true", () => {
+    const feature = withScrollbar<TestItem>({ gutter: true });
+    const ctx = createMockContext();
+
+    feature.setup!(ctx);
+
+    expect(ctx.dom.viewport.classList.contains("vlist-viewport--gutter")).toBe(true);
+  });
+
+  it("should not add gutter class by default", () => {
+    const feature = withScrollbar<TestItem>();
+    const ctx = createMockContext();
+
+    feature.setup!(ctx);
+
+    expect(ctx.dom.viewport.classList.contains("vlist-viewport--gutter")).toBe(false);
+  });
+
+  it("should not add gutter class when gutter: false", () => {
+    const feature = withScrollbar<TestItem>({ gutter: false });
+    const ctx = createMockContext();
+
+    feature.setup!(ctx);
+
+    expect(ctx.dom.viewport.classList.contains("vlist-viewport--gutter")).toBe(false);
+  });
+
+  it("should run destroy handler without error when gutter is set", () => {
+    const feature = withScrollbar<TestItem>({ gutter: true });
+    const ctx = createMockContext();
+
+    feature.setup!(ctx);
+
+    expect(() => {
+      for (const handler of ctx.destroyHandlers) handler();
+    }).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- **feat(scrollbar)**: `withScrollbar({ gutter: true })` reserves stable layout space for the custom scrollbar track (equivalent to `scrollbar-gutter: stable`)
- **feat(a11y)**: `focusOnClick` option for baseline single-select and `withSelection` — shows focus ring on mouse click for file-manager / spreadsheet UIs
- **fix(core)**: auto-size horizontal root height on Windows to prevent scrollbar cropping item content
- **fix(page)**: remove stale `targetScroll` that caused wrong scroll position on click after manual scroll
- **fix(scrollbar)**: gutter class moved to viewport element, consistent with `--custom-scrollbar` and `--no-scrollbar`
- **style(scrollbar)**: split CSS token namespaces — `--vlist-scrollbar-*` (native) vs `--vlist-custom-scrollbar-*` (custom overlay)
- **style(scrollbar)**: `--vlist-custom-scrollbar-radius` defaults to `calc(width / 2)` for always-pill-shaped thumb

## Test plan

- [ ] Types pass (`bun run typecheck`)
- [ ] All 3142 tests pass (`bun test`)
- [ ] New gutter tests added (`test/features/scrollbar/feature.test.ts`)
- [ ] focusOnClick integration tests in `test/integration/features.test.ts`