### PR TITLE
fix(ci): add NPM_TOKEN to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Publish
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         run: gh release create ${{ github.ref_name }} --title "${{ github.ref_name }}" --generate-notes


### PR DESCRIPTION
Adds missing NODE_AUTH_TOKEN env var to npm publish step.