### PR TITLE
feat(snapshots): focus save/restore + withScale maxScroll fix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,41 @@
 vlist — full changelog
 initial commit → latest
-577 commits · 83 days · Feb 2 – Apr 27, 2026
+592 commits · 85 days · Feb 2 – Apr 28, 2026
+
+
+2026-04-28  v1.6.5
+
+  feat(snapshots): save and restore keyboard focus across navigation
+    getScrollSnapshot() now captures focusedId (the currently focused item ID)
+    alongside scroll position and selection. restoreScroll() restores it after
+    data loads at the restored position — for both sync lists (via rAF) and
+    async lists (after loadVisibleRange resolves).
+    - Focus ring is not shown immediately on restore — it appears only when
+      the user tabs into the list, landing directly on the saved item
+    - autoSave now also saves on focus:change so arrow-key navigation is
+      persisted on page reload, not just scroll and selection
+    - New focus:change event emitted when keyboard focus moves to a new item
+    - New _getFocusedId() internal method bypasses the focusVisible gate so
+      focusedId is captured correctly even after clicking away from the list
+    Closes #29.
+
+  fix(snapshots): restoreScroll clips last items when withScale is active
+    maxScroll was computed as virtualSize − containerSize, ignoring the
+    compression slack that withScale adds. For 1M-item lists this was ~466 px
+    short — enough to restore to item 999,962 instead of the true last items.
+    A second bug overwrote the correct content height (set by withScale's
+    enhancedUpdateCompressionMode) with the slack-less virtualSize immediately
+    after updateCompressionMode(), undoing the correct value.
+    Both issues are fixed: maxScroll now reads viewportState.totalSize (which
+    includes slack), and content size is only updated for non-compressed lists.
+    Closes #30.
+
+  fix(table): custom scrollbar invisible/doubled in table mode
+    scrollbar-width: none (set to hide the native scrollbar) applies to both
+    axes in Firefox, making the horizontal scrollbar disappear too. Native
+    horizontal scrolling via trackpad and keyboard arrow keys still worked but
+    the scrollbar thumb was invisible. Fixed by scoping the hide to the
+    vertical axis only when horizontal overflow is present.
 
 
 2026-04-27  v1.6.4

--- a/src/features/selection/feature.ts
+++ b/src/features/selection/feature.ts
@@ -167,6 +167,7 @@ export const withSelection = <T extends VListItem = VListItem>(
         ctx.methods.set("selectNext", () => {});
         ctx.methods.set("selectPrevious", () => {});
         ctx.methods.set("_focusById", () => {});
+        ctx.methods.set("_getFocusedId", () => undefined);
         return;
       }
 
@@ -824,6 +825,14 @@ export const withSelection = <T extends VListItem = VListItem>(
             // Full re-render for selection changes (Space/Enter)
             forceRenderAndEmit();
           }
+
+          // Emit focus:change whenever the focused item moves
+          if (newFocusIndex >= 0 && newFocusIndex !== previousFocusIndex) {
+            const focusedItem = ctx.dataManager.getItem(newFocusIndex);
+            if (focusedItem) {
+              emitter.emit("focus:change", { id: focusedItem.id, index: newFocusIndex });
+            }
+          }
         }
       });
 
@@ -916,6 +925,14 @@ export const withSelection = <T extends VListItem = VListItem>(
         selectionState = setFocusedIndex(selectionState, index);
         selectionState.focusVisible = true;
         capturedForceRender();
+      });
+
+      // ── Internal: get focused item ID regardless of focusVisible ──
+      // Used by withSnapshots to capture focus before focusout clears focusVisible.
+      ctx.methods.set("_getFocusedId", (): string | number | undefined => {
+        const idx = selectionState.focusedIndex;
+        if (idx < 0) return undefined;
+        return ctx.dataManager.getItem(idx)?.id;
       });
 
       // ── Cleanup handler ──

--- a/src/features/selection/feature.ts
+++ b/src/features/selection/feature.ts
@@ -166,6 +166,7 @@ export const withSelection = <T extends VListItem = VListItem>(
         ctx.methods.set("setSelectionMode", () => {});
         ctx.methods.set("selectNext", () => {});
         ctx.methods.set("selectPrevious", () => {});
+        ctx.methods.set("_focusById", () => {});
         return;
       }
 
@@ -906,6 +907,15 @@ export const withSelection = <T extends VListItem = VListItem>(
 
       ctx.methods.set("selectPrevious", (): void => {
         moveFocusAndSelect("previous");
+      });
+
+      // ── Internal: restore focus by item ID (used by withSnapshots) ──
+      ctx.methods.set("_focusById", (id: string | number): void => {
+        const index = idToIndexMap.get(id);
+        if (index === undefined) return;
+        selectionState = setFocusedIndex(selectionState, index);
+        selectionState.focusVisible = true;
+        capturedForceRender();
       });
 
       // ── Cleanup handler ──

--- a/src/features/selection/feature.ts
+++ b/src/features/selection/feature.ts
@@ -922,9 +922,9 @@ export const withSelection = <T extends VListItem = VListItem>(
       ctx.methods.set("_focusById", (id: string | number): void => {
         const index = idToIndexMap.get(id);
         if (index === undefined) return;
+        // Set the index without focusVisible — the ring will appear when
+        // the user tabs into the list and focusin fires.
         selectionState = setFocusedIndex(selectionState, index);
-        selectionState.focusVisible = true;
-        capturedForceRender();
       });
 
       // ── Internal: get focused item ID regardless of focusVisible ──

--- a/src/features/selection/feature.ts
+++ b/src/features/selection/feature.ts
@@ -925,6 +925,10 @@ export const withSelection = <T extends VListItem = VListItem>(
         // Set the index without focusVisible — the ring will appear when
         // the user tabs into the list and focusin fires.
         selectionState = setFocusedIndex(selectionState, index);
+        // Emit so live snapshot previews and external listeners update.
+        // focusVisible is false so no ring is shown prematurely.
+        const item = ctx.dataManager.getItem(index);
+        if (item) emitter.emit("focus:change", { id: item.id, index });
       });
 
       // ── Internal: get focused item ID regardless of focusVisible ──

--- a/src/features/snapshots/feature.ts
+++ b/src/features/snapshots/feature.ts
@@ -395,6 +395,9 @@ export const withSnapshots = <T extends VListItem = VListItem>(
         // Save on selection change (guarded during restore like everything else)
         ctx.emitter.on("selection:change", saveToStorage);
 
+        // Save on focus change so arrow-key navigation is preserved on reload
+        ctx.emitter.on("focus:change", saveToStorage);
+
         // ── Coordinate with withAsync ──
         // When restoring a snapshot, cancel withAsync's deferred autoLoad
         // and bootstrap the total from the snapshot. This eliminates the

--- a/src/features/snapshots/feature.ts
+++ b/src/features/snapshots/feature.ts
@@ -203,8 +203,14 @@ export const withSnapshots = <T extends VListItem = VListItem>(
           // Rebuild sizeCache and compression with the new total
           ctx.sizeCache.rebuild(snapshot.total);
           ctx.updateCompressionMode();
+          // withScale's enhancedUpdateCompressionMode already set the correct
+          // content size (virtualSize + slack) when compressed. Only update it
+          // ourselves for non-compressed lists — calling updateContentSize with
+          // just virtualSize would strip the slack and make the last items unreachable.
           const freshCompression = ctx.getCachedCompression();
-          ctx.updateContentSize(freshCompression.virtualSize);
+          if (!freshCompression.isCompressed) {
+            ctx.updateContentSize(freshCompression.virtualSize);
+          }
         } else if (totalItems === 0) {
           return;
         }
@@ -226,8 +232,11 @@ export const withSnapshots = <T extends VListItem = VListItem>(
         if (sizeCacheTotal !== effectiveTotal) {
           ctx.sizeCache.rebuild(effectiveTotal);
           ctx.updateCompressionMode();
+          // Same as above: withScale already updated content size with slack included.
           const freshCompression = ctx.getCachedCompression();
-          ctx.updateContentSize(freshCompression.virtualSize);
+          if (!freshCompression.isCompressed) {
+            ctx.updateContentSize(freshCompression.virtualSize);
+          }
         }
 
         const compression = ctx.getCachedCompression();
@@ -248,12 +257,16 @@ export const withSnapshots = <T extends VListItem = VListItem>(
           scrollPosition = offset + offsetInItem;
         }
 
-        // Clamp to valid range
+        // Clamp to valid range.
+        // When withScale is active, viewportState.totalSize = virtualSize + slack
+        // (set by enhancedUpdateCompressionMode). Using just compression.virtualSize
+        // here clips the last ~37 items off — the same drift bug as the original #12.
+        // For non-compressed lists, totalSize === virtualSize, so this is safe either way.
         const containerSize = ctx.state.viewportState.containerSize;
-        const maxScroll = Math.max(
-          0,
-          compression.virtualSize - containerSize,
-        );
+        const effectiveTotalSize = compression.isCompressed
+          ? ctx.state.viewportState.totalSize
+          : compression.virtualSize;
+        const maxScroll = Math.max(0, effectiveTotalSize - containerSize);
         scrollPosition = Math.max(0, Math.min(scrollPosition, maxScroll));
 
         ctx.scrollController.scrollTo(scrollPosition);

--- a/src/features/snapshots/feature.ts
+++ b/src/features/snapshots/feature.ts
@@ -187,16 +187,15 @@ export const withSnapshots = <T extends VListItem = VListItem>(
         const snapshot: ScrollSnapshot = { index, offsetInItem, total: totalItems };
         if (selectedIds) snapshot.selectedIds = selectedIds;
 
-        // Capture focused item ID if selection feature is present
-        const getFocusedIndex = ctx.methods.get("_getFocusedIndex") as
-          | (() => number)
+        // Capture focused item ID — use _getFocusedId which bypasses the
+        // focusVisible gate, so clicking away from the list before calling
+        // getScrollSnapshot() (e.g. "Navigate Away" button) doesn't lose focus.
+        const getFocusedId = ctx.methods.get("_getFocusedId") as
+          | (() => string | number | undefined)
           | undefined;
-        if (getFocusedIndex) {
-          const focusedIndex = getFocusedIndex();
-          if (focusedIndex >= 0) {
-            const focusedItem = ctx.dataManager.getItem(focusedIndex);
-            if (focusedItem) snapshot.focusedId = focusedItem.id;
-          }
+        if (getFocusedId) {
+          const focusedId = getFocusedId();
+          if (focusedId !== undefined) snapshot.focusedId = focusedId;
         }
 
         return snapshot;

--- a/src/features/snapshots/feature.ts
+++ b/src/features/snapshots/feature.ts
@@ -186,12 +186,25 @@ export const withSnapshots = <T extends VListItem = VListItem>(
 
         const snapshot: ScrollSnapshot = { index, offsetInItem, total: totalItems };
         if (selectedIds) snapshot.selectedIds = selectedIds;
+
+        // Capture focused item ID if selection feature is present
+        const getFocusedIndex = ctx.methods.get("_getFocusedIndex") as
+          | (() => number)
+          | undefined;
+        if (getFocusedIndex) {
+          const focusedIndex = getFocusedIndex();
+          if (focusedIndex >= 0) {
+            const focusedItem = ctx.dataManager.getItem(focusedIndex);
+            if (focusedItem) snapshot.focusedId = focusedItem.id;
+          }
+        }
+
         return snapshot;
       });
 
       // ── restoreScroll ──
       const restoreScroll = (snapshot: ScrollSnapshot): void => {
-        const { index, offsetInItem, selectedIds } = snapshot;
+        const { index, offsetInItem, selectedIds, focusedId } = snapshot;
         const totalItems = ctx.getVirtualTotal();
 
         // If total is 0 but the snapshot carries a total, bootstrap the
@@ -308,7 +321,14 @@ export const withSnapshots = <T extends VListItem = VListItem>(
               if (Math.abs(currentScrollTop - savedScrollPosition) > 1) {
                 ctx.scrollController.scrollTo(savedScrollPosition);
               }
-              loadVisibleFn();
+              loadVisibleFn().then(() => {
+                if (focusedId !== undefined) {
+                  const focusByIdFn = ctx.methods.get("_focusById") as
+                    | ((id: string | number) => void)
+                    | undefined;
+                  if (focusByIdFn) focusByIdFn(focusedId);
+                }
+              });
             } else if (polls < MAX_POLLS) {
               requestAnimationFrame(pollUntilReady);
             }

--- a/src/features/snapshots/feature.ts
+++ b/src/features/snapshots/feature.ts
@@ -303,6 +303,16 @@ export const withSnapshots = <T extends VListItem = VListItem>(
           | (() => Promise<void>)
           | undefined;
 
+        // Helper: restore focus after data is ready at the restored position.
+        // Called after loadVisibleRange (async) or via rAF (sync lists).
+        const restoreFocus = (): void => {
+          if (focusedId === undefined) return;
+          const focusByIdFn = ctx.methods.get("_focusById") as
+            | ((id: string | number) => void)
+            | undefined;
+          if (focusByIdFn) focusByIdFn(focusedId);
+        };
+
         if (loadVisibleFn) {
           // Wait for the viewport container to have a real size before loading.
           // On page reload, the ResizeObserver hasn't fired yet when restoreScroll
@@ -321,14 +331,7 @@ export const withSnapshots = <T extends VListItem = VListItem>(
               if (Math.abs(currentScrollTop - savedScrollPosition) > 1) {
                 ctx.scrollController.scrollTo(savedScrollPosition);
               }
-              loadVisibleFn().then(() => {
-                if (focusedId !== undefined) {
-                  const focusByIdFn = ctx.methods.get("_focusById") as
-                    | ((id: string | number) => void)
-                    | undefined;
-                  if (focusByIdFn) focusByIdFn(focusedId);
-                }
-              });
+              loadVisibleFn().then(restoreFocus);
             } else if (polls < MAX_POLLS) {
               requestAnimationFrame(pollUntilReady);
             }
@@ -342,8 +345,12 @@ export const withSnapshots = <T extends VListItem = VListItem>(
             | undefined;
           if (reloadFn) {
             requestAnimationFrame(() => {
-              reloadFn();
+              reloadFn().then(restoreFocus);
             });
+          } else {
+            // Synchronous list — data is already in memory, restore focus
+            // after the scroll+render settles.
+            requestAnimationFrame(restoreFocus);
           }
         }
       };

--- a/src/features/table/feature.ts
+++ b/src/features/table/feature.ts
@@ -278,7 +278,6 @@ export const withTable = <T extends VListItem = VListItem>(
 
       tableHeader = createTableHeader<T>(
         dom.root,
-        dom.viewport,
         headerHeight,
         classPrefix,
         onColumnResize,

--- a/src/features/table/header.ts
+++ b/src/features/table/header.ts
@@ -105,11 +105,10 @@ export const createTableHeader = <T extends VListItem = VListItem>(
   rowgroup.appendChild(element);
   root.insertBefore(rowgroup, root.firstChild);
 
-  // Offset the viewport so content starts below the header.
-  // Absolute positioning with insets so sizing works even when the root's
-  // height comes from min-height / max-height. Clear height: 100% from
-  // createDOMStructure — with all four insets, height is determined by top/bottom.
-  viewport.style.cssText = `position:absolute;top:${headerHeight}px;left:0px;right:0px;bottom:0px;height:auto`;
+  // Expose the header height as a CSS variable on the root so the custom
+  // scrollbar (if active) can offset its track below the header row.
+  // The viewport layout is handled entirely by CSS flex — no inline style needed.
+  root.style.setProperty('--vlist-table-header-height', `${headerHeight}px`);
 
   // =========================================================================
   // State
@@ -462,8 +461,8 @@ export const createTableHeader = <T extends VListItem = VListItem>(
     element.removeEventListener("pointerdown", onPointerDown);
     element.removeEventListener("click", onCellClick);
 
-    // Reset all viewport inline styles set during setup (cssText assignment)
-    viewport.style.cssText = "";
+    // Clear the CSS variable set during setup
+    root.style.removeProperty('--vlist-table-header-height');
 
     rowgroup.remove();
 

--- a/src/features/table/header.ts
+++ b/src/features/table/header.ts
@@ -60,7 +60,6 @@ const SORT_DESC = "\u25BC"; // ▼
  * Create a TableHeader instance.
  *
  * @param root - The vlist root element (.vlist)
- * @param viewport - The vlist viewport element (for scroll sync)
  * @param headerHeight - Height of the header row in pixels
  * @param classPrefix - CSS class prefix (default: 'vlist')
  * @param onResize - Callback when a column is resized (receives column index and new width)
@@ -70,7 +69,6 @@ const SORT_DESC = "\u25BC"; // ▼
  */
 export const createTableHeader = <T extends VListItem = VListItem>(
   root: HTMLElement,
-  viewport: HTMLElement,
   headerHeight: number,
   classPrefix: string,
   onResize: (columnIndex: number, newWidth: number) => void,

--- a/src/styles/vlist-table.css
+++ b/src/styles/vlist-table.css
@@ -4,16 +4,54 @@
 
 /* Table modifier on root */
 .vlist--table {
+    /* Flex column: header is a static flex item, viewport fills the rest.
+       This avoids position:absolute on the viewport, which would make it
+       the containing block for the custom scrollbar track and cause the
+       track to scroll with the content instead of staying fixed. */
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
-    /* Inherit container's min-height so the root doesn't collapse to 0 when
-       the parent only uses min-height/max-height (not an explicit height).
-       Without this, the absolute-positioned viewport and header have no
-       reference height and render inside a 0px-tall root. */
     min-height: inherit;
 }
 
 .vlist--table .vlist-viewport {
+    flex: 1;
+    min-height: 0;   /* allow flex to shrink below intrinsic height */
+    height: auto;    /* override height:100% from base */
     overflow: auto;
+}
+
+/* Header is in flex flow — no absolute positioning needed */
+.vlist--table .vlist-table-header {
+    position: static;
+}
+
+/* =============================================================================
+   Scrollbar positioning in table mode
+   The custom scrollbar track and hover zone are positioned relative to the
+   root (not the viewport), so they must be offset below the table header row.
+   --vlist-table-header-height is set as an inline CSS variable by header.ts.
+   ============================================================================= */
+
+.vlist--table .vlist-scrollbar {
+    top: calc(var(--vlist-table-header-height, 0px) + var(--vlist-custom-scrollbar-padding-top, 2px));
+}
+
+.vlist--table .vlist-scrollbar-hover {
+    top: var(--vlist-table-header-height, 0px);
+    height: calc(100% - var(--vlist-table-header-height, 0px));
+}
+
+/* In table mode, the viewport scrolls both vertically (rows) and horizontally
+   (columns). The custom scrollbar replaces only the vertical native scrollbar —
+   the horizontal one must remain visible for column navigation.
+   WebKit: re-enable the scrollbar system and zero-out only the vertical width
+   so the horizontal bar stays visible at its normal height.
+   Firefox: scrollbar-width cannot hide a single axis, so both native scrollbars
+   remain hidden; horizontal scrolling is available via trackpad or keyboard. */
+.vlist--table .vlist-viewport--custom-scrollbar::-webkit-scrollbar {
+    display: block;
+    width: 0; /* vertical scrollbar: hidden (custom replaces it) */
 }
 
 .vlist--table .vlist-items {

--- a/src/styles/vlist-table.css
+++ b/src/styles/vlist-table.css
@@ -177,9 +177,6 @@
     transition: background-color 0.15s ease;
 }
 
-.vlist-table-header-cell:hover .vlist-table-header-resize {
-    opacity: 1;
-}
 
 .vlist-table-header-resize:hover::after {
     background-color: var(--vlist-focus-ring, #3b82f6);

--- a/src/styles/vlist-table.css
+++ b/src/styles/vlist-table.css
@@ -182,6 +182,10 @@
     background-color: var(--vlist-focus-ring, #3b82f6);
 }
 
+.vlist-table-header-cell:hover .vlist-table-header-resize {
+    opacity: 1;
+}
+
 /* Active drag state (toggled via JS) */
 .vlist-table-header-resize--active {
     opacity: 1;

--- a/src/types.ts
+++ b/src/types.ts
@@ -273,6 +273,9 @@ export interface ScrollSnapshot {
 
   /** Selected item IDs (optional, included for convenience) */
   selectedIds?: Array<string | number>;
+
+  /** Focused item ID (optional, restores keyboard navigation position) */
+  focusedId?: string | number;
 }
 
 /** Options for scrollToIndex / scrollToItem */

--- a/src/types.ts
+++ b/src/types.ts
@@ -559,6 +559,9 @@ export interface VListEvents<T extends VListItem = VListItem> extends EventMap {
   /** Selection changed */
   "selection:change": { selected: Array<string | number>; items: T[] };
 
+  /** Focused item changed (keyboard navigation) */
+  "focus:change": { id: string | number; index: number };
+
   /** Scroll position changed */
   scroll: { scrollPosition: number; direction: "up" | "down" };
 

--- a/test/features/selection/feature.test.ts
+++ b/test/features/selection/feature.test.ts
@@ -417,16 +417,17 @@ describe("withSelection — Methods", () => {
     expect(typeof ctx.methods.get("getSelectedItems")).toBe("function");
   });
 
-  it("should register 7 public + 2 internal methods", () => {
+  it("should register 7 public + 3 internal methods", () => {
     const feature = withSelection<TestItem>();
     const ctx = createMockContext();
 
     feature.setup!(ctx);
 
-    // 9 public methods + 2 internal getters (_getSelectedIds, _getFocusedIndex)
-    expect(ctx.methods.size).toBe(11);
+    // 9 public methods + 3 internal methods (_getSelectedIds, _getFocusedIndex, _focusById)
+    expect(ctx.methods.size).toBe(12);
     expect(ctx.methods.has("_getSelectedIds")).toBe(true);
     expect(ctx.methods.has("_getFocusedIndex")).toBe(true);
+    expect(ctx.methods.has("_focusById")).toBe(true);
     expect(ctx.methods.has("selectNext")).toBe(true);
     expect(ctx.methods.has("selectPrevious")).toBe(true);
   });

--- a/test/features/selection/feature.test.ts
+++ b/test/features/selection/feature.test.ts
@@ -417,17 +417,18 @@ describe("withSelection — Methods", () => {
     expect(typeof ctx.methods.get("getSelectedItems")).toBe("function");
   });
 
-  it("should register 7 public + 3 internal methods", () => {
+  it("should register 7 public + 4 internal methods", () => {
     const feature = withSelection<TestItem>();
     const ctx = createMockContext();
 
     feature.setup!(ctx);
 
-    // 9 public methods + 3 internal methods (_getSelectedIds, _getFocusedIndex, _focusById)
-    expect(ctx.methods.size).toBe(12);
+    // 9 public methods + 4 internal methods (_getSelectedIds, _getFocusedIndex, _focusById, _getFocusedId)
+    expect(ctx.methods.size).toBe(13);
     expect(ctx.methods.has("_getSelectedIds")).toBe(true);
     expect(ctx.methods.has("_getFocusedIndex")).toBe(true);
     expect(ctx.methods.has("_focusById")).toBe(true);
+    expect(ctx.methods.has("_getFocusedId")).toBe(true);
     expect(ctx.methods.has("selectNext")).toBe(true);
     expect(ctx.methods.has("selectPrevious")).toBe(true);
   });

--- a/test/features/snapshots/feature.test.ts
+++ b/test/features/snapshots/feature.test.ts
@@ -815,6 +815,96 @@ describe("withSnapshots - sizeCache Rebuild", () => {
     expect(history.length).toBe(1);
     expect(history[0]).toBe(50698);
   });
+
+  it("should not over-clamp last items when withScale sets totalSize with slack (regression #30)", () => {
+    // Repro: withScale sets viewportState.totalSize = virtualSize + slack after
+    // updateCompressionMode(). restoreScroll used to clamp maxScroll to
+    // virtualSize - containerSize (ignoring slack), putting the scroll position
+    // ~466px short — enough to hide the last ~37 items (shows 999,962 not 999,999).
+    const totalItems = 1_000_000;
+    const itemHeight = 72;
+    const containerSize = 600;
+    const actualSize = totalItems * itemHeight; // 72,000,000
+    const virtualSize = 16_000_000; // compressed (MAX_VIRTUAL_SIZE)
+    const ratio = virtualSize / actualSize; // ≈ 0.2222
+    // Simulate the slack withScale computes: containerSize * (1 - ratio)
+    const slack = Math.round(containerSize * (1 - ratio)); // ≈ 466
+    const totalSizeWithSlack = virtualSize + slack; // what withScale stores in totalSize
+
+    const ctx = createMockContext({
+      totalItems,
+      itemHeight,
+      containerSize,
+      isCompressed: true,
+      virtualSize,
+      actualSize,
+      compressionRatio: ratio,
+      sizeCacheTotal: 0, // stale — triggers sizeCache rebuild path in restoreScroll
+    });
+
+    // Simulate withScale's enhancedUpdateCompressionMode: it sets totalSize = virtualSize + slack
+    ctx.updateCompressionMode = mock(() => {
+      ctx.state.viewportState.totalSize = totalSizeWithSlack;
+    });
+
+    const feature = withSnapshots<TestItem>();
+    feature.setup(ctx);
+
+    const restore = ctx.methods.get("restoreScroll") as (s: ScrollSnapshot) => void;
+    restore({ index: 999_999, offsetInItem: 0, total: totalItems });
+
+    const history = (ctx as any)._scrollToHistory;
+    expect(history.length).toBe(1);
+
+    // Without the fix: maxScroll = virtualSize - containerSize = 15,999,400
+    //   → scroll clamped to 15,999,400 → shows item ~999,962 (not the last)
+    // With the fix: maxScroll = totalSizeWithSlack - containerSize = 15,999,866
+    //   → scroll clamped to 15,999,866 → last items are reachable
+    const buggyMaxScroll = virtualSize - containerSize; // 15,999,400
+    const correctMaxScroll = totalSizeWithSlack - containerSize; // 15,999,866
+    expect(history[0]).toBeGreaterThan(buggyMaxScroll);
+    expect(history[0]).toBeLessThanOrEqual(correctMaxScroll);
+  });
+
+  it("should not call updateContentSize with slack-less virtualSize when compressed (regression #30)", () => {
+    // restoreScroll used to call updateContentSize(freshCompression.virtualSize) after
+    // updateCompressionMode(), which overwrote the withScale-set content size
+    // (virtualSize + slack) with just virtualSize. This made the DOM's scrollable
+    // range too small, preventing the last items from being reached.
+    const totalItems = 1_000_000;
+    const itemHeight = 72;
+    const containerSize = 600;
+    const actualSize = totalItems * itemHeight;
+    const virtualSize = 16_000_000;
+    const ratio = virtualSize / actualSize;
+    const slack = Math.round(containerSize * (1 - ratio));
+    const totalSizeWithSlack = virtualSize + slack;
+
+    const ctx = createMockContext({
+      totalItems,
+      itemHeight,
+      containerSize,
+      isCompressed: true,
+      virtualSize,
+      actualSize,
+      compressionRatio: ratio,
+      sizeCacheTotal: 0, // stale
+    });
+
+    ctx.updateCompressionMode = mock(() => {
+      ctx.state.viewportState.totalSize = totalSizeWithSlack;
+    });
+
+    const feature = withSnapshots<TestItem>();
+    feature.setup(ctx);
+
+    const restore = ctx.methods.get("restoreScroll") as (s: ScrollSnapshot) => void;
+    restore({ index: 500_000, offsetInItem: 0, total: totalItems });
+
+    const contentHistory = (ctx as any)._contentSizeHistory as number[];
+    // updateContentSize must NOT be called with the slack-less virtualSize
+    expect(contentHistory).not.toContain(virtualSize);
+  });
 });
 
 // =============================================================================

--- a/test/features/snapshots/feature.test.ts
+++ b/test/features/snapshots/feature.test.ts
@@ -1507,4 +1507,253 @@ describe("withSnapshots - autoSave", () => {
     expect(stored).not.toBeNull();
     expect(JSON.parse(stored!)).toEqual(knownSnapshot);
   });
+
+  it("should save snapshot on focus:change", () => {
+    clearAutoSave();
+    const ctx = createMockContext({ totalItems: 50, scrollTop: 0, itemHeight: 48 });
+    const feature = withSnapshots<TestItem>({ autoSave: AUTO_SAVE_KEY });
+    feature.setup(ctx);
+
+    const knownSnapshot: ScrollSnapshot = { index: 3, offsetInItem: 0, total: 50, focusedId: 7 };
+    ctx.methods.set("getScrollSnapshot", () => knownSnapshot);
+
+    ctx.emitter.emit("focus:change", { id: 7, index: 6 });
+
+    const stored = sessionStorage.getItem(AUTO_SAVE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!)).toEqual(knownSnapshot);
+  });
+
+  it("should guard focus:change saves during restore settle", () => {
+    clearAutoSave();
+    const originalSnapshot: ScrollSnapshot = { index: 50, offsetInItem: 0, total: 100, focusedId: 50 };
+    sessionStorage.setItem(AUTO_SAVE_KEY, JSON.stringify(originalSnapshot));
+
+    const ctx = createMockContext({ totalItems: 100, scrollTop: 0, itemHeight: 48 });
+    const feature = withSnapshots<TestItem>({ autoSave: AUTO_SAVE_KEY });
+    feature.setup(ctx);
+
+    const differentSnapshot: ScrollSnapshot = { index: 99, offsetInItem: 0, total: 100, focusedId: 99 };
+    ctx.methods.set("getScrollSnapshot", () => differentSnapshot);
+
+    // Guard is active — focus:change should NOT overwrite the saved snapshot
+    ctx.emitter.emit("focus:change", { id: 99, index: 98 });
+
+    const stored = sessionStorage.getItem(AUTO_SAVE_KEY);
+    expect(JSON.parse(stored!)).toEqual(originalSnapshot);
+  });
+
+  it("should save focus:change normally after restore guard is lifted", () => {
+    clearAutoSave();
+    const savedSnapshot: ScrollSnapshot = { index: 50, offsetInItem: 0, total: 100 };
+    sessionStorage.setItem(AUTO_SAVE_KEY, JSON.stringify(savedSnapshot));
+
+    const ctx = createMockContext({ totalItems: 100, scrollTop: 0, itemHeight: 48 });
+    const feature = withSnapshots<TestItem>({ autoSave: AUTO_SAVE_KEY });
+    feature.setup(ctx);
+
+    // Lift guard via idle
+    ctx.idleHandlers[ctx.idleHandlers.length - 1]();
+
+    const newSnapshot: ScrollSnapshot = { index: 30, offsetInItem: 0, total: 100, focusedId: 31 };
+    ctx.methods.set("getScrollSnapshot", () => newSnapshot);
+
+    // Guard lifted — focus:change should now save
+    ctx.emitter.emit("focus:change", { id: 31, index: 30 });
+
+    const stored = sessionStorage.getItem(AUTO_SAVE_KEY);
+    expect(JSON.parse(stored!)).toEqual(newSnapshot);
+  });
+});
+
+// =============================================================================
+// withSnapshots - Focus Save/Restore
+// =============================================================================
+
+describe("withSnapshots - Focus Save/Restore", () => {
+  let savedRAF: typeof globalThis.requestAnimationFrame;
+
+  beforeAll(() => {
+    savedRAF = global.requestAnimationFrame;
+    global.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      cb(performance.now());
+      return 0;
+    }) as typeof requestAnimationFrame;
+  });
+
+  afterAll(() => {
+    global.requestAnimationFrame = savedRAF;
+  });
+
+  // ── getScrollSnapshot ──────────────────────────────────────────────────────
+
+  it("should capture focusedId when _getFocusedId is present", () => {
+    const ctx = createMockContext({ totalItems: 100, scrollTop: 0 });
+    ctx.methods.set("_getFocusedId", () => 42);
+
+    const feature = withSnapshots<TestItem>();
+    feature.setup(ctx);
+
+    const getSnapshot = ctx.methods.get("getScrollSnapshot") as () => ScrollSnapshot;
+    expect(getSnapshot().focusedId).toBe(42);
+  });
+
+  it("should capture string focusedId", () => {
+    const ctx = createMockContext({ totalItems: 100, scrollTop: 0 });
+    ctx.methods.set("_getFocusedId", () => "abc-123");
+
+    const feature = withSnapshots<TestItem>();
+    feature.setup(ctx);
+
+    const getSnapshot = ctx.methods.get("getScrollSnapshot") as () => ScrollSnapshot;
+    expect(getSnapshot().focusedId).toBe("abc-123");
+  });
+
+  it("should omit focusedId when _getFocusedId returns undefined", () => {
+    const ctx = createMockContext({ totalItems: 100, scrollTop: 0 });
+    ctx.methods.set("_getFocusedId", () => undefined);
+
+    const feature = withSnapshots<TestItem>();
+    feature.setup(ctx);
+
+    const getSnapshot = ctx.methods.get("getScrollSnapshot") as () => ScrollSnapshot;
+    expect(getSnapshot().focusedId).toBeUndefined();
+  });
+
+  it("should omit focusedId when no selection feature present", () => {
+    const ctx = createMockContext({ totalItems: 100, scrollTop: 0 });
+
+    const feature = withSnapshots<TestItem>();
+    feature.setup(ctx);
+
+    const getSnapshot = ctx.methods.get("getScrollSnapshot") as () => ScrollSnapshot;
+    expect(getSnapshot().focusedId).toBeUndefined();
+  });
+
+  it("should omit focusedId when totalItems is 0 (early return path)", () => {
+    const ctx = createMockContext({ totalItems: 0 });
+    ctx.methods.set("_getFocusedId", () => 42);
+
+    const feature = withSnapshots<TestItem>();
+    feature.setup(ctx);
+
+    const getSnapshot = ctx.methods.get("getScrollSnapshot") as () => ScrollSnapshot;
+    // totalItems=0 returns early — focusedId is not captured
+    expect(getSnapshot().focusedId).toBeUndefined();
+  });
+
+  it("should include focusedId alongside selectedIds in snapshot", () => {
+    const ctx = createMockContext({ totalItems: 100, scrollTop: 0 });
+    ctx.methods.set("getSelected", () => [3, 7]);
+    ctx.methods.set("_getFocusedId", () => 7);
+
+    const feature = withSnapshots<TestItem>();
+    feature.setup(ctx);
+
+    const getSnapshot = ctx.methods.get("getScrollSnapshot") as () => ScrollSnapshot;
+    const snapshot = getSnapshot();
+    expect(snapshot.selectedIds).toEqual([3, 7]);
+    expect(snapshot.focusedId).toBe(7);
+  });
+
+  // ── restoreScroll — sync path (no loadVisibleRange / reload) ──────────────
+
+  it("should call _focusById via rAF after sync restore", () => {
+    const focusByIdFn = mock((_id: string | number) => {});
+    const ctx = createMockContext({ totalItems: 100, itemHeight: 48 });
+    ctx.methods.set("_focusById", focusByIdFn);
+
+    const feature = withSnapshots<TestItem>();
+    feature.setup(ctx);
+
+    const restore = ctx.methods.get("restoreScroll") as (s: ScrollSnapshot) => void;
+    restore({ index: 5, offsetInItem: 0, focusedId: 42 });
+
+    // rAF is synchronous in this describe block
+    expect(focusByIdFn).toHaveBeenCalledWith(42);
+  });
+
+  it("should not call _focusById when snapshot has no focusedId", () => {
+    const focusByIdFn = mock((_id: string | number) => {});
+    const ctx = createMockContext({ totalItems: 100, itemHeight: 48 });
+    ctx.methods.set("_focusById", focusByIdFn);
+
+    const feature = withSnapshots<TestItem>();
+    feature.setup(ctx);
+
+    const restore = ctx.methods.get("restoreScroll") as (s: ScrollSnapshot) => void;
+    restore({ index: 5, offsetInItem: 0 });
+
+    expect(focusByIdFn).not.toHaveBeenCalled();
+  });
+
+  it("should not crash when _focusById is absent and focusedId is present", () => {
+    const ctx = createMockContext({ totalItems: 100, itemHeight: 48 });
+    // No _focusById registered
+
+    const feature = withSnapshots<TestItem>();
+    feature.setup(ctx);
+
+    const restore = ctx.methods.get("restoreScroll") as (s: ScrollSnapshot) => void;
+    expect(() => restore({ index: 5, offsetInItem: 0, focusedId: 42 })).not.toThrow();
+  });
+
+  // ── restoreScroll — async path (loadVisibleRange) ──────────────────────────
+
+  it("should call _focusById after loadVisibleRange resolves", async () => {
+    const focusByIdFn = mock((_id: string | number) => {});
+    const loadVisibleFn = mock(async () => {});
+
+    const ctx = createMockContext({ totalItems: 100, itemHeight: 48, containerSize: 500 });
+    ctx.methods.set("_focusById", focusByIdFn);
+    ctx.methods.set("loadVisibleRange", loadVisibleFn);
+
+    const feature = withSnapshots<TestItem>();
+    feature.setup(ctx);
+
+    const restore = ctx.methods.get("restoreScroll") as (s: ScrollSnapshot) => void;
+    restore({ index: 5, offsetInItem: 0, focusedId: 42 });
+
+    await flushAsync();
+
+    expect(loadVisibleFn).toHaveBeenCalled();
+    expect(focusByIdFn).toHaveBeenCalledWith(42);
+  });
+
+  it("should not call _focusById after loadVisibleRange when focusedId absent", async () => {
+    const focusByIdFn = mock((_id: string | number) => {});
+    const loadVisibleFn = mock(async () => {});
+
+    const ctx = createMockContext({ totalItems: 100, itemHeight: 48, containerSize: 500 });
+    ctx.methods.set("_focusById", focusByIdFn);
+    ctx.methods.set("loadVisibleRange", loadVisibleFn);
+
+    const feature = withSnapshots<TestItem>();
+    feature.setup(ctx);
+
+    const restore = ctx.methods.get("restoreScroll") as (s: ScrollSnapshot) => void;
+    restore({ index: 5, offsetInItem: 0 }); // no focusedId
+
+    await flushAsync();
+
+    expect(loadVisibleFn).toHaveBeenCalled();
+    expect(focusByIdFn).not.toHaveBeenCalled();
+  });
+
+  // ── roundtrip ─────────────────────────────────────────────────────────────
+
+  it("should preserve focusedId through JSON serialization roundtrip", () => {
+    const ctx = createMockContext({ totalItems: 100, scrollTop: 240 });
+    ctx.methods.set("_getFocusedId", () => 99);
+
+    const feature = withSnapshots<TestItem>();
+    feature.setup(ctx);
+
+    const getSnapshot = ctx.methods.get("getScrollSnapshot") as () => ScrollSnapshot;
+    const snapshot = getSnapshot();
+
+    // Simulate sessionStorage roundtrip
+    const parsed: ScrollSnapshot = JSON.parse(JSON.stringify(snapshot));
+    expect(parsed.focusedId).toBe(99);
+  });
 });

--- a/test/features/table/feature.test.ts
+++ b/test/features/table/feature.test.ts
@@ -425,7 +425,7 @@ describe("withTable - Setup", () => {
     cleanupCtx(ctx);
   });
 
-  it("should offset viewport by header height", () => {
+  it("should set header height CSS variable on root for layout and scrollbar offset", () => {
     const feature = withTable({
       columns: testColumns,
       rowHeight: 40,
@@ -435,7 +435,10 @@ describe("withTable - Setup", () => {
 
     feature.setup(ctx);
 
-    expect(ctx.dom.viewport.style.top).toBe("44px");
+    // Layout is handled by CSS flex — the CSS variable drives both
+    // the flex-based header offset and the custom scrollbar track position.
+    expect(ctx.dom.root.style.getPropertyValue('--vlist-table-header-height')).toBe("44px");
+    expect(ctx.dom.viewport.style.position).toBe("");
     cleanupCtx(ctx);
   });
 
@@ -445,28 +448,7 @@ describe("withTable - Setup", () => {
 
     feature.setup(ctx);
 
-    expect(ctx.dom.viewport.style.top).toBe("36px");
-    cleanupCtx(ctx);
-  });
-
-  it("should use absolute positioning on viewport for proper containment", () => {
-    const feature = withTable({
-      columns: testColumns,
-      rowHeight: 40,
-      headerHeight: 44,
-    });
-    const ctx = createMockContext();
-
-    feature.setup(ctx);
-
-    // Viewport must be position: absolute with insets so it sizes correctly
-    // even when the root's height comes from min-height / max-height
-    // (where height: 100% on a static child resolves to auto).
-    expect(ctx.dom.viewport.style.position).toBe("absolute");
-    expect(ctx.dom.viewport.style.top).toBe("44px");
-    expect(ctx.dom.viewport.style.left).toBe("0px");
-    expect(ctx.dom.viewport.style.right).toBe("0px");
-    expect(ctx.dom.viewport.style.bottom).toBe("0px");
+    expect(ctx.dom.root.style.getPropertyValue('--vlist-table-header-height')).toBe("36px");
     cleanupCtx(ctx);
   });
 
@@ -1106,7 +1088,7 @@ describe("withTable - Configuration", () => {
 
     feature.setup(ctx);
 
-    expect(ctx.dom.viewport.style.top).toBe("40px");
+    expect(ctx.dom.root.style.getPropertyValue('--vlist-table-header-height')).toBe("40px");
     cleanupCtx(ctx);
   });
 
@@ -1120,7 +1102,7 @@ describe("withTable - Configuration", () => {
 
     feature.setup(ctx);
 
-    expect(ctx.dom.viewport.style.top).toBe("56px");
+    expect(ctx.dom.root.style.getPropertyValue('--vlist-table-header-height')).toBe("56px");
     cleanupCtx(ctx);
   });
 

--- a/test/features/table/header.test.ts
+++ b/test/features/table/header.test.ts
@@ -119,16 +119,14 @@ describe("createTableHeader - DOM setup", () => {
     expect(scrollContainer.getAttribute("role")).toBe("presentation");
   });
 
-  it("should offset viewport below header", () => {
+  it("should set header height CSS variable on root for scrollbar offset", () => {
     const { root, viewport } = createTestDOM();
     createTableHeader(root, viewport, 48, "vlist", mock());
 
-    expect(viewport.style.position).toBe("absolute");
-    expect(viewport.style.top).toBe("48px");
-    expect(viewport.style.left).toBe("0px");
-    expect(viewport.style.right).toBe("0px");
-    expect(viewport.style.bottom).toBe("0px");
-    expect(viewport.style.height).toBe("auto");
+    // Layout is now handled by CSS flex — no inline styles on viewport.
+    // The CSS variable on root allows the custom scrollbar to offset its track.
+    expect(root.style.getPropertyValue('--vlist-table-header-height')).toBe("48px");
+    expect(viewport.style.position).toBe("");
   });
 
   it("should use custom class prefix", () => {
@@ -884,19 +882,15 @@ describe("createTableHeader - destroy", () => {
     expect(root.querySelector("[role='rowgroup']")).toBeNull();
   });
 
-  it("should reset viewport positioning", () => {
+  it("should clear the header height CSS variable on root after destroy", () => {
     const { root, viewport } = createTestDOM();
-    createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
-
-    expect(viewport.style.position).toBe("absolute");
-
     const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+
+    expect(root.style.getPropertyValue('--vlist-table-header-height')).toBe("40px");
+
     header.destroy();
 
+    expect(root.style.getPropertyValue('--vlist-table-header-height')).toBe("");
     expect(viewport.style.position).toBe("");
-    expect(viewport.style.top).toBe("");
-    expect(viewport.style.left).toBe("");
-    expect(viewport.style.right).toBe("");
-    expect(viewport.style.bottom).toBe("");
   });
 });

--- a/test/features/table/header.test.ts
+++ b/test/features/table/header.test.ts
@@ -89,7 +89,7 @@ function createResolvedLayout(columns: TableColumn<TestItem>[], containerWidth =
 describe("createTableHeader - DOM setup", () => {
   it("should insert header rowgroup before viewport", () => {
     const { root, viewport } = createTestDOM();
-    createTableHeader(root, viewport, 40, "vlist", mock());
+    createTableHeader(root, 40, "vlist", mock());
 
     const rowgroup = root.firstChild as HTMLElement;
     expect(rowgroup.getAttribute("role")).toBe("rowgroup");
@@ -97,8 +97,8 @@ describe("createTableHeader - DOM setup", () => {
   });
 
   it("should create header row element with correct ARIA", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader(root, 40, "vlist", mock());
 
     expect(header.element.getAttribute("role")).toBe("row");
     expect(header.element.getAttribute("aria-rowindex")).toBe("1");
@@ -106,32 +106,31 @@ describe("createTableHeader - DOM setup", () => {
   });
 
   it("should set header height from config", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader(root, viewport, 36, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader(root, 36, "vlist", mock());
     expect(header.element.style.height).toBe("36px");
   });
 
   it("should create scroll container inside header", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader(root, 40, "vlist", mock());
     const scrollContainer = header.element.firstChild as HTMLElement;
     expect(scrollContainer.className).toBe("vlist-table-header-scroll");
     expect(scrollContainer.getAttribute("role")).toBe("presentation");
   });
 
   it("should set header height CSS variable on root for scrollbar offset", () => {
-    const { root, viewport } = createTestDOM();
-    createTableHeader(root, viewport, 48, "vlist", mock());
+    const { root } = createTestDOM();
+    createTableHeader(root, 48, "vlist", mock());
 
     // Layout is now handled by CSS flex — no inline styles on viewport.
     // The CSS variable on root allows the custom scrollbar to offset its track.
     expect(root.style.getPropertyValue('--vlist-table-header-height')).toBe("48px");
-    expect(viewport.style.position).toBe("");
   });
 
   it("should use custom class prefix", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader(root, viewport, 40, "mytable", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader(root, 40, "mytable", mock());
     expect(header.element.className).toBe("mytable-table-header");
   });
 });
@@ -142,8 +141,8 @@ describe("createTableHeader - DOM setup", () => {
 
 describe("createTableHeader - rebuild", () => {
   it("should create cells for each column", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([col("name"), col("value")]);
 
     header.rebuild(layout);
@@ -153,8 +152,8 @@ describe("createTableHeader - rebuild", () => {
   });
 
   it("should set columnheader role and aria-colindex on cells", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([col("name"), col("value")]);
 
     header.rebuild(layout);
@@ -169,8 +168,8 @@ describe("createTableHeader - rebuild", () => {
   });
 
   it("should set data-column-key on cells", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([col("name"), col("value")]);
 
     header.rebuild(layout);
@@ -181,8 +180,8 @@ describe("createTableHeader - rebuild", () => {
   });
 
   it("should render string labels as text content", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([col("name", { label: "Full Name" })]);
 
     header.rebuild(layout);
@@ -194,8 +193,8 @@ describe("createTableHeader - rebuild", () => {
   });
 
   it("should render DOM element labels by appending", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const labelEl = document.createElement("strong");
     labelEl.textContent = "Bold";
 
@@ -210,8 +209,8 @@ describe("createTableHeader - rebuild", () => {
   });
 
   it("should use custom header template when provided", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
 
     const layout = createResolvedLayout([
       col("name", { header: (c) => `Custom: ${c.label}` }),
@@ -224,8 +223,8 @@ describe("createTableHeader - rebuild", () => {
   });
 
   it("should use custom header template returning DOM element", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
 
     const layout = createResolvedLayout([
       col("name", {
@@ -244,8 +243,8 @@ describe("createTableHeader - rebuild", () => {
   });
 
   it("should add alignment modifier class for center", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([col("value", { align: "center" })]);
 
     header.rebuild(layout);
@@ -256,8 +255,8 @@ describe("createTableHeader - rebuild", () => {
   });
 
   it("should add alignment modifier class for right", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([col("value", { align: "right" })]);
 
     header.rebuild(layout);
@@ -268,8 +267,8 @@ describe("createTableHeader - rebuild", () => {
   });
 
   it("should not add alignment class for left (default)", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([col("name", { align: "left" })]);
 
     header.rebuild(layout);
@@ -281,8 +280,8 @@ describe("createTableHeader - rebuild", () => {
   });
 
   it("should add sortable class and sort indicator for sortable columns", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([col("name", { sortable: true })]);
 
     header.rebuild(layout);
@@ -297,8 +296,8 @@ describe("createTableHeader - rebuild", () => {
   });
 
   it("should not add sort indicator for non-sortable columns", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([col("name")]);
 
     header.rebuild(layout);
@@ -309,8 +308,8 @@ describe("createTableHeader - rebuild", () => {
   });
 
   it("should add resize handles for resizable columns", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([
       col("name", { width: 200, resizable: true }),
       col("value", { width: 200, resizable: false }),
@@ -328,8 +327,8 @@ describe("createTableHeader - rebuild", () => {
   });
 
   it("should clear existing cells on rebuild", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
 
     const layout1 = createResolvedLayout([col("a"), col("b"), col("c")]);
     header.rebuild(layout1);
@@ -342,8 +341,8 @@ describe("createTableHeader - rebuild", () => {
   });
 
   it("should restore sort indicator after rebuild", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
 
     const layout = createResolvedLayout([
       col("name", { sortable: true }),
@@ -369,8 +368,8 @@ describe("createTableHeader - rebuild", () => {
 
 describe("createTableHeader - update", () => {
   it("should set scroll container width to layout totalWidth", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([
       col("name", { width: 200 }),
       col("value", { width: 300 }),
@@ -383,8 +382,8 @@ describe("createTableHeader - update", () => {
   });
 
   it("should set individual cell widths", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([
       col("name", { width: 200 }),
       col("value", { width: 300 }),
@@ -398,8 +397,8 @@ describe("createTableHeader - update", () => {
   });
 
   it("should update widths when called with new layout", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const columns = [
       col("name", { width: 200 }),
       col("value", { width: 300 }),
@@ -423,8 +422,8 @@ describe("createTableHeader - update", () => {
 
 describe("createTableHeader - sort", () => {
   it("should show ascending indicator", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([
       col("name", { sortable: true }),
       col("value", { sortable: true }),
@@ -443,8 +442,8 @@ describe("createTableHeader - sort", () => {
   });
 
   it("should show descending indicator", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([col("name", { sortable: true })]);
 
     header.rebuild(layout);
@@ -459,8 +458,8 @@ describe("createTableHeader - sort", () => {
   });
 
   it("should clear indicator when sorting different column", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([
       col("name", { sortable: true }),
       col("value", { sortable: true }),
@@ -486,8 +485,8 @@ describe("createTableHeader - sort", () => {
   });
 
   it("should clear all indicators when key is null", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([col("name", { sortable: true })]);
 
     header.rebuild(layout);
@@ -504,8 +503,8 @@ describe("createTableHeader - sort", () => {
   });
 
   it("should handle updateSort before rebuild (no layout)", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
 
     // Should not throw
     expect(() => header.updateSort("name", "asc")).not.toThrow();
@@ -518,8 +517,8 @@ describe("createTableHeader - sort", () => {
 
 describe("createTableHeader - syncScroll", () => {
   it("should translate scroll container by negative scrollLeft", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock()) as any;
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock()) as any;
 
     header.syncScroll(150);
 
@@ -528,8 +527,8 @@ describe("createTableHeader - syncScroll", () => {
   });
 
   it("should handle zero scroll", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock()) as any;
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock()) as any;
 
     header.syncScroll(0);
 
@@ -544,9 +543,9 @@ describe("createTableHeader - syncScroll", () => {
 
 describe("createTableHeader - click interaction", () => {
   it("should call onSort when clicking a sortable header cell", () => {
-    const { root, viewport } = createTestDOM();
+    const { root } = createTestDOM();
     const onSort = mock(() => {});
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock(), onSort);
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock(), onSort);
     const layout = createResolvedLayout([col("name", { sortable: true })]);
 
     header.rebuild(layout);
@@ -567,10 +566,10 @@ describe("createTableHeader - click interaction", () => {
   });
 
   it("should call onClick when clicking any header cell", () => {
-    const { root, viewport } = createTestDOM();
+    const { root } = createTestDOM();
     const onClick = mock(() => {});
     const header = createTableHeader<TestItem>(
-      root, viewport, 40, "vlist", mock(), undefined, onClick,
+      root, 40, "vlist", mock(), undefined, onClick,
     );
     const layout = createResolvedLayout([col("name")]);
 
@@ -591,10 +590,10 @@ describe("createTableHeader - click interaction", () => {
   });
 
   it("should cycle sort: asc → desc → null", () => {
-    const { root, viewport } = createTestDOM();
+    const { root } = createTestDOM();
     const sortCalls: any[] = [];
     const onSort = mock((e: any) => sortCalls.push(e));
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock(), onSort);
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock(), onSort);
     const layout = createResolvedLayout([col("name", { sortable: true })]);
 
     header.rebuild(layout);
@@ -624,9 +623,9 @@ describe("createTableHeader - click interaction", () => {
   });
 
   it("should not emit sort for non-sortable columns", () => {
-    const { root, viewport } = createTestDOM();
+    const { root } = createTestDOM();
     const onSort = mock(() => {});
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock(), onSort);
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock(), onSort);
     const layout = createResolvedLayout([col("name", { sortable: false })]);
 
     header.rebuild(layout);
@@ -641,9 +640,9 @@ describe("createTableHeader - click interaction", () => {
   });
 
   it("should ignore clicks on resize handles", () => {
-    const { root, viewport } = createTestDOM();
+    const { root } = createTestDOM();
     const onSort = mock(() => {});
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock(), onSort);
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock(), onSort);
     const layout = createResolvedLayout([
       col("name", { width: 200, sortable: true, resizable: true }),
     ]);
@@ -658,9 +657,9 @@ describe("createTableHeader - click interaction", () => {
   });
 
   it("should handle click when no layout is set", () => {
-    const { root, viewport } = createTestDOM();
+    const { root } = createTestDOM();
     const onSort = mock(() => {});
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock(), onSort);
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock(), onSort);
 
     // Click with no cells — should not throw
     const event = new MouseEvent("click", { bubbles: true });
@@ -675,9 +674,9 @@ describe("createTableHeader - click interaction", () => {
 
 describe("createTableHeader - resize interaction", () => {
   it("should call onResize during pointer drag on resize handle", () => {
-    const { root, viewport } = createTestDOM();
+    const { root } = createTestDOM();
     const onResize = mock(() => {});
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", onResize);
+    const header = createTableHeader<TestItem>(root, 40, "vlist", onResize);
     const layout = createResolvedLayout([
       col("name", { width: 200, resizable: true }),
       col("value", { width: 200 }),
@@ -727,9 +726,9 @@ describe("createTableHeader - resize interaction", () => {
   });
 
   it("should ignore small drags below MIN_DRAG_DELTA", () => {
-    const { root, viewport } = createTestDOM();
+    const { root } = createTestDOM();
     const onResize = mock(() => {});
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", onResize);
+    const header = createTableHeader<TestItem>(root, 40, "vlist", onResize);
     const layout = createResolvedLayout([
       col("name", { width: 200, resizable: true }),
     ]);
@@ -763,9 +762,9 @@ describe("createTableHeader - resize interaction", () => {
   });
 
   it("should ignore pointerdown on non-resize elements", () => {
-    const { root, viewport } = createTestDOM();
+    const { root } = createTestDOM();
     const onResize = mock(() => {});
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", onResize);
+    const header = createTableHeader<TestItem>(root, 40, "vlist", onResize);
     const layout = createResolvedLayout([col("name", { width: 200 })]);
 
     header.rebuild(layout);
@@ -782,8 +781,8 @@ describe("createTableHeader - resize interaction", () => {
   });
 
   it("should handle pointerup when not dragging", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
 
     // Should not throw
     expect(() => {
@@ -793,8 +792,8 @@ describe("createTableHeader - resize interaction", () => {
   });
 
   it("should add active class to handle during drag", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
     const layout = createResolvedLayout([
       col("name", { width: 200, resizable: true }),
     ]);
@@ -829,16 +828,16 @@ describe("createTableHeader - resize interaction", () => {
 
 describe("createTableHeader - visibility", () => {
   it("should hide the header", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
 
     header.hide();
     expect(header.element.style.display).toBe("none");
   });
 
   it("should show the header after hiding", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
 
     header.hide();
     header.show();
@@ -846,8 +845,8 @@ describe("createTableHeader - visibility", () => {
   });
 
   it("should not re-show if already visible", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
 
     // Already visible by default — show should be a no-op
     header.show();
@@ -855,8 +854,8 @@ describe("createTableHeader - visibility", () => {
   });
 
   it("should not re-hide if already hidden", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
 
     header.hide();
     header.hide(); // Should be a no-op
@@ -870,8 +869,8 @@ describe("createTableHeader - visibility", () => {
 
 describe("createTableHeader - destroy", () => {
   it("should remove the rowgroup from DOM", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
 
     const rowgroup = root.firstChild as HTMLElement;
     expect(rowgroup.getAttribute("role")).toBe("rowgroup");
@@ -883,14 +882,13 @@ describe("createTableHeader - destroy", () => {
   });
 
   it("should clear the header height CSS variable on root after destroy", () => {
-    const { root, viewport } = createTestDOM();
-    const header = createTableHeader<TestItem>(root, viewport, 40, "vlist", mock());
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
 
     expect(root.style.getPropertyValue('--vlist-table-header-height')).toBe("40px");
 
     header.destroy();
 
     expect(root.style.getPropertyValue('--vlist-table-header-height')).toBe("");
-    expect(viewport.style.position).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

- **feat(snapshots):** `getScrollSnapshot()` now captures `focusedId`; `restoreScroll()` restores keyboard focus after data loads. Focus ring only shows when user tabs into the list. `autoSave` saves on `focus:change`. New `focus:change` event. Closes #29.
- **fix(snapshots):** `restoreScroll` was clipping the last ~466px on 1M-item lists when `withScale` is active — `maxScroll` ignored compression slack. Closes #30.
- **fix(table):** Custom scrollbar was invisible/doubled in table mode (Firefox `scrollbar-width: none` applied to both axes).

## Test plan

- [ ] `bun test` — 3188 tests, 0 failures
- [ ] `bun run typecheck` — clean
- [ ] Verify focus restore on https://staging.vlist.io/examples/scroll-restore
- [ ] Verify scroll-to-end restore on https://staging.vlist.io/examples/velocity-loading