### PR TITLE
chore(release): v1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,19 @@
 
 The virtual list library for every framework. Accessible by default, batteries-included, with composable features — in 10.5 KB.
 
-**v1.7.0** — [Changelog](./changelog.txt)
+**v1.7.1** — [Changelog](./changelog.txt)
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![CI](https://github.com/floor/vlist/actions/workflows/ci.yml/badge.svg)](https://github.com/floor/vlist/actions/workflows/ci.yml)
 [![license](https://img.shields.io/npm/l/vlist.svg)](https://github.com/floor/vlist/blob/main/LICENSE)
 
+- **New: `withSortable()`** — drag-and-drop reordering with auto-scroll, keyboard support, and ARIA announcements
 - **Accessible** — WAI-ARIA, 2D keyboard navigation, focus recovery, screen-reader DOM ordering, ARIA live region
 - **Zero dependencies** — framework-agnostic core with tiny adapters for Vue, Svelte, Solid, React
 - **10.6 KB gzipped** — composable features with perfect tree-shaking
 - **Constant memory** — ~0.1 MB overhead at any scale, from 10K to 1M+ items
-- **Grid, masonry, table, groups, async, selection, scale** — all opt-in
-- **Vertical & horizontal** — dimension-agnostic API, every layout mode works in both orientations
+- **Grid, masonry, table, groups, async, selection, sortable, scale** — all opt-in
+- **Vertical & horizontal** — single axis-neutral code path, every feature works in both orientations
 
 **18 interactive examples, docs & benchmarks → [vlist.io](https://vlist.io)**
 
@@ -95,7 +96,7 @@ const list = vlist({
 |---------|------|-------------|
 | **Base** | 10.6 KB | Virtualization, ARIA, keyboard nav, gap, padding |
 | `withAsync()` | +4.6 KB | Lazy loading with velocity-aware fetching |
-| `withSelection()` | +2.7 KB | Single/multiple selection with 2D keyboard nav |
+| `withSelection()` | +2.9 KB | Single/multiple selection with 2D keyboard nav |
 | `withScale()` | +3.7 KB | 1M+ items via scroll compression |
 | `withGroups()` | +2.7 KB | Sticky/inline headers |
 | `withAutoSize()` | +0.9 KB | Auto-measure items via ResizeObserver |
@@ -104,6 +105,7 @@ const list = vlist({
 | `withMasonry()` | +3.4 KB | Pinterest-style masonry with lane-aware keyboard nav |
 | `withTable()` | +5.5 KB | Data table with columns, resize, sort |
 | `withPage()` | +0.8 KB | Window-level scrolling |
+| `withSortable()` | +2.9 KB | Drag-and-drop reordering with auto-scroll |
 | `withSnapshots()` | +0.8 KB | Scroll position save/restore |
 
 ## Examples
@@ -253,6 +255,8 @@ list.on('selection:change', ({ selectedIds, selectedItems }) => {})
 list.on('load:start', ({ offset, limit }) => {})
 list.on('load:end', ({ items, offset, total }) => {})
 list.on('load:error', ({ error, offset, limit }) => {})
+list.on('sort:end', ({ fromIndex, toIndex }) => {})
+list.on('sort:cancel', ({ originalItems }) => {})
 ```
 
 ### Properties
@@ -278,6 +282,7 @@ withTable({ columns, rowHeight, headerHeight?, resizable? })
 withAutoSize()                        // auto-measure items (requires estimatedHeight)
 withScale()                           // auto-activates at 16.7M px
 withScrollbar({ autoHide?, autoHideDelay?, minThumbSize? })
+withSortable({ handle?: '.drag-handle' })  // drag-and-drop reordering
 withPage()                            // no config — uses document scroll
 withSnapshots({ autoSave: 'key' })    // automatic sessionStorage save/restore
 ```

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,33 @@
 vlist — full changelog
 initial commit → latest
-617 commits · 86 days · Feb 2 – Apr 29, 2026
+621 commits · 88 days · Feb 2 – Apr 30, 2026
+
+
+2026-04-30  v1.7.1
+
+  fix(sortable): fix drop index oscillation on direction change
+    The old computeDropIndex switched between ghost bottom/top edge based
+    on a direction flag, causing a discontinuity of draggedItemSize when
+    the drag reversed — triggering double-shifts or oscillation near the
+    reversal point. Replaced with a stateless, direction-agnostic approach
+    that scans from dragIndex using the natural leading edge for each
+    direction: bottom edge for downward checks, top edge for upward checks.
+
+  perf(sortable): use O(log n) binary search in computeDropIndex
+    Replace linear scan from dragIndex with sizeCache.indexAtOffset()
+    binary search. Avoids iterating through all items between dragIndex
+    and the ghost position after auto-scrolling large distances.
+
+  fix(sortable): refactor drop index calculation and element recycling
+    - Replace DOM-walking computeDropIndex with sizeCache.indexAtOffset()
+      to avoid wrong results from element recycling shuffling DOM order
+    - Add afterRenderBatch handler to maintain drag visual state when
+      virtual scrolling recycles elements (hide dragIndex, re-apply shifts)
+    - Simplify cleanupDrag to reset ALL children's opacity/pointerEvents
+      instead of only the tracked draggedElement
+    - Add withScale to conflicts list
+
+  fix(sortable): clear text selection after drop (Safari)
 
 
 2026-04-28  v1.6.5

--- a/npm-readme.md
+++ b/npm-readme.md
@@ -6,10 +6,12 @@ The virtual list library for every framework. Accessible by default, batteries-i
 [![CI](https://github.com/floor/vlist/actions/workflows/ci.yml/badge.svg)](https://github.com/floor/vlist/actions/workflows/ci.yml)
 [![license](https://img.shields.io/npm/l/vlist.svg)](https://github.com/floor/vlist/blob/main/LICENSE)
 
+- **New: `withSortable()`** — drag-and-drop reordering with auto-scroll, keyboard support, and ARIA announcements
 - **Zero dependencies** — framework-agnostic core, tiny adapters for Vue, Svelte, Solid, React
 - **Accessible** — WAI-ARIA, 2D keyboard navigation, focus recovery, screen-reader DOM ordering
 - **10.6 KB gzipped** — composable features with perfect tree-shaking
 - **Constant memory** — ~0.1 MB overhead at any scale, from 10K to 1M+ items
+- **Vertical & horizontal** — single axis-neutral code path, every feature works in both orientations
 
 ## Install
 
@@ -54,7 +56,7 @@ const list = vlist({ container: '#app', items, item: { height: 200, template: re
 |---------|------|-------------|
 | **Base** | 10.6 KB | Virtualization, ARIA, keyboard nav, gap, padding |
 | `withAsync()` | +4.6 KB | Lazy loading with velocity-aware fetching |
-| `withSelection()` | +2.7 KB | Single/multiple selection with 2D keyboard nav |
+| `withSelection()` | +2.9 KB | Single/multiple selection with 2D keyboard nav |
 | `withScale()` | +3.7 KB | 1M+ items via scroll compression |
 | `withGroups()` | +2.7 KB | Sticky/inline headers |
 | `withAutoSize()` | +0.9 KB | Auto-measure items via ResizeObserver |
@@ -63,6 +65,7 @@ const list = vlist({ container: '#app', items, item: { height: 200, template: re
 | `withMasonry()` | +3.4 KB | Pinterest-style masonry with lane-aware keyboard nav |
 | `withTable()` | +5.5 KB | Data table with columns, resize, sort |
 | `withPage()` | +0.8 KB | Window-level scrolling |
+| `withSortable()` | +2.9 KB | Drag-and-drop reordering with auto-scroll |
 | `withSnapshots()` | +0.8 KB | Scroll position save/restore |
 
 ## Framework Adapters

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/src/features/sortable/feature.ts
+++ b/src/features/sortable/feature.ts
@@ -203,51 +203,41 @@ export const withSortable = <T extends VListItem = VListItem>(
       };
 
       // ── Helper: determine drop index from pointer position ──
-      // Uses sizeCache.indexAtOffset() instead of walking DOM elements,
-      // because element recycling can shuffle DOM order and produce
-      // wrong results when iterating querySelectorAll in DOM order.
+      // Stateless, direction-agnostic: scans from dragIndex in both
+      // directions using the appropriate leading edge for each.
+      // - Downward: ghost BOTTOM edge vs item midpoint (shift triggers early)
+      // - Upward: ghost TOP edge vs item midpoint (shift triggers early)
+      // No direction flag needed — avoids the discontinuity that caused
+      // oscillation when switching between top/bottom edges.
       const computeDropIndex = (): number => {
         const totalItems = ctx.dataManager.getTotal();
         if (totalItems === 0) return 0;
 
-        // Use the ghost's LEADING EDGE based on drag direction:
-        // - Dragging down → bottom edge of the ghost
-        // - Dragging up → top edge of the ghost
-        // The shift triggers when this edge crosses the midpoint of a target item.
         const viewportRect = dom.viewport.getBoundingClientRect();
         const scrollPos = ctx.scrollController.getScrollTop();
-        const movingDown = horizontal
-          ? pointerCurrentX > pointerStartX
-          : pointerCurrentY > pointerStartY;
-        const ghostEdge = horizontal
-          ? pointerCurrentX - ghostOffsetX + (movingDown ? draggedItemSize : 0)
-          : pointerCurrentY - ghostOffsetY + (movingDown ? draggedItemSize : 0);
-        const pointerInContent = horizontal
-          ? ghostEdge - viewportRect.left + dom.viewport.scrollLeft + scrollPos
-          : ghostEdge - viewportRect.top + scrollPos;
+        const ghostTop = horizontal
+          ? pointerCurrentX - ghostOffsetX - viewportRect.left + dom.viewport.scrollLeft + scrollPos
+          : pointerCurrentY - ghostOffsetY - viewportRect.top + scrollPos;
+        const ghostBottom = ghostTop + draggedItemSize;
 
-        // Find the item slot at the pointer position via sizeCache
-        const rawIndex = ctx.sizeCache.indexAtOffset(pointerInContent);
-        const itemOffset = ctx.sizeCache.getOffset(rawIndex);
-        const itemSize = ctx.sizeCache.getSize(rawIndex);
-        const itemMid = itemOffset + itemSize / 2;
-
-        // Determine insertion point based on which half of the item
-        // the pointer falls in
-        let insertAt: number;
-        if (pointerInContent < itemMid) {
-          insertAt = rawIndex;
-        } else {
-          insertAt = rawIndex + 1;
+        // Scan downward: find the furthest item whose midpoint the ghost
+        // bottom edge has crossed
+        let result = dragIndex;
+        for (let i = dragIndex + 1; i < totalItems; i++) {
+          const mid = ctx.sizeCache.getOffset(i) + ctx.sizeCache.getSize(i) / 2;
+          if (ghostBottom > mid) result = i;
+          else break;
         }
+        if (result > dragIndex) return result;
 
-        // Adjust for the dragged item gap — indices above dragIndex
-        // shift down by 1 when the dragged item is "removed"
-        if (insertAt > dragIndex) {
-          insertAt -= 1;
+        // Scan upward: find the furthest item whose midpoint the ghost
+        // top edge has crossed
+        for (let i = dragIndex - 1; i >= 0; i--) {
+          const mid = ctx.sizeCache.getOffset(i) + ctx.sizeCache.getSize(i) / 2;
+          if (ghostTop < mid) result = i;
+          else break;
         }
-
-        return Math.max(0, Math.min(insertAt, totalItems - 1));
+        return Math.max(0, Math.min(result, totalItems - 1));
       };
 
       // ── Apply CSS transforms to shift items out of the way ──
@@ -257,8 +247,6 @@ export const withSortable = <T extends VListItem = VListItem>(
       const applyShifts = (): void => {
         const children = dom.items.children;
         const shiftPx = draggedItemSize;
-
-        console.log(`[sort] applyShifts: dragIndex=${dragIndex} dropIndex=${dropIndex} shiftPx=${shiftPx} children=${children.length}`);
 
         for (let i = 0; i < children.length; i++) {
           const itemEl = children[i] as HTMLElement;
@@ -274,9 +262,6 @@ export const withSortable = <T extends VListItem = VListItem>(
 
           const baseOffset = ctx.sizeCache.getOffset(idx);
           const finalOffset = Math.round(baseOffset + shift);
-          if (shift !== 0) {
-            console.log(`  [sort] shift idx=${idx} base=${baseOffset} shift=${shift} final=${finalOffset}`);
-          }
           itemEl.style.transition = shiftTransition;
           itemEl.style.transform = `${prop}(${finalOffset}px)`;
         }
@@ -299,7 +284,6 @@ export const withSortable = <T extends VListItem = VListItem>(
       const updateDropPosition = (): void => {
         const newDropIndex = computeDropIndex();
         if (newDropIndex === dropIndex) return;
-        console.log(`[sort] updateDropPosition: ${dropIndex} → ${newDropIndex} (dragIndex=${dragIndex})`);
         dropIndex = newDropIndex;
         applyShifts();
         emitter.emit("sort:move", { fromIndex: dragIndex, currentIndex: dropIndex });
@@ -391,7 +375,6 @@ export const withSortable = <T extends VListItem = VListItem>(
       // triggered a force render — calling clearShifts + forceRender
       // again would be redundant.
       const cleanupDrag = (skipRender = false): void => {
-        console.log(`[sort] cleanupDrag: skipRender=${skipRender} dragIndex=${dragIndex} dropIndex=${dropIndex}`);
         sorting = false;
         dragInitiated = false;
 
@@ -493,7 +476,6 @@ export const withSortable = <T extends VListItem = VListItem>(
           dragInitiated = true;
           sorting = true;
           dropIndex = dragIndex;
-          console.log(`[sort] drag started: dragIndex=${dragIndex} itemId=${ctx.dataManager.getItem(dragIndex)?.id}`);
           dom.root.classList.add(`${classPrefix}--sorting`);
 
           // Cache the dragged item's size for shift calculations
@@ -534,7 +516,6 @@ export const withSortable = <T extends VListItem = VListItem>(
           } else if (isPointerOutsideViewport()) {
             // Clear shifts when pointer leaves viewport
             if (dropIndex !== dragIndex) {
-              console.log(`[sort] outside viewport: clearing shifts, dropIndex ${dropIndex} → ${dragIndex}`);
               dropIndex = dragIndex;
               clearShifts();
             }
@@ -957,11 +938,9 @@ export const withSortable = <T extends VListItem = VListItem>(
       ctx.afterRenderBatch.push(
         (items: ReadonlyArray<{ index: number; element: HTMLElement }>) => {
           if (!sorting) return;
-          console.log(`[sort] afterRenderBatch: sorting=${sorting} dragIndex=${dragIndex} dropIndex=${dropIndex} batchSize=${items.length}`);
           for (let i = 0; i < items.length; i++) {
             const { index, element } = items[i]!;
             if (index === dragIndex) {
-              console.log(`  [sort] hide dragIndex=${index}`);
               element.style.opacity = "0";
               element.style.pointerEvents = "none";
               draggedElement = element;
@@ -975,9 +954,6 @@ export const withSortable = <T extends VListItem = VListItem>(
                 if (index >= dropIndex && index < dragIndex) shift = draggedItemSize;
               }
               const finalOffset = Math.round(ctx.sizeCache.getOffset(index) + shift);
-              if (shift !== 0) {
-                console.log(`  [sort] renderBatch shift idx=${index} shift=${shift} final=${finalOffset}`);
-              }
               element.style.transform = `${prop}(${finalOffset}px)`;
             }
           }

--- a/src/features/sortable/feature.ts
+++ b/src/features/sortable/feature.ts
@@ -203,11 +203,11 @@ export const withSortable = <T extends VListItem = VListItem>(
       };
 
       // ── Helper: determine drop index from pointer position ──
-      // Stateless, direction-agnostic: scans from dragIndex in both
-      // directions using the appropriate leading edge for each.
-      // - Downward: ghost BOTTOM edge vs item midpoint (shift triggers early)
-      // - Upward: ghost TOP edge vs item midpoint (shift triggers early)
-      // No direction flag needed — avoids the discontinuity that caused
+      // Stateless, direction-agnostic — uses O(log n) binary search via
+      // indexAtOffset instead of scanning from dragIndex.
+      // - Downward: ghost BOTTOM edge vs item midpoint
+      // - Upward: ghost TOP edge vs item midpoint
+      // No direction flag — avoids the discontinuity that caused
       // oscillation when switching between top/bottom edges.
       const computeDropIndex = (): number => {
         const totalItems = ctx.dataManager.getTotal();
@@ -220,24 +220,27 @@ export const withSortable = <T extends VListItem = VListItem>(
           : pointerCurrentY - ghostOffsetY - viewportRect.top + scrollPos;
         const ghostBottom = ghostTop + draggedItemSize;
 
-        // Scan downward: find the furthest item whose midpoint the ghost
-        // bottom edge has crossed
-        let result = dragIndex;
-        for (let i = dragIndex + 1; i < totalItems; i++) {
-          const mid = ctx.sizeCache.getOffset(i) + ctx.sizeCache.getSize(i) / 2;
-          if (ghostBottom > mid) result = i;
-          else break;
-        }
-        if (result > dragIndex) return result;
+        const dragEnd = ctx.sizeCache.getOffset(dragIndex) + ctx.sizeCache.getSize(dragIndex);
 
-        // Scan upward: find the furthest item whose midpoint the ghost
-        // top edge has crossed
-        for (let i = dragIndex - 1; i >= 0; i--) {
-          const mid = ctx.sizeCache.getOffset(i) + ctx.sizeCache.getSize(i) / 2;
-          if (ghostTop < mid) result = i;
-          else break;
+        // Downward: ghost bottom past the drag slot
+        if (ghostBottom > dragEnd) {
+          const rawIndex = ctx.sizeCache.indexAtOffset(ghostBottom);
+          const mid = ctx.sizeCache.getOffset(rawIndex) + ctx.sizeCache.getSize(rawIndex) / 2;
+          const result = ghostBottom > mid ? rawIndex : rawIndex - 1;
+          return Math.min(Math.max(result, dragIndex), totalItems - 1);
         }
-        return Math.max(0, Math.min(result, totalItems - 1));
+
+        // Upward: ghost top above the drag slot
+        const dragStart = ctx.sizeCache.getOffset(dragIndex);
+        if (ghostTop < dragStart) {
+          const rawIndex = ctx.sizeCache.indexAtOffset(ghostTop);
+          const mid = ctx.sizeCache.getOffset(rawIndex) + ctx.sizeCache.getSize(rawIndex) / 2;
+          const result = ghostTop < mid ? rawIndex : rawIndex + 1;
+          return Math.max(Math.min(result, dragIndex), 0);
+        }
+
+        // Ghost still within the drag slot — no shift
+        return dragIndex;
       };
 
       // ── Apply CSS transforms to shift items out of the way ──

--- a/src/features/sortable/feature.ts
+++ b/src/features/sortable/feature.ts
@@ -124,7 +124,7 @@ export const withSortable = <T extends VListItem = VListItem>(
 
     methods: ["isSorting"] as const,
 
-    conflicts: ["withGrid", "withMasonry", "withTable"] as const,
+    conflicts: ["withGrid", "withMasonry", "withTable", "withScale"] as const,
 
     setup(ctx: BuilderContext<T>): void {
       const { dom, emitter, config: resolvedConfig } = ctx;
@@ -203,6 +203,9 @@ export const withSortable = <T extends VListItem = VListItem>(
       };
 
       // ── Helper: determine drop index from pointer position ──
+      // Uses sizeCache.indexAtOffset() instead of walking DOM elements,
+      // because element recycling can shuffle DOM order and produce
+      // wrong results when iterating querySelectorAll in DOM order.
       const computeDropIndex = (): number => {
         const totalItems = ctx.dataManager.getTotal();
         if (totalItems === 0) return 0;
@@ -223,36 +226,28 @@ export const withSortable = <T extends VListItem = VListItem>(
           ? ghostEdge - viewportRect.left + dom.viewport.scrollLeft + scrollPos
           : ghostEdge - viewportRect.top + scrollPos;
 
-        // Walk visible items to find the insertion point
-        const itemElements = dom.items.querySelectorAll("[data-index]");
-        let insertBefore = totalItems; // default: end of list
+        // Find the item slot at the pointer position via sizeCache
+        const rawIndex = ctx.sizeCache.indexAtOffset(pointerInContent);
+        const itemOffset = ctx.sizeCache.getOffset(rawIndex);
+        const itemSize = ctx.sizeCache.getSize(rawIndex);
+        const itemMid = itemOffset + itemSize / 2;
 
-        for (let i = 0; i < itemElements.length; i++) {
-          const itemEl = itemElements[i] as HTMLElement;
-          const idx = getIndex(itemEl);
-          if (idx < 0) continue;
-
-          // Skip the dragged item itself
-          if (idx === dragIndex) continue;
-
-          // Use the original position from sizeCache (not the visual position
-          // which may be shifted by transforms)
-          const itemOffset = ctx.sizeCache.getOffset(idx);
-          const itemSize = ctx.sizeCache.getSize(idx);
-          const itemMid = itemOffset + itemSize / 2;
-
-          if (pointerInContent < itemMid) {
-            insertBefore = idx > dragIndex ? idx - 1 : idx;
-            break;
-          }
+        // Determine insertion point based on which half of the item
+        // the pointer falls in
+        let insertAt: number;
+        if (pointerInContent < itemMid) {
+          insertAt = rawIndex;
+        } else {
+          insertAt = rawIndex + 1;
         }
 
-        // If we iterated past all items, drop at end
-        if (insertBefore === totalItems) {
-          insertBefore = totalItems - 1;
+        // Adjust for the dragged item gap — indices above dragIndex
+        // shift down by 1 when the dragged item is "removed"
+        if (insertAt > dragIndex) {
+          insertAt -= 1;
         }
 
-        return Math.max(0, Math.min(insertBefore, totalItems - 1));
+        return Math.max(0, Math.min(insertAt, totalItems - 1));
       };
 
       // ── Apply CSS transforms to shift items out of the way ──
@@ -262,6 +257,8 @@ export const withSortable = <T extends VListItem = VListItem>(
       const applyShifts = (): void => {
         const children = dom.items.children;
         const shiftPx = draggedItemSize;
+
+        console.log(`[sort] applyShifts: dragIndex=${dragIndex} dropIndex=${dropIndex} shiftPx=${shiftPx} children=${children.length}`);
 
         for (let i = 0; i < children.length; i++) {
           const itemEl = children[i] as HTMLElement;
@@ -275,7 +272,11 @@ export const withSortable = <T extends VListItem = VListItem>(
             if (idx >= dropIndex && idx < dragIndex) shift = shiftPx;
           }
 
-          const finalOffset = Math.round(ctx.sizeCache.getOffset(idx) + shift);
+          const baseOffset = ctx.sizeCache.getOffset(idx);
+          const finalOffset = Math.round(baseOffset + shift);
+          if (shift !== 0) {
+            console.log(`  [sort] shift idx=${idx} base=${baseOffset} shift=${shift} final=${finalOffset}`);
+          }
           itemEl.style.transition = shiftTransition;
           itemEl.style.transform = `${prop}(${finalOffset}px)`;
         }
@@ -298,6 +299,7 @@ export const withSortable = <T extends VListItem = VListItem>(
       const updateDropPosition = (): void => {
         const newDropIndex = computeDropIndex();
         if (newDropIndex === dropIndex) return;
+        console.log(`[sort] updateDropPosition: ${dropIndex} → ${newDropIndex} (dragIndex=${dragIndex})`);
         dropIndex = newDropIndex;
         applyShifts();
         emitter.emit("sort:move", { fromIndex: dragIndex, currentIndex: dropIndex });
@@ -389,6 +391,7 @@ export const withSortable = <T extends VListItem = VListItem>(
       // triggered a force render — calling clearShifts + forceRender
       // again would be redundant.
       const cleanupDrag = (skipRender = false): void => {
+        console.log(`[sort] cleanupDrag: skipRender=${skipRender} dragIndex=${dragIndex} dropIndex=${dropIndex}`);
         sorting = false;
         dragInitiated = false;
 
@@ -396,16 +399,25 @@ export const withSortable = <T extends VListItem = VListItem>(
           ghost.remove();
         }
         ghost = null;
+        draggedElement = null;
 
-        if (draggedElement) {
-          draggedElement.style.opacity = "";
-          draggedElement.style.pointerEvents = "";
-          draggedElement = null;
+        // Reset opacity/pointerEvents/transforms on ALL children.
+        // During drag, the afterRenderBatch handler may have set opacity: 0
+        // on multiple elements (as they were recycled through dragIndex).
+        // clearShifts only resets transforms — we also need to clear
+        // inline opacity and pointerEvents to avoid stale styles.
+        const children = dom.items.children;
+        for (let i = 0; i < children.length; i++) {
+          const el = children[i] as HTMLElement;
+          el.style.opacity = "";
+          el.style.pointerEvents = "";
+          const idx = getIndex(el);
+          if (idx >= 0) {
+            el.style.transform = `${prop}(${Math.round(ctx.sizeCache.getOffset(idx))}px)`;
+          }
+          el.style.transition = "";
         }
 
-        if (!skipRender) {
-          clearShifts();
-        }
         stopEdgeScroll();
 
         dom.root.classList.remove(`${classPrefix}--sorting`);
@@ -419,7 +431,6 @@ export const withSortable = <T extends VListItem = VListItem>(
         document.removeEventListener("pointercancel", onPointerCancel);
 
         if (!skipRender) {
-          // Re-render to restore clean DOM state
           ctx.forceRender();
         }
       };
@@ -482,7 +493,7 @@ export const withSortable = <T extends VListItem = VListItem>(
           dragInitiated = true;
           sorting = true;
           dropIndex = dragIndex;
-
+          console.log(`[sort] drag started: dragIndex=${dragIndex} itemId=${ctx.dataManager.getItem(dragIndex)?.id}`);
           dom.root.classList.add(`${classPrefix}--sorting`);
 
           // Cache the dragged item's size for shift calculations
@@ -523,6 +534,7 @@ export const withSortable = <T extends VListItem = VListItem>(
           } else if (isPointerOutsideViewport()) {
             // Clear shifts when pointer leaves viewport
             if (dropIndex !== dragIndex) {
+              console.log(`[sort] outside viewport: clearing shifts, dropIndex ${dropIndex} → ${dragIndex}`);
               dropIndex = dragIndex;
               clearShifts();
             }
@@ -533,30 +545,17 @@ export const withSortable = <T extends VListItem = VListItem>(
       // ── Animate ghost to drop target, then finalize ──
       const animateDrop = (fromIndex: number, toIndex: number): void => {
         if (!ghost) {
+          // Disable sorting flag before emit so that the consumer's
+          // setItems() render doesn't trigger stale shifts in afterRenderBatch
+          sorting = false;
           const posChanged = fromIndex !== toIndex && fromIndex >= 0 && toIndex >= 0;
           if (posChanged) {
-            // Suppress transitions, then let sort:end → setItems → force render
-            const children = dom.items.children;
-            for (let i = 0; i < children.length; i++) {
-              (children[i] as HTMLElement).style.transition = "none";
-            }
-            dom.root.classList.remove(`${classPrefix}--sorting`);
             emitter.emit("sort:end", { fromIndex, toIndex });
-            // Restore focus to the originally-focused item (by ID, since indices shifted)
             if (dragFocusedItemId !== null) {
               focusById(dragFocusedItemId);
-              ctx.forceRender();
             }
           }
-          cleanupDrag(posChanged);
-          if (posChanged) {
-            requestAnimationFrame(() => {
-              const children = dom.items.children;
-              for (let i = 0; i < children.length; i++) {
-                (children[i] as HTMLElement).style.transition = "";
-              }
-            });
-          }
+          cleanupDrag(false);
           return;
         }
 
@@ -584,53 +583,19 @@ export const withSortable = <T extends VListItem = VListItem>(
           if (settled) return;
           settled = true;
           ghost?.removeEventListener("transitionend", onEnd);
+
+          // Disable sorting flag before emit so that the consumer's
+          // setItems() render doesn't trigger stale shifts in afterRenderBatch
+          sorting = false;
+
           const positionChanged = fromIndex !== toIndex && fromIndex >= 0 && toIndex >= 0;
-
           if (positionChanged) {
-            // Restore the dragged element before emitting sort:end
-            if (draggedElement) {
-              draggedElement.style.opacity = "";
-              draggedElement.style.pointerEvents = "";
-            }
-
-            // Suppress ALL transitions on items before any class/style changes.
-            // Base vlist.css has `transition: opacity 150ms` on .vlist-item.
-            // Example CSS may add `.vlist--sorting .vlist-item { opacity: 0.85 }`.
-            // Without suppression, removing .vlist--sorting triggers a visible
-            // opacity fade. We also suppress transform transitions so the force
-            // render (triggered by the consumer's setItems) snaps positions
-            // instantly instead of animating from the shifted offsets.
-            const children = dom.items.children;
-            for (let i = 0; i < children.length; i++) {
-              (children[i] as HTMLElement).style.transition = "none";
-            }
-
-            // Now safe to remove sorting class — transitions are suppressed
-            dom.root.classList.remove(`${classPrefix}--sorting`);
-
-            // Emit sort:end — consumer calls setItems() which triggers
-            // a force render that corrects all transforms and templates.
-            // No need to call clearShifts() — the force render handles it.
             emitter.emit("sort:end", { fromIndex, toIndex });
-            // Restore focus to the originally-focused item (by ID, since indices shifted)
             if (dragFocusedItemId !== null) {
               focusById(dragFocusedItemId);
-              ctx.forceRender();
             }
           }
-          cleanupDrag(positionChanged);
-
-          // Re-enable transitions on the next frame. By now the browser
-          // has committed the final styles, so restoring transitions
-          // won't re-trigger any animations.
-          if (positionChanged) {
-            requestAnimationFrame(() => {
-              const children = dom.items.children;
-              for (let i = 0; i < children.length; i++) {
-                (children[i] as HTMLElement).style.transition = "";
-              }
-            });
-          }
+          cleanupDrag(false);
         };
 
         ghost.addEventListener("transitionend", onEnd);
@@ -981,6 +946,40 @@ export const withSortable = <T extends VListItem = VListItem>(
             const el = items[i]!.element;
             el.setAttribute("aria-roledescription", "sortable item");
             el.setAttribute("aria-describedby", instructionsId);
+          }
+        },
+      );
+
+      // Maintain drag visual state when virtual scrolling recycles elements.
+      // Without this, the hidden dragged item's element may be reused for
+      // a different item (still hidden), and newly rendered elements at
+      // dragIndex won't be hidden. Also re-applies shifts to new elements.
+      ctx.afterRenderBatch.push(
+        (items: ReadonlyArray<{ index: number; element: HTMLElement }>) => {
+          if (!sorting) return;
+          console.log(`[sort] afterRenderBatch: sorting=${sorting} dragIndex=${dragIndex} dropIndex=${dropIndex} batchSize=${items.length}`);
+          for (let i = 0; i < items.length; i++) {
+            const { index, element } = items[i]!;
+            if (index === dragIndex) {
+              console.log(`  [sort] hide dragIndex=${index}`);
+              element.style.opacity = "0";
+              element.style.pointerEvents = "none";
+              draggedElement = element;
+            } else {
+              element.style.opacity = "";
+              element.style.pointerEvents = "";
+              let shift = 0;
+              if (dropIndex > dragIndex) {
+                if (index > dragIndex && index <= dropIndex) shift = -draggedItemSize;
+              } else if (dropIndex < dragIndex) {
+                if (index >= dropIndex && index < dragIndex) shift = draggedItemSize;
+              }
+              const finalOffset = Math.round(ctx.sizeCache.getOffset(index) + shift);
+              if (shift !== 0) {
+                console.log(`  [sort] renderBatch shift idx=${index} shift=${shift} final=${finalOffset}`);
+              }
+              element.style.transform = `${prop}(${finalOffset}px)`;
+            }
           }
         },
       );

--- a/src/features/sortable/feature.ts
+++ b/src/features/sortable/feature.ts
@@ -410,6 +410,10 @@ export const withSortable = <T extends VListItem = VListItem>(
 
         dom.root.classList.remove(`${classPrefix}--sorting`);
 
+        // Clear text selection that Safari may apply after pointer release
+        const sel = window.getSelection();
+        if (sel) sel.removeAllRanges();
+
         document.removeEventListener("pointermove", onPointerMove);
         document.removeEventListener("pointerup", onPointerUp);
         document.removeEventListener("pointercancel", onPointerCancel);

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -493,12 +493,20 @@
    Vertical: right-wall inset + track width + left breathing room.
    Horizontal: bottom-wall inset + track height + top breathing room. */
 .vlist-viewport--gutter {
-    padding-right: calc(var(--vlist-custom-scrollbar-padding-right) + var(--vlist-custom-scrollbar-width) + var(--vlist-custom-scrollbar-padding-left));
+    padding-right: calc(
+        var(--vlist-custom-scrollbar-padding-right) +
+            var(--vlist-custom-scrollbar-width) +
+            var(--vlist-custom-scrollbar-padding-left)
+    );
 }
 
 .vlist--horizontal .vlist-viewport--gutter {
     padding-right: 0;
-    padding-bottom: calc(var(--vlist-custom-scrollbar-padding-bottom) + var(--vlist-custom-scrollbar-width) + var(--vlist-custom-scrollbar-padding-top));
+    padding-bottom: calc(
+        var(--vlist-custom-scrollbar-padding-bottom) +
+            var(--vlist-custom-scrollbar-width) +
+            var(--vlist-custom-scrollbar-padding-top)
+    );
 }
 
 /* Hide native scrollbar when custom scrollbar is active */
@@ -539,7 +547,9 @@
 
 /* Sorting state on root */
 .vlist--sorting {
+    -webkit-user-select: none;
     user-select: none;
+    -webkit-touch-callout: none;
 }
 
 /* Keyboard grab — highlight the grabbed item */

--- a/test/features/sortable/feature.test.ts
+++ b/test/features/sortable/feature.test.ts
@@ -1476,3 +1476,265 @@ describe("withSortable — focus preservation", () => {
     expect(focusByIdSpy.mock.calls.length).toBe(0);
   });
 });
+
+// =============================================================================
+// Drop Index Calculation Tests
+// =============================================================================
+
+describe("withSortable — drop index calculation", () => {
+  // Helper: start a drag on an item, then move to specific Y positions
+  // and collect sort:move events to track the drop index at each step.
+  function setupDragSession(ctx: BuilderContext<TestItem>, fromIndex: number): {
+    moveTo: (clientY: number) => void;
+    getDropIndices: () => number[];
+    cleanup: () => void;
+  } {
+    const PointerEventCtor = dom.window.PointerEvent ?? dom.window.MouseEvent;
+    const itemEl = ctx.dom.items.querySelector(
+      `[data-index='${fromIndex}']`,
+    ) as HTMLElement;
+
+    itemEl.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        top: fromIndex * 56,
+        right: 400,
+        bottom: fromIndex * 56 + 56,
+        width: 400,
+        height: 56,
+        x: 0,
+        y: fromIndex * 56,
+        toJSON: () => {},
+      }) as DOMRect;
+
+    ctx.dom.viewport.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        top: 0,
+        right: 400,
+        bottom: 600,
+        width: 400,
+        height: 600,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      }) as DOMRect;
+
+    // pointerdown
+    itemEl.dispatchEvent(
+      new PointerEventCtor("pointerdown", {
+        bubbles: true,
+        clientX: 200,
+        clientY: fromIndex * 56 + 28,
+        button: 0,
+      }),
+    );
+
+    // Initial move to cross drag threshold
+    document.dispatchEvent(
+      new PointerEventCtor("pointermove", {
+        bubbles: true,
+        clientX: 200,
+        clientY: fromIndex * 56 + 28 + 10,
+        button: 0,
+      }),
+    );
+
+    const emitSpy = ctx.emitter.emit as ReturnType<typeof mock>;
+    const dropIndices: number[] = [];
+
+    const moveTo = (clientY: number): void => {
+      // Clear previous calls to track new emissions
+      const callsBefore = emitSpy.mock.calls.length;
+
+      document.dispatchEvent(
+        new PointerEventCtor("pointermove", {
+          bubbles: true,
+          clientX: 200,
+          clientY,
+          button: 0,
+        }),
+      );
+
+      // Collect sort:move events from this move
+      for (let i = callsBefore; i < emitSpy.mock.calls.length; i++) {
+        const call = emitSpy.mock.calls[i] as unknown[];
+        if (call[0] === "sort:move") {
+          const payload = call[1] as { currentIndex: number };
+          dropIndices.push(payload.currentIndex);
+        }
+      }
+    };
+
+    const cleanup = (): void => {
+      document.dispatchEvent(
+        new PointerEventCtor("pointercancel", { bubbles: true }),
+      );
+    };
+
+    return { moveTo, getDropIndices: () => dropIndices, cleanup };
+  }
+
+  it("shifts one item at a time when dragging down", () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+    feature.setup(ctx);
+
+    // Drag item 3 (offset=168, mid=196) downward
+    // Item 4: offset=224, mid=252 — ghost bottom must cross 252
+    // Item 5: offset=280, mid=308 — ghost bottom must cross 308
+    const session = setupDragSession(ctx, 3);
+
+    // Ghost bottom = clientY - ghostOffsetY + draggedItemSize
+    // ghostOffsetY = 28 (pointer started at mid-item)
+    // So ghost bottom = clientY - 28 + 56 = clientY + 28
+
+    // Move ghost bottom just past mid of item 4 (252)
+    // clientY + 28 > 252 → clientY > 224
+    session.moveTo(225);
+    expect(session.getDropIndices()).toEqual([4]);
+
+    // Move ghost bottom just past mid of item 5 (308)
+    // clientY + 28 > 308 → clientY > 280
+    session.moveTo(281);
+    expect(session.getDropIndices()).toEqual([4, 5]);
+
+    session.cleanup();
+  });
+
+  it("shifts one item at a time when dragging up", () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+    feature.setup(ctx);
+
+    // Drag item 5 (offset=280, mid=308) upward
+    // Item 4: offset=224, mid=252 — ghost top must cross BELOW 252
+    // Item 3: offset=168, mid=196 — ghost top must cross BELOW 196
+    const session = setupDragSession(ctx, 5);
+
+    // Ghost top = clientY - ghostOffsetY
+    // ghostOffsetY = 28 (pointer started at mid-item)
+    // So ghost top = clientY - 28
+
+    // Move ghost top just below mid of item 4 (252)
+    // clientY - 28 < 252 → clientY < 280
+    // But we also need to be above the drag slot (offset=280)
+    // ghost top < 280 → clientY < 308, which is true
+    session.moveTo(279);
+    expect(session.getDropIndices()).toEqual([4]);
+
+    // Move ghost top just below mid of item 3 (196)
+    // clientY - 28 < 196 → clientY < 224
+    session.moveTo(223);
+    expect(session.getDropIndices()).toEqual([4, 3]);
+
+    session.cleanup();
+  });
+
+  it("does not oscillate when reversing drag direction", () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+    feature.setup(ctx);
+
+    // Drag item 4 (offset=224, mid=252) downward past items 5 and 6
+    const session = setupDragSession(ctx, 4);
+
+    // Move past item 5 (mid=308): clientY + 28 > 308 → clientY > 280
+    session.moveTo(281);
+    expect(session.getDropIndices()).toEqual([5]);
+
+    // Move past item 6 (mid=364): clientY + 28 > 364 → clientY > 336
+    session.moveTo(337);
+    expect(session.getDropIndices()).toEqual([5, 6]);
+
+    // Now reverse direction — move back up slowly
+    // The drop index should NOT oscillate between values
+    const indicesBefore = session.getDropIndices().length;
+
+    // Small upward movements within the hysteresis zone — should stay at 6
+    session.moveTo(335);
+    session.moveTo(333);
+    session.moveTo(330);
+
+    // Verify no oscillation: either stayed at 6 or moved to 5 once
+    const indicesAfter = session.getDropIndices().slice(indicesBefore);
+    for (let i = 1; i < indicesAfter.length; i++) {
+      // No back-and-forth: each consecutive index should be the same or
+      // monotonically decreasing (retreating)
+      expect(indicesAfter[i]!).toBeLessThanOrEqual(indicesAfter[i - 1]!);
+    }
+
+    session.cleanup();
+  });
+
+  it("handles large displacement correctly (e.g. after auto-scroll)", () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+    feature.setup(ctx);
+
+    // Drag item 2 (offset=112, mid=140) far down past many items
+    const session = setupDragSession(ctx, 2);
+
+    // Jump ghost far down — past items 3 through 8
+    // Item 8: offset=448, mid=476. clientY + 28 > 476 → clientY > 448
+    session.moveTo(449);
+
+    const indices = session.getDropIndices();
+    // Should have jumped to 8 in one step (binary search, not scanning)
+    expect(indices[indices.length - 1]).toBe(8);
+
+    session.cleanup();
+  });
+
+  it("returns dragIndex when ghost is within the drag slot", () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+    feature.setup(ctx);
+
+    // Drag item 4 (offset=224) — small move that stays within the slot
+    const session = setupDragSession(ctx, 4);
+
+    // Move within item 4's area — no sort:move should fire
+    session.moveTo(4 * 56 + 28 + 15);
+    expect(session.getDropIndices()).toEqual([]);
+
+    session.cleanup();
+  });
+
+  it("each step shifts exactly one item when moving down then back up", () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+    feature.setup(ctx);
+
+    // Drag item 3 downward past items 4, 5, 6
+    const session = setupDragSession(ctx, 3);
+
+    // Past item 4 (mid=252): clientY > 224
+    session.moveTo(225);
+    // Past item 5 (mid=308): clientY > 280
+    session.moveTo(281);
+    // Past item 6 (mid=364): clientY > 336
+    session.moveTo(337);
+
+    expect(session.getDropIndices()).toEqual([4, 5, 6]);
+
+    // Now move back up — each step should retreat by exactly 1
+    // Ghost top must cross below item midpoints to retreat
+    // ghost top = clientY - 28
+    // Retreat from 6: ghost top < mid(6) = 364 → clientY < 392 (already true)
+    //   BUT ghost bottom must also be < mid(7) = 420 → clientY + 28 < 420 → clientY < 392
+    //   We need ghost top to go above the drag slot boundary for retreat
+    //   Retreat from dropIndex 6: ghost top < mid(6) = 364 → clientY - 28 < 364 → clientY < 392
+    //   But we're already at 337 < 392, so why didn't it retreat?
+    //   Because the downward check still holds: ghost bottom = 337 + 28 = 365 > mid(6) = 364
+    //   So result stays at 6. We need ghost bottom <= 364 → clientY <= 336
+
+    session.moveTo(335); // ghost bottom = 363 < 364 → retreat from 6 to 5
+    session.moveTo(278); // ghost bottom = 306 < 308 → retreat from 5 to 4
+    session.moveTo(222); // ghost bottom = 250 < 252 → retreat from 4 to 3
+
+    expect(session.getDropIndices()).toEqual([4, 5, 6, 5, 4, 3]);
+
+    session.cleanup();
+  });
+});


### PR DESCRIPTION
## Summary

- **fix(sortable):** Fix drop index oscillation on direction change — replaced direction-based ghost edge switching with a stateless, direction-agnostic approach
- **perf(sortable):** Use O(log n) binary search in computeDropIndex via `sizeCache.indexAtOffset()`
- **fix(sortable):** Refactor drop index calculation to use sizeCache instead of DOM walking, add element recycling support, simplify cleanupDrag and animateDrop
- **fix(sortable):** Clear text selection after drop (Safari)
- Add `withSortable` to features table, update bundle sizes