### PR TITLE
feat(scrollbar): per-side padding, click target fix, and scrollbar UX improvements (v1.6.4)

### DIFF
--- a/.github/workflows/notify-staging.yml
+++ b/.github/workflows/notify-staging.yml
@@ -25,4 +25,4 @@ jobs:
           token: ${{ secrets.DISPATCH_TOKEN }}
           repository: floor/vlist.io
           event-type: vlist-staging-updated
-          client-payload: '{"ref": "${{ github.sha }}", "message": "${{ github.event.head_commit.message }}"}'
+          client-payload: '{"ref": "${{ github.sha }}", "message": ${{ toJSON(github.event.head_commit.message) }}}'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The virtual list library for every framework. Accessible by default, batteries-included, with composable features — in 10.5 KB.
 
-**v1.6.2** — [Changelog](./changelog.txt)
+**v1.6.4** — [Changelog](./changelog.txt)
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![CI](https://github.com/floor/vlist/actions/workflows/ci.yml/badge.svg)](https://github.com/floor/vlist/actions/workflows/ci.yml)
@@ -10,7 +10,7 @@ The virtual list library for every framework. Accessible by default, batteries-i
 
 - **Accessible** — WAI-ARIA, 2D keyboard navigation, focus recovery, screen-reader DOM ordering, ARIA live region
 - **Zero dependencies** — framework-agnostic core with tiny adapters for Vue, Svelte, Solid, React
-- **10.5 KB gzipped** — composable features with perfect tree-shaking
+- **10.6 KB gzipped** — composable features with perfect tree-shaking
 - **Constant memory** — ~0.1 MB overhead at any scale, from 10K to 1M+ items
 - **Grid, masonry, table, groups, async, selection, scale** — all opt-in
 - **Vertical & horizontal** — dimension-agnostic API, every layout mode works in both orientations

--- a/README.md
+++ b/README.md
@@ -93,18 +93,18 @@ const list = vlist({
 
 | Feature | Size | Description |
 |---------|------|-------------|
-| **Base** | 10.5 KB | Core virtualization, gap, padding, ARIA live region, baseline keyboard nav |
-| `withGrid()` | +3.8 KB | 2D grid layout with context injection |
-| `withMasonry()` | +3.3 KB | Pinterest-style masonry layout with lane-aware nav |
-| `withGroups()` | +2.7 KB | Grouped lists with sticky/inline headers |
-| `withAsync()` | +4.5 KB | Lazy loading with adapters |
-| `withSelection()` | +2.7 KB | Single/multiple selection + 2D keyboard nav |
+| **Base** | 10.6 KB | Virtualization, ARIA, keyboard nav, gap, padding |
+| `withAsync()` | +4.6 KB | Lazy loading with velocity-aware fetching |
+| `withSelection()` | +2.7 KB | Single/multiple selection with 2D keyboard nav |
 | `withScale()` | +3.1 KB | 1M+ items via scroll compression |
-| `withScrollbar()` | +1.1 KB | Custom scrollbar UI |
-| `withTable()` | +5.5 KB | Data table with columns, resize, sort, groups |
+| `withGroups()` | +2.7 KB | Sticky/inline headers |
 | `withAutoSize()` | +0.9 KB | Auto-measure items via ResizeObserver |
-| `withPage()` | +0.9 KB | Document-level scrolling |
-| `withSnapshots()` | +0.7 KB | Scroll save/restore with autoSave |
+| `withScrollbar()` | +1.7 KB | Custom scrollbar UI |
+| `withGrid()` | +3.9 KB | 2D grid layout |
+| `withMasonry()` | +3.4 KB | Pinterest-style masonry with lane-aware keyboard nav |
+| `withTable()` | +5.5 KB | Data table with columns, resize, sort |
+| `withPage()` | +0.8 KB | Window-level scrolling |
+| `withSnapshots()` | +0.8 KB | Scroll position save/restore |
 
 ## Examples
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,41 @@ initial commit → latest
 470 commits · 82 days · Feb 2 – Apr 24, 2026
 
 
+2026-04-27  v1.6.4
+
+  feat(scrollbar): per-side padding support
+    padding now accepts a number (all sides) or { top?, right?, bottom?, left? }
+    for independent control per edge. Omitted sides default to 2px.
+    - New ScrollbarPadding type exported from public API
+    - Replaces --vlist-custom-scrollbar-padding with four per-side CSS variables:
+      --vlist-custom-scrollbar-padding-{top,right,bottom,left}
+    - Thumb travel uses scroll-axis sides (top+bottom / left+right)
+    - Hover zone default uses wall-side padding (right for vertical, bottom for horizontal)
+    - Stable gutter reserves right-padding + width + left-padding per axis
+
+  feat(scrollbar): add padding, clickBehavior, minThumbSize, and hoverZoneWidth options
+    - padding: inset the track from viewport edges (default: 2px)
+    - clickBehavior: 'page' (default) scrolls by one page toward the click with
+      smooth continuous scroll on hold; 'jump' centers the thumb instantly
+    - minThumbSize: minimum thumb length in pixels (default: 15); also settable
+      via --vlist-custom-scrollbar-min-thumb-size CSS variable
+    - hoverZoneWidth defaults to wall-side padding + 16px so the hover zone
+      always covers the full inset track area regardless of padding
+
+  fix(scrollbar): extend click target into padding margin
+    The edge zone element is now always created (not only when showOnHover is
+    true) so clicks anywhere in the padding margin trigger the same page/jump
+    behavior as clicking the track itself. Existing position clamping handles
+    out-of-track coordinates: above the track scrolls back, below scrolls forward.
+
+  fix(scrollbar): gutter correctly reserves padding on both sides
+    Stable gutter now reserves right-padding + width + left-padding (vertical)
+    or bottom-padding + height + top-padding (horizontal), ensuring the track
+    never overlaps content even when asymmetric padding is configured.
+    CSS variable scope fixed: padding variables are set on the viewport element
+    so the gutter calc() can read them (CSS custom properties only cascade down).
+
+
 2026-04-26  v1.6.3
 
   feat(a11y): add focusOnClick option (#32)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vlist — full changelog
 initial commit → latest
-470 commits · 82 days · Feb 2 – Apr 24, 2026
+577 commits · 83 days · Feb 2 – Apr 27, 2026
 
 
 2026-04-27  v1.6.4

--- a/npm-readme.md
+++ b/npm-readme.md
@@ -53,15 +53,15 @@ const list = vlist({ container: '#app', items, item: { height: 200, template: re
 | Feature | Size | Description |
 |---------|------|-------------|
 | **Base** | 10.6 KB | Virtualization, ARIA, keyboard nav, gap, padding |
-| `withGrid()` | +3.9 KB | 2D grid layout |
-| `withMasonry()` | +3.4 KB | Pinterest-style masonry with lane-aware keyboard nav |
-| `withTable()` | +5.5 KB | Data table with columns, resize, sort |
-| `withGroups()` | +2.7 KB | Sticky/inline headers |
 | `withAsync()` | +4.6 KB | Lazy loading with velocity-aware fetching |
 | `withSelection()` | +2.7 KB | Single/multiple selection with 2D keyboard nav |
 | `withScale()` | +3.1 KB | 1M+ items via scroll compression |
+| `withGroups()` | +2.7 KB | Sticky/inline headers |
 | `withAutoSize()` | +0.9 KB | Auto-measure items via ResizeObserver |
-| `withScrollbar()` | +1.2 KB | Custom scrollbar UI |
+| `withScrollbar()` | +1.7 KB | Custom scrollbar UI |
+| `withGrid()` | +3.9 KB | 2D grid layout |
+| `withMasonry()` | +3.4 KB | Pinterest-style masonry with lane-aware keyboard nav |
+| `withTable()` | +5.5 KB | Data table with columns, resize, sort |
 | `withPage()` | +0.8 KB | Window-level scrolling |
 | `withSnapshots()` | +0.8 KB | Scroll position save/restore |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/src/features/scrollbar/feature.ts
+++ b/src/features/scrollbar/feature.ts
@@ -60,6 +60,15 @@ export interface ScrollbarFeatureConfig {
    * never overlaps items. Equivalent to CSS `scrollbar-gutter: stable`.
    */
   gutter?: boolean;
+
+  /**
+   * Padding between the scrollbar track and the viewport edges in pixels (default: 1).
+   * Insets the track from the right wall and from the top and bottom, so the scrollbar
+   * floats rather than sitting flush against the edges. Also adjusts the thumb travel
+   * range to keep position accurate.
+   * Can also be set globally via the `--vlist-custom-scrollbar-padding` CSS variable.
+   */
+  padding?: number;
 }
 
 // =============================================================================

--- a/src/features/scrollbar/feature.ts
+++ b/src/features/scrollbar/feature.ts
@@ -69,6 +69,14 @@ export interface ScrollbarFeatureConfig {
    * Can also be set globally via the `--vlist-custom-scrollbar-padding` CSS variable.
    */
   padding?: number;
+
+  /**
+   * Behavior when clicking on the scrollbar track (not the thumb) (default: 'jump').
+   * - `'jump'`  — jumps directly to the clicked position (centers the thumb there).
+   * - `'page'`  — scrolls by one page (containerSize) toward the clicked position,
+   *               matching macOS native scrollbar behavior.
+   */
+  clickBehavior?: 'jump' | 'page';
 }
 
 // =============================================================================

--- a/src/features/scrollbar/scrollbar.ts
+++ b/src/features/scrollbar/scrollbar.ts
@@ -216,7 +216,8 @@ export const createScrollbar = (
   // DOM elements
   const track = document.createElement("div");
   const thumb = document.createElement("div");
-  const hoverZone = showOnHover ? document.createElement("div") : null;
+  // Always created: extends click target into the padding margin + handles hover when showOnHover
+  const hoverZone = document.createElement("div");
 
   // =============================================================================
   // DOM Setup
@@ -244,18 +245,17 @@ export const createScrollbar = (
     track.appendChild(thumb);
     viewport.appendChild(track);
 
-    // Hover zone — always pointer-events:auto so mouseenter fires
-    // even when the track is hidden (opacity:0 / pointer-events:none)
-    if (hoverZone) {
-      hoverZone.className = `${classPrefix}-scrollbar-hover`;
-      if (horizontal) {
-        hoverZone.classList.add(`${classPrefix}-scrollbar-hover--horizontal`);
-        hoverZone.style.height = `${hoverZoneWidth}px`;
-      } else {
-        hoverZone.style.width = `${hoverZoneWidth}px`;
-      }
-      viewport.appendChild(hoverZone);
+    // Edge zone — covers the padding margin + track area along the scrollbar edge.
+    // Always present so clicks in the padding margin are captured regardless of showOnHover.
+    // pointer-events:auto so events fire even when the track is hidden (opacity:0).
+    hoverZone.className = `${classPrefix}-scrollbar-hover`;
+    if (horizontal) {
+      hoverZone.classList.add(`${classPrefix}-scrollbar-hover--horizontal`);
+      hoverZone.style.height = `${hoverZoneWidth}px`;
+    } else {
+      hoverZone.style.width = `${hoverZoneWidth}px`;
     }
+    viewport.appendChild(hoverZone);
   };
 
   // =============================================================================
@@ -617,12 +617,14 @@ export const createScrollbar = (
     document.removeEventListener("mousemove", handleMouseMove);
     document.removeEventListener("mouseup", handleMouseUp);
 
-    if (hoverZone) {
+    hoverZone.removeEventListener("click", handleTrackClick);
+    hoverZone.removeEventListener("mousedown", handleTrackMouseDown);
+    if (showOnHover) {
       hoverZone.removeEventListener("mouseenter", handleScrollbarAreaEnter);
       hoverZone.removeEventListener("mouseleave", handleScrollbarAreaLeave);
-      if (hoverZone.parentNode) {
-        hoverZone.parentNode.removeChild(hoverZone);
-      }
+    }
+    if (hoverZone.parentNode) {
+      hoverZone.parentNode.removeChild(hoverZone);
     }
 
     // Remove inline CSS variable overrides from viewport
@@ -652,7 +654,11 @@ export const createScrollbar = (
   viewport.addEventListener("mouseenter", handleViewportEnter);
   viewport.addEventListener("mouseleave", handleViewportLeave);
 
-  if (hoverZone) {
+  // Always: clicks in the padding margin behave the same as track clicks
+  hoverZone.addEventListener("click", handleTrackClick);
+  hoverZone.addEventListener("mousedown", handleTrackMouseDown);
+  // Conditional: hover-to-reveal behavior
+  if (showOnHover) {
     hoverZone.addEventListener("mouseenter", handleScrollbarAreaEnter);
     hoverZone.addEventListener("mouseleave", handleScrollbarAreaLeave);
   }

--- a/src/features/scrollbar/scrollbar.ts
+++ b/src/features/scrollbar/scrollbar.ts
@@ -17,17 +17,8 @@
 // Types
 // =============================================================================
 
-/**
- * Per-side padding for the scrollbar track.
- * Each side defaults to the global `PADDING` constant when omitted.
- * A plain number is shorthand for all four sides.
- */
-export type ScrollbarPadding = number | {
-  top?: number;
-  right?: number;
-  bottom?: number;
-  left?: number;
-};
+import type { ScrollbarPadding } from "../../types";
+export type { ScrollbarPadding } from "../../types";
 
 /** Scrollbar configuration */
 export interface ScrollbarConfig {

--- a/src/features/scrollbar/scrollbar.ts
+++ b/src/features/scrollbar/scrollbar.ts
@@ -17,6 +17,18 @@
 // Types
 // =============================================================================
 
+/**
+ * Per-side padding for the scrollbar track.
+ * Each side defaults to the global `PADDING` constant when omitted.
+ * A plain number is shorthand for all four sides.
+ */
+export type ScrollbarPadding = number | {
+  top?: number;
+  right?: number;
+  bottom?: number;
+  left?: number;
+};
+
 /** Scrollbar configuration */
 export interface ScrollbarConfig {
   /** Enable scrollbar (default: true when compressed) */
@@ -60,13 +72,16 @@ export interface ScrollbarConfig {
   showOnViewportEnter?: boolean;
 
   /**
-   * Padding between the scrollbar track and the viewport edges in pixels (default: 1).
-   * Insets the track from the right wall and from the top and bottom, so the scrollbar
-   * floats rather than sitting flush against the edges. Also adjusts the thumb travel
-   * range to keep position accurate.
-   * Can also be set globally via the `--vlist-custom-scrollbar-padding` CSS variable.
+   * Padding between the scrollbar track and the viewport edges (default: 2).
+   * Insets the track from the edges so the scrollbar floats rather than sitting flush.
+   * Also adjusts the thumb travel range to keep position accurate.
+   *
+   * Accepts a single number (all sides) or an object for per-side control:
+   * `{ top?, right?, bottom?, left? }` — omitted sides default to 2px.
+   *
+   * Can also be set globally via the `--vlist-custom-scrollbar-padding-{side}` CSS variables.
    */
-  padding?: number;
+  padding?: ScrollbarPadding;
 
   /**
    * Behavior when clicking on the scrollbar track (not the thumb) (default: 'jump').
@@ -111,10 +126,34 @@ const MIN_THUMB_SIZE = 15;
 const SHOW_ON_HOVER = true;
 const HOVER_ZONE_REACH = 16; // px of reach beyond the visible track (added to padding for the default)
 const SHOW_ON_VIEWPORT_ENTER = true;
-const PADDING = 1;
+const PADDING = 2;
 const TRACK_CLICK_BEHAVIOR = 'page' as const;
 const PAGE_SCROLL_INITIAL_DELAY = 350; // ms before continuous scroll starts (matches keyboard repeat)
 const PAGE_SCROLL_SPEED_PPS = 12;      // pages per second during held continuous scroll
+
+// =============================================================================
+// Padding resolver
+// =============================================================================
+
+interface ResolvedPadding {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+const resolvePadding = (raw: ScrollbarPadding | undefined): ResolvedPadding => {
+  if (raw === undefined || typeof raw === 'number') {
+    const v = raw ?? PADDING;
+    return { top: v, right: v, bottom: v, left: v };
+  }
+  return {
+    top: raw.top ?? PADDING,
+    right: raw.right ?? PADDING,
+    bottom: raw.bottom ?? PADDING,
+    left: raw.left ?? PADDING,
+  };
+};
 
 // =============================================================================
 // Factory
@@ -142,12 +181,18 @@ export const createScrollbar = (
     minThumbSize = MIN_THUMB_SIZE,
     showOnHover = SHOW_ON_HOVER,
     showOnViewportEnter = SHOW_ON_VIEWPORT_ENTER,
-    padding = PADDING,
     clickBehavior = TRACK_CLICK_BEHAVIOR,
   } = config;
 
-  // Hover zone covers padding offset + fixed reach beyond the track edge
-  const hoverZoneWidth = config.hoverZoneWidth ?? (padding + HOVER_ZONE_REACH);
+  const pad = resolvePadding(config.padding);
+
+  // Axis-aware padding: start/end along the scroll axis, wall-side for hover zone default
+  const scrollAxisStartPad = horizontal ? pad.left : pad.top;
+  const scrollAxisEndPad   = horizontal ? pad.right : pad.bottom;
+  const wallPad            = horizontal ? pad.bottom : pad.right;
+
+  // Hover zone covers wall-gap + fixed reach beyond the track edge
+  const hoverZoneWidth = config.hoverZoneWidth ?? (wallPad + HOVER_ZONE_REACH);
 
   // State
   let totalSize = 0;
@@ -195,7 +240,10 @@ export const createScrollbar = (
     }
 
     if (config.padding !== undefined) {
-      track.style.setProperty("--vlist-custom-scrollbar-padding", `${padding}px`);
+      viewport.style.setProperty("--vlist-custom-scrollbar-padding-top",    `${pad.top}px`);
+      viewport.style.setProperty("--vlist-custom-scrollbar-padding-right",  `${pad.right}px`);
+      viewport.style.setProperty("--vlist-custom-scrollbar-padding-bottom", `${pad.bottom}px`);
+      viewport.style.setProperty("--vlist-custom-scrollbar-padding-left",   `${pad.left}px`);
     }
 
     if (config.minThumbSize !== undefined) {
@@ -288,8 +336,8 @@ export const createScrollbar = (
       return;
     }
 
-    // Effective track length shrinks by the margin on both ends
-    const trackLength = Math.max(0, containerSize - 2 * padding);
+    // Effective track length shrinks by the margin on both ends (start + end along scroll axis)
+    const trackLength = Math.max(0, containerSize - scrollAxisStartPad - scrollAxisEndPad);
 
     // Calculate thumb size (proportional to visible content, scaled to track)
     const scrollRatio = containerSize / totalSize;
@@ -585,6 +633,12 @@ export const createScrollbar = (
         hoverZone.parentNode.removeChild(hoverZone);
       }
     }
+
+    // Remove inline CSS variable overrides from viewport
+    viewport.style.removeProperty("--vlist-custom-scrollbar-padding-top");
+    viewport.style.removeProperty("--vlist-custom-scrollbar-padding-right");
+    viewport.style.removeProperty("--vlist-custom-scrollbar-padding-bottom");
+    viewport.style.removeProperty("--vlist-custom-scrollbar-padding-left");
 
     // Remove DOM elements
     if (track.parentNode) {

--- a/src/features/scrollbar/scrollbar.ts
+++ b/src/features/scrollbar/scrollbar.ts
@@ -28,7 +28,10 @@ export interface ScrollbarConfig {
   /** Auto-hide delay in milliseconds (default: 1000) */
   autoHideDelay?: number;
 
-  /** Minimum thumb size in pixels (default: 30) */
+  /**
+   * Minimum thumb size in pixels (default: 15).
+   * Can also be set globally via the `--vlist-custom-scrollbar-min-thumb-size` CSS variable.
+   */
   minThumbSize?: number;
 
   /**
@@ -40,8 +43,10 @@ export interface ScrollbarConfig {
   showOnHover?: boolean;
 
   /**
-   * Width of the invisible hover zone in pixels (default: 16).
+   * Width of the invisible hover zone in pixels.
    * Only used when `showOnHover` is true.
+   * Defaults to `padding + 16` so the zone always covers the full inset track
+   * area plus a comfortable reach buffer, regardless of how much padding is set.
    * A wider zone makes the scrollbar easier to discover;
    * a narrower zone avoids interference with content near the edge.
    */
@@ -102,9 +107,9 @@ export type ScrollCallback = (position: number) => void;
 
 const AUTO_HIDE = true;
 const AUTO_HIDE_DELAY = 1000;
-const MIN_THUMB_SIZE = 30;
+const MIN_THUMB_SIZE = 15;
 const SHOW_ON_HOVER = true;
-const HOVER_ZONE_WIDTH = 16;
+const HOVER_ZONE_REACH = 16; // px of reach beyond the visible track (added to padding for the default)
 const SHOW_ON_VIEWPORT_ENTER = true;
 const PADDING = 1;
 const TRACK_CLICK_BEHAVIOR = 'page' as const;
@@ -136,11 +141,13 @@ export const createScrollbar = (
     autoHideDelay = AUTO_HIDE_DELAY,
     minThumbSize = MIN_THUMB_SIZE,
     showOnHover = SHOW_ON_HOVER,
-    hoverZoneWidth = HOVER_ZONE_WIDTH,
     showOnViewportEnter = SHOW_ON_VIEWPORT_ENTER,
     padding = PADDING,
     clickBehavior = TRACK_CLICK_BEHAVIOR,
   } = config;
+
+  // Hover zone covers padding offset + fixed reach beyond the track edge
+  const hoverZoneWidth = config.hoverZoneWidth ?? (padding + HOVER_ZONE_REACH);
 
   // State
   let totalSize = 0;
@@ -189,6 +196,10 @@ export const createScrollbar = (
 
     if (config.padding !== undefined) {
       track.style.setProperty("--vlist-custom-scrollbar-padding", `${padding}px`);
+    }
+
+    if (config.minThumbSize !== undefined) {
+      track.style.setProperty("--vlist-custom-scrollbar-min-thumb-size", `${minThumbSize}px`);
     }
 
     track.appendChild(thumb);

--- a/src/features/scrollbar/scrollbar.ts
+++ b/src/features/scrollbar/scrollbar.ts
@@ -62,6 +62,14 @@ export interface ScrollbarConfig {
    * Can also be set globally via the `--vlist-custom-scrollbar-padding` CSS variable.
    */
   padding?: number;
+
+  /**
+   * Behavior when clicking on the scrollbar track (not the thumb) (default: 'jump').
+   * - `'jump'`  — jumps directly to the clicked position (centers the thumb there).
+   * - `'page'`  — scrolls by one page (containerSize) toward the clicked position,
+   *               matching macOS native scrollbar behavior.
+   */
+  clickBehavior?: 'jump' | 'page';
 }
 
 /** Scrollbar instance */
@@ -99,6 +107,9 @@ const SHOW_ON_HOVER = true;
 const HOVER_ZONE_WIDTH = 16;
 const SHOW_ON_VIEWPORT_ENTER = true;
 const PADDING = 1;
+const TRACK_CLICK_BEHAVIOR = 'page' as const;
+const PAGE_SCROLL_INITIAL_DELAY = 350; // ms before continuous scroll starts (matches keyboard repeat)
+const PAGE_SCROLL_SPEED_PPS = 12;      // pages per second during held continuous scroll
 
 // =============================================================================
 // Factory
@@ -128,6 +139,7 @@ export const createScrollbar = (
     hoverZoneWidth = HOVER_ZONE_WIDTH,
     showOnViewportEnter = SHOW_ON_VIEWPORT_ENTER,
     padding = PADDING,
+    clickBehavior = TRACK_CLICK_BEHAVIOR,
   } = config;
 
   // State
@@ -144,6 +156,11 @@ export const createScrollbar = (
   let visible = false;
   let animationFrameId: number | null = null;
   let lastRequestedPosition: number | null = null;
+  let pageClickPos = 0;
+  let pageScrollPosition = 0; // internal tracker — updated synchronously each tick
+  let repeatTimeout: ReturnType<typeof setTimeout> | null = null;
+  let repeatRafId: number | null = null;
+  let repeatLastTime: number | null = null;
 
   // Axis helpers — select CSS property / mouse coordinate once
   const thumbSizeProp = horizontal ? "width" : "height";
@@ -290,33 +307,119 @@ export const createScrollbar = (
   };
 
   // =============================================================================
-  // Track Click Handler
+  // Track Click Handlers
   // =============================================================================
 
+  // 'jump' — instantly center thumb at clicked position
   const handleTrackClick = (e: MouseEvent): void => {
-    // Ignore clicks on thumb
-    if (e.target === thumb) return;
+    if (e.target === thumb || clickBehavior !== 'jump' || maxThumbTravel <= 0) return;
 
+    const maxScroll = totalSize - containerSize;
     const trackRect = track.getBoundingClientRect();
     const clickPos = mousePos(e) - trackRect[rectStart];
-
-    // Center thumb at click position
-    const targetThumbCenter = clickPos;
-    const targetThumbStart = targetThumbCenter - thumbSize / 2;
-
-    // Clamp to valid range
     const clampedThumbStart = Math.max(
       0,
-      Math.min(targetThumbStart, maxThumbTravel),
+      Math.min(clickPos - thumbSize / 2, maxThumbTravel),
     );
-
-    // Convert to scroll position
-    const scrollRatio = clampedThumbStart / maxThumbTravel;
-    const maxScroll = totalSize - containerSize;
-    const targetScrollPosition = scrollRatio * maxScroll;
-
-    onScroll(targetScrollPosition);
+    onScroll((clampedThumbStart / maxThumbTravel) * maxScroll);
     show();
+  };
+
+  const clearRepeat = (): void => {
+    if (repeatTimeout !== null) { clearTimeout(repeatTimeout); repeatTimeout = null; }
+    if (repeatRafId !== null) { cancelAnimationFrame(repeatRafId); repeatRafId = null; }
+    repeatLastTime = null;
+  };
+
+  // Compute direction toward pageClickPos; returns -1 (back), 1 (forward), or 0 (arrived).
+  // Caller must provide maxScroll to avoid recomputing it.
+  const pageScrollDirection = (maxScroll: number): -1 | 0 | 1 => {
+    const thumbCurrentStart =
+      maxThumbTravel > 0 ? (pageScrollPosition / maxScroll) * maxThumbTravel : 0;
+    if (pageClickPos < thumbCurrentStart) return -1;
+    if (pageClickPos >= thumbCurrentStart + thumbSize) return 1;
+    return 0;
+  };
+
+  // 'page' — immediate first scroll by one containerSize toward click
+  const firePageScroll = (): void => {
+    const maxScroll = totalSize - containerSize;
+    const dir = pageScrollDirection(maxScroll);
+    if (dir === 0) { clearRepeat(); return; }
+    if (dir === -1) {
+      if (pageScrollPosition <= 0) { clearRepeat(); return; }
+      const newPos = Math.max(0, pageScrollPosition - containerSize);
+      pageScrollPosition = newPos;
+      onScroll(newPos);
+    } else {
+      if (pageScrollPosition >= maxScroll) { clearRepeat(); return; }
+      const newPos = Math.min(maxScroll, pageScrollPosition + containerSize);
+      pageScrollPosition = newPos;
+      onScroll(newPos);
+    }
+    show();
+  };
+
+  // Continuous RAF loop — runs after initial delay while mouse is held
+  const tickContinuousScroll = (timestamp: number): void => {
+    // First frame: record baseline time and reschedule without scrolling
+    if (repeatLastTime === null) {
+      repeatLastTime = timestamp;
+      repeatRafId = requestAnimationFrame(tickContinuousScroll);
+      return;
+    }
+
+    const maxScroll = totalSize - containerSize;
+    const dt = timestamp - repeatLastTime;
+    repeatLastTime = timestamp;
+
+    const dir = pageScrollDirection(maxScroll);
+    if (dir === 0) { clearRepeat(); return; }
+
+    // Speed in px/ms, capped so one frame never overshoots more than containerSize
+    const speed = (PAGE_SCROLL_SPEED_PPS * containerSize) / 1000;
+    const delta = Math.min(speed * dt, containerSize);
+
+    if (dir === -1) {
+      if (pageScrollPosition <= 0) { clearRepeat(); return; }
+      const newPos = Math.max(0, pageScrollPosition - delta);
+      pageScrollPosition = newPos;
+      onScroll(newPos);
+    } else {
+      if (pageScrollPosition >= maxScroll) { clearRepeat(); return; }
+      const newPos = Math.min(maxScroll, pageScrollPosition + delta);
+      pageScrollPosition = newPos;
+      onScroll(newPos);
+    }
+    // Keep scrollbar visible without creating a new hide timer every frame
+    clearHideTimeout();
+    repeatRafId = requestAnimationFrame(tickContinuousScroll);
+  };
+
+  const handleRepeatMouseUp = (): void => {
+    clearRepeat();
+    // Begin auto-hide now that the hold has ended
+    scheduleHide();
+    document.removeEventListener('mouseup', handleRepeatMouseUp);
+  };
+
+  // 'page' — immediate first scroll then smooth continuous scroll while held
+  const handleTrackMouseDown = (e: MouseEvent): void => {
+    if (e.target === thumb || clickBehavior !== 'page') return;
+    e.preventDefault();
+
+    const trackRect = track.getBoundingClientRect();
+    pageClickPos = mousePos(e) - trackRect[rectStart];
+    pageScrollPosition = currentScrollPosition;
+
+    firePageScroll();
+
+    // After initial delay, begin smooth RAF-driven continuous scroll
+    repeatTimeout = setTimeout(() => {
+      repeatRafId = requestAnimationFrame(tickContinuousScroll);
+    }, PAGE_SCROLL_INITIAL_DELAY);
+
+    document.addEventListener('mouseup', handleRepeatMouseUp);
   };
 
   // =============================================================================
@@ -445,6 +548,7 @@ export const createScrollbar = (
   const destroy = (): void => {
     // Clear timers
     clearHideTimeout();
+    clearRepeat();
 
     if (animationFrameId !== null) {
       cancelAnimationFrame(animationFrameId);
@@ -453,7 +557,9 @@ export const createScrollbar = (
 
     // Remove event listeners
     track.removeEventListener("click", handleTrackClick);
+    track.removeEventListener("mousedown", handleTrackMouseDown);
     track.removeEventListener("mouseenter", handleScrollbarAreaEnter);
+    document.removeEventListener("mouseup", handleRepeatMouseUp);
     track.removeEventListener("mouseleave", handleScrollbarAreaLeave);
     thumb.removeEventListener("mousedown", handleThumbMouseDown);
     viewport.removeEventListener("mouseenter", handleViewportEnter);
@@ -483,6 +589,7 @@ export const createScrollbar = (
 
   // Attach event listeners
   track.addEventListener("click", handleTrackClick);
+  track.addEventListener("mousedown", handleTrackMouseDown);
   track.addEventListener("mouseenter", handleScrollbarAreaEnter);
   track.addEventListener("mouseleave", handleScrollbarAreaLeave);
   thumb.addEventListener("mousedown", handleThumbMouseDown);

--- a/src/features/scrollbar/scrollbar.ts
+++ b/src/features/scrollbar/scrollbar.ts
@@ -135,7 +135,9 @@ interface ResolvedPadding {
 }
 
 const resolvePadding = (raw: ScrollbarPadding | undefined): ResolvedPadding => {
-  if (raw === undefined || typeof raw === 'number') {
+  // typeof !== 'object' narrows raw to number | undefined in the true branch,
+  // avoiding a narrowing gap that occurs with the equivalent (raw === undefined || typeof raw === 'number') OR form.
+  if (typeof raw !== 'object') {
     const v = raw ?? PADDING;
     return { top: v, right: v, bottom: v, left: v };
   }

--- a/src/features/scrollbar/scrollbar.ts
+++ b/src/features/scrollbar/scrollbar.ts
@@ -53,6 +53,15 @@ export interface ScrollbarConfig {
    * near the scrollbar edge (if `showOnHover` is true).
    */
   showOnViewportEnter?: boolean;
+
+  /**
+   * Padding between the scrollbar track and the viewport edges in pixels (default: 1).
+   * Insets the track from the right wall and from the top and bottom, so the scrollbar
+   * floats rather than sitting flush against the edges. Also adjusts the thumb travel
+   * range to keep position accurate.
+   * Can also be set globally via the `--vlist-custom-scrollbar-padding` CSS variable.
+   */
+  padding?: number;
 }
 
 /** Scrollbar instance */
@@ -89,6 +98,7 @@ const MIN_THUMB_SIZE = 30;
 const SHOW_ON_HOVER = true;
 const HOVER_ZONE_WIDTH = 16;
 const SHOW_ON_VIEWPORT_ENTER = true;
+const PADDING = 1;
 
 // =============================================================================
 // Factory
@@ -117,6 +127,7 @@ export const createScrollbar = (
     showOnHover = SHOW_ON_HOVER,
     hoverZoneWidth = HOVER_ZONE_WIDTH,
     showOnViewportEnter = SHOW_ON_VIEWPORT_ENTER,
+    padding = PADDING,
   } = config;
 
   // State
@@ -157,6 +168,10 @@ export const createScrollbar = (
 
     if (horizontal) {
       track.classList.add(`${classPrefix}-scrollbar--horizontal`);
+    }
+
+    if (config.padding !== undefined) {
+      track.style.setProperty("--vlist-custom-scrollbar-padding", `${padding}px`);
     }
 
     track.appendChild(thumb);
@@ -245,13 +260,16 @@ export const createScrollbar = (
       return;
     }
 
-    // Calculate thumb size (proportional to visible content)
+    // Effective track length shrinks by the margin on both ends
+    const trackLength = Math.max(0, containerSize - 2 * padding);
+
+    // Calculate thumb size (proportional to visible content, scaled to track)
     const scrollRatio = containerSize / totalSize;
-    thumbSize = Math.max(minThumbSize, scrollRatio * containerSize);
+    thumbSize = Math.max(minThumbSize, scrollRatio * trackLength);
     thumb.style[thumbSizeProp] = `${thumbSize}px`;
 
     // Calculate max thumb travel distance
-    maxThumbTravel = containerSize - thumbSize;
+    maxThumbTravel = trackLength - thumbSize;
 
     // Update position with current scroll
     updatePosition(currentScrollPosition);

--- a/src/features/scrollbar/scrollbar.ts
+++ b/src/features/scrollbar/scrollbar.ts
@@ -46,12 +46,13 @@ export interface ScrollbarConfig {
   showOnHover?: boolean;
 
   /**
-   * Width of the invisible hover zone in pixels.
-   * Only used when `showOnHover` is true.
-   * Defaults to `padding + 16` so the zone always covers the full inset track
-   * area plus a comfortable reach buffer, regardless of how much padding is set.
-   * A wider zone makes the scrollbar easier to discover;
-   * a narrower zone avoids interference with content near the edge.
+   * Width of the edge zone in pixels (default: `wallPadding + 16`).
+   * The edge zone covers the scrollbar edge including the padding margin, making
+   * the full area clickable regardless of `showOnHover`. When `showOnHover` is
+   * true, it also acts as the hover-to-reveal target.
+   * Defaults to wall-side padding (`right` for vertical, `bottom` for horizontal)
+   * plus 16px reach, so the zone always covers the full inset track plus a
+   * comfortable buffer.
    */
   hoverZoneWidth?: number;
 
@@ -75,10 +76,10 @@ export interface ScrollbarConfig {
   padding?: ScrollbarPadding;
 
   /**
-   * Behavior when clicking on the scrollbar track (not the thumb) (default: 'jump').
-   * - `'jump'`  — jumps directly to the clicked position (centers the thumb there).
+   * Behavior when clicking on the scrollbar track (not the thumb) (default: 'page').
    * - `'page'`  — scrolls by one page (containerSize) toward the clicked position,
-   *               matching macOS native scrollbar behavior.
+   *               matching macOS native scrollbar behavior. Hold to scroll continuously.
+   * - `'jump'`  — jumps directly to the clicked position (centers the thumb there).
    */
   clickBehavior?: 'jump' | 'page';
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export type {
 
   // Scrollbar
   ScrollbarConfig,
+  ScrollbarPadding,
   ScrollbarOptions,
 
   // Scroll

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -44,6 +44,7 @@
     --vlist-custom-scrollbar-width: 8px;
     --vlist-custom-scrollbar-track-color: transparent;
     --vlist-custom-scrollbar-radius: calc(var(--vlist-custom-scrollbar-width) / 2);
+    --vlist-custom-scrollbar-padding: 1px;
 
     /* Spacing & shape */
     --vlist-item-padding-x: 1rem;
@@ -330,10 +331,10 @@
 /* Scrollbar track */
 .vlist-scrollbar {
     position: absolute;
-    top: 0;
-    right: 0;
+    top: var(--vlist-custom-scrollbar-padding);
+    right: var(--vlist-custom-scrollbar-padding);
+    bottom: var(--vlist-custom-scrollbar-padding);
     width: var(--vlist-custom-scrollbar-width);
-    height: 100%;
     background-color: var(--vlist-custom-scrollbar-track-color);
     opacity: 0;
     transition: opacity 0.2s ease-out;
@@ -467,10 +468,8 @@
 /* Horizontal custom scrollbar — track at bottom, thumb moves on X axis */
 .vlist-scrollbar--horizontal {
     top: auto;
-    right: auto;
-    bottom: 0;
-    left: 0;
-    width: 100%;
+    left: var(--vlist-custom-scrollbar-padding);
+    width: auto;
     height: var(--vlist-custom-scrollbar-width);
 }
 

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -44,7 +44,10 @@
     --vlist-custom-scrollbar-width: 8px;
     --vlist-custom-scrollbar-track-color: transparent;
     --vlist-custom-scrollbar-radius: 4px;
-    --vlist-custom-scrollbar-padding: 1px;
+    --vlist-custom-scrollbar-padding-top: 2px;
+    --vlist-custom-scrollbar-padding-right: 2px;
+    --vlist-custom-scrollbar-padding-bottom: 2px;
+    --vlist-custom-scrollbar-padding-left: 2px;
     --vlist-custom-scrollbar-min-thumb-size: 15px;
 
     /* Spacing & shape */
@@ -332,9 +335,9 @@
 /* Scrollbar track */
 .vlist-scrollbar {
     position: absolute;
-    top: var(--vlist-custom-scrollbar-padding);
-    right: var(--vlist-custom-scrollbar-padding);
-    bottom: var(--vlist-custom-scrollbar-padding);
+    top: var(--vlist-custom-scrollbar-padding-top);
+    right: var(--vlist-custom-scrollbar-padding-right);
+    bottom: var(--vlist-custom-scrollbar-padding-bottom);
     width: var(--vlist-custom-scrollbar-width);
     background-color: var(--vlist-custom-scrollbar-track-color);
     opacity: 0;
@@ -469,7 +472,9 @@
 /* Horizontal custom scrollbar — track at bottom, thumb moves on X axis */
 .vlist-scrollbar--horizontal {
     top: auto;
-    left: var(--vlist-custom-scrollbar-padding);
+    left: var(--vlist-custom-scrollbar-padding-left);
+    right: var(--vlist-custom-scrollbar-padding-right);
+    bottom: var(--vlist-custom-scrollbar-padding-bottom);
     width: auto;
     height: var(--vlist-custom-scrollbar-width);
 }
@@ -484,14 +489,16 @@
 /* Scrollbar gutter — reserve layout space so the custom scrollbar never overlaps items.
    Equivalent to CSS scrollbar-gutter: stable. Enabled via withScrollbar({ gutter: true }).
    Padding is on the viewport so the scrollable content box shrinks — items are absolutely
-   positioned and unaffected by padding on inner containers. */
+   positioned and unaffected by padding on inner containers.
+   Vertical: right-wall inset + track width + left breathing room.
+   Horizontal: bottom-wall inset + track height + top breathing room. */
 .vlist-viewport--gutter {
-    padding-right: var(--vlist-custom-scrollbar-width);
+    padding-right: calc(var(--vlist-custom-scrollbar-padding-right) + var(--vlist-custom-scrollbar-width) + var(--vlist-custom-scrollbar-padding-left));
 }
 
 .vlist--horizontal .vlist-viewport--gutter {
     padding-right: 0;
-    padding-bottom: var(--vlist-custom-scrollbar-width);
+    padding-bottom: calc(var(--vlist-custom-scrollbar-padding-bottom) + var(--vlist-custom-scrollbar-width) + var(--vlist-custom-scrollbar-padding-top));
 }
 
 /* Hide native scrollbar when custom scrollbar is active */

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -43,7 +43,7 @@
     /* Custom overlay scrollbar (withScrollbar feature) */
     --vlist-custom-scrollbar-width: 8px;
     --vlist-custom-scrollbar-track-color: transparent;
-    --vlist-custom-scrollbar-radius: calc(var(--vlist-custom-scrollbar-width) / 2);
+    --vlist-custom-scrollbar-radius: 4px;
     --vlist-custom-scrollbar-padding: 1px;
 
     /* Spacing & shape */
@@ -69,8 +69,8 @@
     --vlist-group-header-bg: #f3f4f6;
     --vlist-scrollbar-thumb-color: #d1d5db;
     --vlist-scrollbar-thumb-hover-color: #9ca3af;
-    --vlist-custom-scrollbar-thumb-color: rgba(0, 0, 0, 0.3);
-    --vlist-custom-scrollbar-thumb-hover-color: rgba(0, 0, 0, 0.5);
+    --vlist-custom-scrollbar-thumb-color: rgba(0, 0, 0, 0.2);
+    --vlist-custom-scrollbar-thumb-hover-color: rgba(0, 0, 0, 0.3);
     --vlist-placeholder-bg: rgba(0, 0, 0, 0.2);
 }
 
@@ -99,8 +99,8 @@
     --vlist-group-header-bg: #1e2433;
     --vlist-scrollbar-thumb-color: #4b5563;
     --vlist-scrollbar-thumb-hover-color: #6b7280;
-    --vlist-custom-scrollbar-thumb-color: rgba(255, 255, 255, 0.3);
-    --vlist-custom-scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.5);
+    --vlist-custom-scrollbar-thumb-color: rgba(255, 255, 255, 0.2);
+    --vlist-custom-scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.3);
     --vlist-placeholder-bg: rgba(255, 255, 255, 0.3);
 }
 
@@ -120,8 +120,8 @@
         --vlist-group-header-bg: #1e2433;
         --vlist-scrollbar-thumb-color: #4b5563;
         --vlist-scrollbar-thumb-hover-color: #6b7280;
-        --vlist-custom-scrollbar-thumb-color: rgba(255, 255, 255, 0.3);
-        --vlist-custom-scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.5);
+        --vlist-custom-scrollbar-thumb-color: rgba(255, 255, 255, 0.2);
+        --vlist-custom-scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.3);
         --vlist-placeholder-bg: rgba(255, 255, 255, 0.3);
     }
 }
@@ -141,8 +141,8 @@
     --vlist-group-header-bg: #1e2433;
     --vlist-scrollbar-thumb-color: #4b5563;
     --vlist-scrollbar-thumb-hover-color: #6b7280;
-    --vlist-custom-scrollbar-thumb-color: rgba(255, 255, 255, 0.3);
-    --vlist-custom-scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.5);
+    --vlist-custom-scrollbar-thumb-color: rgba(255, 255, 255, 0.2);
+    --vlist-custom-scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.3);
     --vlist-placeholder-bg: rgba(255, 255, 255, 0.3);
 }
 

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -45,6 +45,7 @@
     --vlist-custom-scrollbar-track-color: transparent;
     --vlist-custom-scrollbar-radius: 4px;
     --vlist-custom-scrollbar-padding: 1px;
+    --vlist-custom-scrollbar-min-thumb-size: 15px;
 
     /* Spacing & shape */
     --vlist-item-padding-x: 1rem;

--- a/src/types.ts
+++ b/src/types.ts
@@ -374,6 +374,18 @@ export interface ScrollbarOptions {
   showOnViewportEnter?: boolean;
 }
 
+/**
+ * Per-side padding for the scrollbar track.
+ * Each side defaults to the global `PADDING` constant when omitted.
+ * A plain number is shorthand for all four sides.
+ */
+export type ScrollbarPadding = number | {
+  top?: number;
+  right?: number;
+  bottom?: number;
+  left?: number;
+};
+
 // =============================================================================
 // Scrollbar (legacy — use ScrollConfig.scrollbar instead)
 // =============================================================================

--- a/test/features/scrollbar/scrollbar.test.ts
+++ b/test/features/scrollbar/scrollbar.test.ts
@@ -258,27 +258,228 @@ describe("createScrollbar", () => {
 
       const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
 
-      // Mock getBoundingClientRect
       track.getBoundingClientRect = () => ({
-        top: 0,
-        left: 0,
-        right: 300,
-        bottom: 400,
-        width: 8,
-        height: 400,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
+        top: 0, left: 0, right: 300, bottom: 400,
+        width: 8, height: 400, x: 0, y: 0, toJSON: () => ({}),
       });
 
-      // Simulate click at middle of track
-      const clickEvent = new MouseEvent("click", {
-        clientY: 200,
-        bubbles: true,
-      });
-      track.dispatchEvent(clickEvent);
+      // Default is 'page' — uses mousedown
+      track.dispatchEvent(new MouseEvent("mousedown", { clientY: 350, bubbles: true }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
 
       expect(onScrollMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("clickBehavior", () => {
+    it("'jump' — centers thumb at click position", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, { autoHide: false, clickBehavior: 'jump' });
+      scrollbar.updateBounds(1000, 400);
+      scrollbar.show();
+
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      track.getBoundingClientRect = () => ({
+        top: 0, left: 0, right: 8, bottom: 400,
+        width: 8, height: 400, x: 0, y: 0, toJSON: () => ({}),
+      });
+
+      // Click at top of track (clientY: 0) — thumb should jump near start
+      track.dispatchEvent(new MouseEvent("click", { clientY: 0, bubbles: true }));
+
+      const position = onScrollMock.mock.calls[0]?.[0] as number;
+      expect(position).toBeGreaterThanOrEqual(0);
+      expect(position).toBeLessThan(200); // should be near the start
+    });
+
+    it("'jump' — does not call onScroll when thumb fills the track (maxThumbTravel ≤ 0)", () => {
+      // minThumbSize (500) > trackLength (398) — maxThumbTravel is negative
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        autoHide: false,
+        clickBehavior: 'jump',
+        minThumbSize: 500,
+      });
+      scrollbar.updateBounds(1000, 400);
+      scrollbar.show();
+
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      track.getBoundingClientRect = () => ({
+        top: 0, left: 0, right: 8, bottom: 400,
+        width: 8, height: 400, x: 0, y: 0, toJSON: () => ({}),
+      });
+
+      track.dispatchEvent(new MouseEvent("click", { clientY: 200, bubbles: true }));
+
+      expect(onScrollMock).not.toHaveBeenCalled();
+    });
+
+    it("'page' — scrolls forward by containerSize when pressing below thumb", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        autoHide: false,
+        clickBehavior: 'page',
+      });
+      scrollbar.updateBounds(1000, 400);
+      scrollbar.show();
+
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      track.getBoundingClientRect = () => ({
+        top: 0, left: 0, right: 8, bottom: 400,
+        width: 8, height: 400, x: 0, y: 0, toJSON: () => ({}),
+      });
+
+      track.dispatchEvent(new MouseEvent("mousedown", { clientY: 350, bubbles: true }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+      const position = onScrollMock.mock.calls[0]?.[0] as number;
+      expect(position).toBe(400);
+    });
+
+    it("'page' — scrolls backward by containerSize when pressing above thumb", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        autoHide: false,
+        clickBehavior: 'page',
+      });
+      scrollbar.updateBounds(1000, 400);
+      scrollbar.show();
+      scrollbar.updatePosition(600);
+
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      track.getBoundingClientRect = () => ({
+        top: 0, left: 0, right: 8, bottom: 400,
+        width: 8, height: 400, x: 0, y: 0, toJSON: () => ({}),
+      });
+
+      track.dispatchEvent(new MouseEvent("mousedown", { clientY: 10, bubbles: true }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+      const position = onScrollMock.mock.calls[0]?.[0] as number;
+      expect(position).toBe(200);
+    });
+
+    it("'page' — clamps to 0 when scrolling backward at start", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        autoHide: false,
+        clickBehavior: 'page',
+      });
+      scrollbar.updateBounds(1000, 400);
+      scrollbar.show();
+      scrollbar.updatePosition(100);
+
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      track.getBoundingClientRect = () => ({
+        top: 0, left: 0, right: 8, bottom: 400,
+        width: 8, height: 400, x: 0, y: 0, toJSON: () => ({}),
+      });
+
+      track.dispatchEvent(new MouseEvent("mousedown", { clientY: 0, bubbles: true }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+      const position = onScrollMock.mock.calls[0]?.[0] as number;
+      expect(position).toBe(0);
+    });
+
+    it("'page' — clamps to maxScroll when scrolling forward at end", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        autoHide: false,
+        clickBehavior: 'page',
+      });
+      scrollbar.updateBounds(1000, 400);
+      scrollbar.show();
+      scrollbar.updatePosition(500);
+
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      track.getBoundingClientRect = () => ({
+        top: 0, left: 0, right: 8, bottom: 400,
+        width: 8, height: 400, x: 0, y: 0, toJSON: () => ({}),
+      });
+
+      track.dispatchEvent(new MouseEvent("mousedown", { clientY: 390, bubbles: true }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+      const position = onScrollMock.mock.calls[0]?.[0] as number;
+      expect(position).toBe(600);
+    });
+
+    it("'page' — repeats scroll while held, stops on mouseup", async () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        autoHide: false,
+        clickBehavior: 'page',
+      });
+      scrollbar.updateBounds(1000, 400);
+      scrollbar.show();
+
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      track.getBoundingClientRect = () => ({
+        top: 0, left: 0, right: 8, bottom: 400,
+        width: 8, height: 400, x: 0, y: 0, toJSON: () => ({}),
+      });
+
+      // Press and hold
+      track.dispatchEvent(new MouseEvent("mousedown", { clientY: 390, bubbles: true }));
+
+      // Wait past initial delay + at least one repeat interval
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Release
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+      // Should have scrolled more than once
+      expect(onScrollMock.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it("'page' — stops repeating when thumb catches cursor", async () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        autoHide: false,
+        clickBehavior: 'page',
+      });
+      // Small list — thumb covers most of the track, one page scroll reaches the end
+      scrollbar.updateBounds(500, 400);
+      scrollbar.show();
+
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      track.getBoundingClientRect = () => ({
+        top: 0, left: 0, right: 8, bottom: 400,
+        width: 8, height: 400, x: 0, y: 0, toJSON: () => ({}),
+      });
+
+      track.dispatchEvent(new MouseEvent("mousedown", { clientY: 390, bubbles: true }));
+
+      // Simulate the scroll position updating after first scroll
+      scrollbar.updatePosition(100); // maxScroll = 100
+
+      // Wait past initial delay
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+      // Should not have fired indefinitely — clamped
+      const calls = onScrollMock.mock.calls.length;
+      expect(calls).toBeGreaterThanOrEqual(1);
+    });
+
+    it("'page' — schedules auto-hide after mouse release", async () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        autoHide: true,
+        autoHideDelay: 50,
+        clickBehavior: 'page',
+      });
+      scrollbar.updateBounds(1000, 400);
+      scrollbar.show();
+
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      track.getBoundingClientRect = () => ({
+        top: 0, left: 0, right: 8, bottom: 400,
+        width: 8, height: 400, x: 0, y: 0, toJSON: () => ({}),
+      });
+
+      track.dispatchEvent(new MouseEvent("mousedown", { clientY: 350, bubbles: true }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+      // Scrollbar should still be visible immediately after release
+      expect(scrollbar.isVisible()).toBe(true);
+
+      // After autoHideDelay, it should be hidden
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(scrollbar.isVisible()).toBe(false);
     });
   });
 
@@ -571,12 +772,9 @@ describe("createScrollbar", () => {
         toJSON: () => ({}),
       });
 
-      // Simulate click at middle of horizontal track
-      const clickEvent = new MouseEvent("click", {
-        clientX: 200,
-        bubbles: true,
-      });
-      track.dispatchEvent(clickEvent);
+      // Default is 'page' — uses mousedown
+      track.dispatchEvent(new MouseEvent("mousedown", { clientX: 350, bubbles: true }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
 
       expect(onScrollMock).toHaveBeenCalled();
     });

--- a/test/features/scrollbar/scrollbar.test.ts
+++ b/test/features/scrollbar/scrollbar.test.ts
@@ -156,8 +156,8 @@ describe("createScrollbar", () => {
       ) as HTMLElement;
       const thumbHeight = parseFloat(thumb.style.height);
 
-      // 40% of 400px container = 160px
-      expect(thumbHeight).toBeCloseTo(160, 0);
+      // 40% of trackLength (400 - 2×defaultPadding = 398) ≈ 159.2px
+      expect(thumbHeight).toBeCloseTo(398 * (400 / 1000), 0);
     });
 
     it("should respect minimum thumb size", () => {
@@ -196,7 +196,7 @@ describe("createScrollbar", () => {
         ".vlist-scrollbar-thumb",
       ) as HTMLElement;
       const thumbHeight = parseFloat(thumb.style.height);
-      const maxThumbTravel = 400 - thumbHeight;
+      const maxThumbTravel = 398 - thumbHeight; // trackLength = 400 - 2×defaultPadding
 
       // Thumb should be at max travel position
       expect(thumb.style.transform).toBe(`translateY(${maxThumbTravel}px)`);
@@ -213,7 +213,7 @@ describe("createScrollbar", () => {
         ".vlist-scrollbar-thumb",
       ) as HTMLElement;
       const thumbHeight = parseFloat(thumb.style.height);
-      const maxThumbTravel = 400 - thumbHeight;
+      const maxThumbTravel = 398 - thumbHeight; // trackLength = 400 - 2×defaultPadding
       const expectedPosition = 0.5 * maxThumbTravel;
 
       expect(thumb.style.transform).toBe(`translateY(${expectedPosition}px)`);
@@ -429,6 +429,46 @@ describe("createScrollbar", () => {
 
       expect(thumbHeight).toBeGreaterThanOrEqual(100);
     });
+
+    it("should apply padding as CSS variable on track", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, { padding: 8 });
+
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      expect(track.style.getPropertyValue("--vlist-custom-scrollbar-padding")).toBe("8px");
+    });
+
+    it("should set CSS variable to 0px when padding is explicitly 0", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, { padding: 0 });
+
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      expect(track.style.getPropertyValue("--vlist-custom-scrollbar-padding")).toBe("0px");
+    });
+
+    it("should not set CSS variable when padding is not specified (CSS wins)", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {});
+
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      expect(track.style.getPropertyValue("--vlist-custom-scrollbar-padding")).toBe("");
+    });
+
+    it("should reduce thumb travel range by 2× padding", () => {
+      const padding = 10;
+      scrollbar = createScrollbar(viewport, onScrollMock, { padding });
+      scrollbar.updateBounds(1000, 400); // 40% visible
+
+      // trackLength = 400 - 2*10 = 380
+      // thumbSize = 0.4 * 380 = 152
+      // maxThumbTravel = 380 - 152 = 228
+      const thumb = viewport.querySelector(".vlist-scrollbar-thumb") as HTMLElement;
+      const thumbHeight = parseFloat(thumb.style.height);
+      const trackLength = 400 - 2 * padding;
+
+      expect(thumbHeight).toBeCloseTo(trackLength * (400 / 1000), 0);
+
+      scrollbar.updatePosition(1000 - 400); // scrolled to bottom
+      const maxThumbTravel = trackLength - thumbHeight;
+      expect(thumb.style.transform).toBe(`translateY(${maxThumbTravel}px)`);
+    });
   });
 
   // ===========================================================================
@@ -463,8 +503,8 @@ describe("createScrollbar", () => {
       ) as HTMLElement;
       const thumbWidth = parseFloat(thumb.style.width);
 
-      // 40% of 400px container = 160px
-      expect(thumbWidth).toBeCloseTo(160, 0);
+      // 40% of trackLength (400 - 2×defaultPadding = 398) ≈ 159.2px
+      expect(thumbWidth).toBeCloseTo(398 * (400 / 1000), 0);
     });
 
     it("should use translateX instead of translateY for thumb positioning", () => {
@@ -489,7 +529,7 @@ describe("createScrollbar", () => {
         ".vlist-scrollbar-thumb",
       ) as HTMLElement;
       const thumbWidth = parseFloat(thumb.style.width);
-      const maxThumbTravel = 400 - thumbWidth;
+      const maxThumbTravel = 398 - thumbWidth; // trackLength = 400 - 2×defaultPadding
 
       expect(thumb.style.transform).toBe(`translateX(${maxThumbTravel}px)`);
     });
@@ -505,7 +545,7 @@ describe("createScrollbar", () => {
         ".vlist-scrollbar-thumb",
       ) as HTMLElement;
       const thumbWidth = parseFloat(thumb.style.width);
-      const maxThumbTravel = 400 - thumbWidth;
+      const maxThumbTravel = 398 - thumbWidth; // trackLength = 400 - 2×defaultPadding
       const expectedPosition = 0.5 * maxThumbTravel;
 
       expect(thumb.style.transform).toBe(`translateX(${expectedPosition}px)`);

--- a/test/features/scrollbar/scrollbar.test.ts
+++ b/test/features/scrollbar/scrollbar.test.ts
@@ -770,14 +770,77 @@ describe("createScrollbar", () => {
       scrollbar.updatePosition(400); // scrolled down — not at top
 
       const hoverZone = viewport.querySelector(".vlist-scrollbar-hover") as HTMLElement;
-
-      // Simulate click above the track (in the top padding area)
-      // Track starts at y=20 (paddingTop), so clicking at y=5 is above the track
-      Object.defineProperty(hoverZone, "getBoundingClientRect", {
-        value: () => ({ top: 0, left: 0, right: 20, bottom: 400 }),
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      Object.defineProperty(track, "getBoundingClientRect", {
+        value: () => ({ top: 20, left: 0, right: 8, bottom: 380, height: 360 }),
         configurable: true,
       });
-      // track rect: top=20, height=360 (400 - 2*20)
+
+      // Click at y=5 — above the track (top padding area)
+      hoverZone.dispatchEvent(new MouseEvent("mousedown", { clientY: 5, bubbles: true }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+      expect(onScrollMock).toHaveBeenCalled();
+      const newPos = onScrollMock.mock.calls[onScrollMock.mock.calls.length - 1][0] as number;
+      expect(newPos).toBeLessThan(400);
+    });
+
+    it("clicking in the padding margin below the track triggers page scroll downward", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        padding: 20,
+        clickBehavior: "page",
+        autoHide: false,
+      });
+      scrollbar.updateBounds(1000, 400);
+      scrollbar.updatePosition(0); // scrolled to top
+
+      const hoverZone = viewport.querySelector(".vlist-scrollbar-hover") as HTMLElement;
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      Object.defineProperty(track, "getBoundingClientRect", {
+        value: () => ({ top: 20, left: 0, right: 8, bottom: 380, height: 360 }),
+        configurable: true,
+      });
+
+      // Click at y=395 — below the track (bottom padding area)
+      hoverZone.dispatchEvent(new MouseEvent("mousedown", { clientY: 395, bubbles: true }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+      expect(onScrollMock).toHaveBeenCalled();
+      const newPos = onScrollMock.mock.calls[onScrollMock.mock.calls.length - 1][0] as number;
+      expect(newPos).toBeGreaterThan(0);
+    });
+
+    it("clicking in the padding margin with jump behavior clamps to track bounds", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        padding: 20,
+        clickBehavior: "jump",
+        autoHide: false,
+      });
+      scrollbar.updateBounds(1000, 400);
+
+      const hoverZone = viewport.querySelector(".vlist-scrollbar-hover") as HTMLElement;
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      Object.defineProperty(track, "getBoundingClientRect", {
+        value: () => ({ top: 20, left: 0, right: 8, bottom: 380, height: 360 }),
+        configurable: true,
+      });
+
+      // Click above the track → clamps to top (position 0)
+      hoverZone.dispatchEvent(new MouseEvent("click", { clientY: 5, bubbles: true }));
+      expect(onScrollMock).toHaveBeenCalledWith(0);
+    });
+
+    it("clicking in the padding margin works even when showOnHover is false", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        padding: 20,
+        clickBehavior: "page",
+        showOnHover: false,
+        autoHide: false,
+      });
+      scrollbar.updateBounds(1000, 400);
+      scrollbar.updatePosition(400);
+
+      const hoverZone = viewport.querySelector(".vlist-scrollbar-hover") as HTMLElement;
       const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
       Object.defineProperty(track, "getBoundingClientRect", {
         value: () => ({ top: 20, left: 0, right: 8, bottom: 380, height: 360 }),
@@ -787,7 +850,6 @@ describe("createScrollbar", () => {
       hoverZone.dispatchEvent(new MouseEvent("mousedown", { clientY: 5, bubbles: true }));
       document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
 
-      // Scroll should have moved backward (toward top)
       expect(onScrollMock).toHaveBeenCalled();
       const newPos = onScrollMock.mock.calls[onScrollMock.mock.calls.length - 1][0] as number;
       expect(newPos).toBeLessThan(400);

--- a/test/features/scrollbar/scrollbar.test.ts
+++ b/test/features/scrollbar/scrollbar.test.ts
@@ -156,8 +156,8 @@ describe("createScrollbar", () => {
       ) as HTMLElement;
       const thumbHeight = parseFloat(thumb.style.height);
 
-      // 40% of trackLength (400 - 2×defaultPadding = 398) ≈ 159.2px
-      expect(thumbHeight).toBeCloseTo(398 * (400 / 1000), 0);
+      // 40% of trackLength (400 - 2×defaultPadding = 396) ≈ 159.2px
+      expect(thumbHeight).toBeCloseTo(396 * (400 / 1000), 0);
     });
 
     it("should respect minimum thumb size", () => {
@@ -196,7 +196,7 @@ describe("createScrollbar", () => {
         ".vlist-scrollbar-thumb",
       ) as HTMLElement;
       const thumbHeight = parseFloat(thumb.style.height);
-      const maxThumbTravel = 398 - thumbHeight; // trackLength = 400 - 2×defaultPadding
+      const maxThumbTravel = 396 - thumbHeight; // trackLength = 400 - 2×defaultPadding
 
       // Thumb should be at max travel position
       expect(thumb.style.transform).toBe(`translateY(${maxThumbTravel}px)`);
@@ -213,7 +213,7 @@ describe("createScrollbar", () => {
         ".vlist-scrollbar-thumb",
       ) as HTMLElement;
       const thumbHeight = parseFloat(thumb.style.height);
-      const maxThumbTravel = 398 - thumbHeight; // trackLength = 400 - 2×defaultPadding
+      const maxThumbTravel = 396 - thumbHeight; // trackLength = 400 - 2×defaultPadding
       const expectedPosition = 0.5 * maxThumbTravel;
 
       expect(thumb.style.transform).toBe(`translateY(${expectedPosition}px)`);
@@ -292,7 +292,7 @@ describe("createScrollbar", () => {
     });
 
     it("'jump' — does not call onScroll when thumb fills the track (maxThumbTravel ≤ 0)", () => {
-      // minThumbSize (500) > trackLength (398) — maxThumbTravel is negative
+      // minThumbSize (500) > trackLength (396) — maxThumbTravel is negative
       scrollbar = createScrollbar(viewport, onScrollMock, {
         autoHide: false,
         clickBehavior: 'jump',
@@ -589,6 +589,20 @@ describe("createScrollbar", () => {
       // If no error thrown, test passes
       expect(true).toBe(true);
     });
+
+    it("should remove all four padding CSS variables from viewport on destroy", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, { padding: 8 });
+
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-top")).toBe("8px");
+
+      scrollbar.destroy();
+      scrollbar = null as unknown as typeof scrollbar; // prevent afterEach double-destroy
+
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-top")).toBe("");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-right")).toBe("");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-bottom")).toBe("");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-left")).toBe("");
+    });
   });
 
   describe("viewport hover", () => {
@@ -631,35 +645,59 @@ describe("createScrollbar", () => {
       expect(thumbHeight).toBeGreaterThanOrEqual(100);
     });
 
-    it("should apply padding as CSS variable on track", () => {
+    it("should apply uniform padding as CSS variables on viewport", () => {
       scrollbar = createScrollbar(viewport, onScrollMock, { padding: 8 });
 
-      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
-      expect(track.style.getPropertyValue("--vlist-custom-scrollbar-padding")).toBe("8px");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-top")).toBe("8px");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-right")).toBe("8px");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-bottom")).toBe("8px");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-left")).toBe("8px");
     });
 
-    it("should set CSS variable to 0px when padding is explicitly 0", () => {
+    it("should apply per-side padding as CSS variables on viewport", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        padding: { top: 4, right: 6, bottom: 8, left: 10 },
+      });
+
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-top")).toBe("4px");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-right")).toBe("6px");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-bottom")).toBe("8px");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-left")).toBe("10px");
+    });
+
+    it("should fill omitted sides with the default when padding is a partial object", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, { padding: { top: 8 } });
+
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-top")).toBe("8px");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-right")).toBe("2px");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-bottom")).toBe("2px");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-left")).toBe("2px");
+    });
+
+    it("should set all CSS variables to 0px when padding is explicitly 0", () => {
       scrollbar = createScrollbar(viewport, onScrollMock, { padding: 0 });
 
-      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
-      expect(track.style.getPropertyValue("--vlist-custom-scrollbar-padding")).toBe("0px");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-top")).toBe("0px");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-right")).toBe("0px");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-bottom")).toBe("0px");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-left")).toBe("0px");
     });
 
-    it("should not set CSS variable when padding is not specified (CSS wins)", () => {
+    it("should not set CSS variables when padding is not specified (CSS wins)", () => {
       scrollbar = createScrollbar(viewport, onScrollMock, {});
 
-      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
-      expect(track.style.getPropertyValue("--vlist-custom-scrollbar-padding")).toBe("");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-top")).toBe("");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-right")).toBe("");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-bottom")).toBe("");
+      expect(viewport.style.getPropertyValue("--vlist-custom-scrollbar-padding-left")).toBe("");
     });
 
-    it("should reduce thumb travel range by 2× padding", () => {
+    it("should reduce thumb travel range by top + bottom padding (uniform)", () => {
       const padding = 10;
       scrollbar = createScrollbar(viewport, onScrollMock, { padding });
       scrollbar.updateBounds(1000, 400); // 40% visible
 
-      // trackLength = 400 - 2*10 = 380
-      // thumbSize = 0.4 * 380 = 152
-      // maxThumbTravel = 380 - 152 = 228
+      // trackLength = 400 - 10 - 10 = 380
       const thumb = viewport.querySelector(".vlist-scrollbar-thumb") as HTMLElement;
       const thumbHeight = parseFloat(thumb.style.height);
       const trackLength = 400 - 2 * padding;
@@ -671,7 +709,33 @@ describe("createScrollbar", () => {
       expect(thumb.style.transform).toBe(`translateY(${maxThumbTravel}px)`);
     });
 
-    it("hover zone default width equals padding + 16", () => {
+    it("should use asymmetric top + bottom padding for thumb travel when object form is used", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, { padding: { top: 5, bottom: 15 } });
+      scrollbar.updateBounds(1000, 400); // 40% visible
+
+      // trackLength = 400 - 5 - 15 = 380
+      const thumb = viewport.querySelector(".vlist-scrollbar-thumb") as HTMLElement;
+      const thumbHeight = parseFloat(thumb.style.height);
+      const trackLength = 400 - 5 - 15;
+
+      expect(thumbHeight).toBeCloseTo(trackLength * (400 / 1000), 0);
+
+      scrollbar.updatePosition(1000 - 400); // scrolled to bottom
+      const maxThumbTravel = trackLength - thumbHeight;
+      expect(thumb.style.transform).toBe(`translateY(${maxThumbTravel}px)`);
+    });
+
+    it("hover zone default width uses right padding (wall side) + 16", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        showOnHover: true,
+        padding: { top: 0, right: 10, bottom: 0, left: 0 },
+      });
+
+      const hoverZone = viewport.querySelector(".vlist-scrollbar-hover") as HTMLElement;
+      expect(parseFloat(hoverZone.style.width)).toBe(10 + 16);
+    });
+
+    it("hover zone default width equals right padding + 16 for uniform padding", () => {
       const padding = 6;
       scrollbar = createScrollbar(viewport, onScrollMock, { showOnHover: true, padding });
 
@@ -723,8 +787,8 @@ describe("createScrollbar", () => {
       ) as HTMLElement;
       const thumbWidth = parseFloat(thumb.style.width);
 
-      // 40% of trackLength (400 - 2×defaultPadding = 398) ≈ 159.2px
-      expect(thumbWidth).toBeCloseTo(398 * (400 / 1000), 0);
+      // 40% of trackLength (400 - 2×defaultPadding = 396) ≈ 159.2px
+      expect(thumbWidth).toBeCloseTo(396 * (400 / 1000), 0);
     });
 
     it("should use translateX instead of translateY for thumb positioning", () => {
@@ -749,7 +813,7 @@ describe("createScrollbar", () => {
         ".vlist-scrollbar-thumb",
       ) as HTMLElement;
       const thumbWidth = parseFloat(thumb.style.width);
-      const maxThumbTravel = 398 - thumbWidth; // trackLength = 400 - 2×defaultPadding
+      const maxThumbTravel = 396 - thumbWidth; // trackLength = 400 - 2×defaultPadding
 
       expect(thumb.style.transform).toBe(`translateX(${maxThumbTravel}px)`);
     });
@@ -765,7 +829,7 @@ describe("createScrollbar", () => {
         ".vlist-scrollbar-thumb",
       ) as HTMLElement;
       const thumbWidth = parseFloat(thumb.style.width);
-      const maxThumbTravel = 398 - thumbWidth; // trackLength = 400 - 2×defaultPadding
+      const maxThumbTravel = 396 - thumbWidth; // trackLength = 400 - 2×defaultPadding
       const expectedPosition = 0.5 * maxThumbTravel;
 
       expect(thumb.style.transform).toBe(`translateX(${expectedPosition}px)`);

--- a/test/features/scrollbar/scrollbar.test.ts
+++ b/test/features/scrollbar/scrollbar.test.ts
@@ -613,8 +613,8 @@ describe("createScrollbar", () => {
       ) as HTMLElement;
       const thumbHeight = parseFloat(thumb.style.height);
 
-      // Default minThumbSize is 30
-      expect(thumbHeight).toBeGreaterThanOrEqual(30);
+      // Default minThumbSize is 15
+      expect(thumbHeight).toBeGreaterThanOrEqual(15);
     });
 
     it("should allow custom minThumbSize", () => {
@@ -669,6 +669,25 @@ describe("createScrollbar", () => {
       scrollbar.updatePosition(1000 - 400); // scrolled to bottom
       const maxThumbTravel = trackLength - thumbHeight;
       expect(thumb.style.transform).toBe(`translateY(${maxThumbTravel}px)`);
+    });
+
+    it("hover zone default width equals padding + 16", () => {
+      const padding = 6;
+      scrollbar = createScrollbar(viewport, onScrollMock, { showOnHover: true, padding });
+
+      const hoverZone = viewport.querySelector(".vlist-scrollbar-hover") as HTMLElement;
+      expect(parseFloat(hoverZone.style.width)).toBe(padding + 16);
+    });
+
+    it("explicit hoverZoneWidth overrides the padding-based default", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        showOnHover: true,
+        padding: 8,
+        hoverZoneWidth: 12,
+      });
+
+      const hoverZone = viewport.querySelector(".vlist-scrollbar-hover") as HTMLElement;
+      expect(parseFloat(hoverZone.style.width)).toBe(12);
     });
   });
 

--- a/test/features/scrollbar/scrollbar.test.ts
+++ b/test/features/scrollbar/scrollbar.test.ts
@@ -753,6 +753,45 @@ describe("createScrollbar", () => {
       const hoverZone = viewport.querySelector(".vlist-scrollbar-hover") as HTMLElement;
       expect(parseFloat(hoverZone.style.width)).toBe(12);
     });
+
+    it("edge zone is always present even when showOnHover is false", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, { showOnHover: false });
+
+      expect(viewport.querySelector(".vlist-scrollbar-hover")).not.toBeNull();
+    });
+
+    it("clicking in the padding margin above the track triggers page scroll upward", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        padding: 20,
+        clickBehavior: "page",
+        autoHide: false,
+      });
+      scrollbar.updateBounds(1000, 400);
+      scrollbar.updatePosition(400); // scrolled down — not at top
+
+      const hoverZone = viewport.querySelector(".vlist-scrollbar-hover") as HTMLElement;
+
+      // Simulate click above the track (in the top padding area)
+      // Track starts at y=20 (paddingTop), so clicking at y=5 is above the track
+      Object.defineProperty(hoverZone, "getBoundingClientRect", {
+        value: () => ({ top: 0, left: 0, right: 20, bottom: 400 }),
+        configurable: true,
+      });
+      // track rect: top=20, height=360 (400 - 2*20)
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      Object.defineProperty(track, "getBoundingClientRect", {
+        value: () => ({ top: 20, left: 0, right: 8, bottom: 380, height: 360 }),
+        configurable: true,
+      });
+
+      hoverZone.dispatchEvent(new MouseEvent("mousedown", { clientY: 5, bubbles: true }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+      // Scroll should have moved backward (toward top)
+      expect(onScrollMock).toHaveBeenCalled();
+      const newPos = onScrollMock.mock.calls[onScrollMock.mock.calls.length - 1][0] as number;
+      expect(newPos).toBeLessThan(400);
+    });
   });
 
   // ===========================================================================


### PR DESCRIPTION
## Summary

- **Per-side padding** — `padding` option now accepts `number` (uniform) or `{ top?, right?, bottom?, left? }` (independent sides, each defaulting to 2px when omitted)
- **Click target fix** — clicking in the padding margin (dead space around the track) now correctly triggers `clickBehavior` (page/jump); the hover zone element always covers the full edge including padding
- **Gutter fix** — `--vlist-custom-scrollbar-padding-*` CSS vars now set on the viewport (not the track) so the gutter `calc()` can read them; split into 4 individual vars for axis-aware layout
- **JSDoc corrections** — `clickBehavior` default corrected to `'page'`; `hoverZoneWidth` description updated to reflect its dual role (hover + click target)
- **CI fix** — commit message serialized with `toJSON()` in `notify-staging.yml` to prevent JSON parse errors on messages with special characters or multi-line bodies
- **`ScrollbarPadding` type** — moved to `src/types.ts` and exported from `src/index.ts` so the public type is properly accessible

## Test plan

- [ ] `bun test` passes (223 tests, 0 failures)
- [ ] `bun run typecheck` passes
- [ ] `bun run build` succeeds
- [ ] Custom scrollbar with `padding: 8` shows uniform inset on all sides
- [ ] Custom scrollbar with `padding: { top: 0, bottom: 0, right: 4, left: 8 }` shows per-side inset
- [ ] Clicking in the top/bottom padding margin triggers scroll (page behavior)
- [ ] Gutter layout reserves correct space including left-side padding