### PR TITLE
Release: scrollbar & sortable fixes, clickBehavior rename

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -114,7 +114,7 @@ async function build() {
     const raw = readFileSync(src, "utf-8");
     const minified = raw
       .replace(/\/\*[\s\S]*?\*\//g, "") // strip comments
-      .replace(/\s*([{}:;,>~+])\s*/g, "$1") // collapse around symbols
+      .replace(/\s*([{}:;,>~])\s*/g, "$1") // collapse around symbols (not + or -, calc needs them spaced)
       .replace(/;\}/g, "}") // drop trailing semicolons
       .replace(/\s+/g, " ") // collapse whitespace
       .trim();

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,31 @@
 vlist — full changelog
 initial commit → latest
-621 commits · 88 days · Feb 2 – Apr 30, 2026
+626 commits · 89 days · Feb 2 – May 1, 2026
+
+
+2026-05-01  v1.7.2
+
+  fix(scrollbar): show scrollbar immediately when autoHide is false (#43)
+    updateBounds() always left the scrollbar hidden on creation/rebuild,
+    requiring a user interaction to reveal it. Now calls show() when
+    autoHide is disabled.
+
+  feat(sortable): add ghostContainer config option
+    Allows specifying a custom parent element for the drag ghost so it
+    inherits scoped CSS (theme variables, list-specific item styles).
+
+  fix(sortable): fix cursor, escape cancel, and drop-at-same-position (#42)
+    - Keep grabbing cursor during drag via CSS and document.body.style
+    - Escape key cancels an active pointer drag
+    - Emit sort:cancel when item is dropped back at original position
+    - Emit sort:cancel on pointercancel
+
+  fix(build): preserve spaces around + and - in CSS minifier
+    calc() expressions need spaces around operators to be valid.
+
+  refactor(scrollbar): rename clickBehavior 'page' to 'scroll'
+    'scroll' better describes the behavior from the user's perspective.
+    'page' is kept as a backwards-compatible alias, normalized at runtime.
 
 
 2026-04-30  v1.7.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/src/features/scrollbar/feature.ts
+++ b/src/features/scrollbar/feature.ts
@@ -71,12 +71,12 @@ export interface ScrollbarFeatureConfig {
   padding?: number;
 
   /**
-   * Behavior when clicking on the scrollbar track (not the thumb) (default: 'jump').
-   * - `'jump'`  — jumps directly to the clicked position (centers the thumb there).
-   * - `'page'`  — scrolls by one page (containerSize) toward the clicked position,
-   *               matching macOS native scrollbar behavior.
+   * Behavior when clicking on the scrollbar track (not the thumb) (default: 'scroll').
+   * - `'scroll'` — scrolls toward the clicked position, matching macOS native scrollbar
+   *                behavior. Hold to scroll continuously.
+   * - `'jump'`   — jumps directly to the clicked position (centers the thumb there).
    */
-  clickBehavior?: 'jump' | 'page';
+  clickBehavior?: 'jump' | 'scroll' | 'page';
 }
 
 // =============================================================================

--- a/src/features/scrollbar/scrollbar.ts
+++ b/src/features/scrollbar/scrollbar.ts
@@ -76,12 +76,12 @@ export interface ScrollbarConfig {
   padding?: ScrollbarPadding;
 
   /**
-   * Behavior when clicking on the scrollbar track (not the thumb) (default: 'page').
-   * - `'page'`  — scrolls by one page (containerSize) toward the clicked position,
-   *               matching macOS native scrollbar behavior. Hold to scroll continuously.
-   * - `'jump'`  — jumps directly to the clicked position (centers the thumb there).
+   * Behavior when clicking on the scrollbar track (not the thumb) (default: 'scroll').
+   * - `'scroll'` — scrolls toward the clicked position, matching macOS native scrollbar
+   *                behavior. Hold to scroll continuously.
+   * - `'jump'`   — jumps directly to the clicked position (centers the thumb there).
    */
-  clickBehavior?: 'jump' | 'page';
+  clickBehavior?: 'jump' | 'scroll' | 'page';
 }
 
 /** Scrollbar instance */
@@ -119,7 +119,7 @@ const SHOW_ON_HOVER = true;
 const HOVER_ZONE_REACH = 16; // px of reach beyond the visible track (added to padding for the default)
 const SHOW_ON_VIEWPORT_ENTER = true;
 const PADDING = 2;
-const TRACK_CLICK_BEHAVIOR = 'page' as const;
+const TRACK_CLICK_BEHAVIOR = 'scroll' as const;
 const PAGE_SCROLL_INITIAL_DELAY = 350; // ms before continuous scroll starts (matches keyboard repeat)
 const PAGE_SCROLL_SPEED_PPS = 12;      // pages per second during held continuous scroll
 
@@ -175,8 +175,10 @@ export const createScrollbar = (
     minThumbSize = MIN_THUMB_SIZE,
     showOnHover = SHOW_ON_HOVER,
     showOnViewportEnter = SHOW_ON_VIEWPORT_ENTER,
-    clickBehavior = TRACK_CLICK_BEHAVIOR,
+    clickBehavior: rawClickBehavior = TRACK_CLICK_BEHAVIOR,
   } = config;
+
+  const clickBehavior = rawClickBehavior === 'page' ? 'scroll' : rawClickBehavior;
 
   const pad = resolvePadding(config.padding);
 
@@ -398,7 +400,7 @@ export const createScrollbar = (
     return 0;
   };
 
-  // 'page' — immediate first scroll by one containerSize toward click
+  // 'scroll' — immediate first scroll by one containerSize toward click
   const firePageScroll = (): void => {
     const maxScroll = totalSize - containerSize;
     const dir = pageScrollDirection(maxScroll);
@@ -460,9 +462,9 @@ export const createScrollbar = (
     document.removeEventListener('mouseup', handleRepeatMouseUp);
   };
 
-  // 'page' — immediate first scroll then smooth continuous scroll while held
+  // 'scroll' — immediate first scroll then smooth continuous scroll while held
   const handleTrackMouseDown = (e: MouseEvent): void => {
-    if (e.target === thumb || clickBehavior !== 'page') return;
+    if (e.target === thumb || clickBehavior !== 'scroll') return;
     e.preventDefault();
 
     const trackRect = track.getBoundingClientRect();

--- a/src/features/scrollbar/scrollbar.ts
+++ b/src/features/scrollbar/scrollbar.ts
@@ -343,6 +343,10 @@ export const createScrollbar = (
 
     // Update position with current scroll
     updatePosition(currentScrollPosition);
+
+    if (!autoHide) {
+      show();
+    }
   };
 
   const updatePosition = (scrollTop: number): void => {

--- a/src/features/sortable/feature.ts
+++ b/src/features/sortable/feature.ts
@@ -415,6 +415,7 @@ export const withSortable = <T extends VListItem = VListItem>(
         stopEdgeScroll();
 
         dom.root.classList.remove(`${classPrefix}--sorting`);
+        document.body.style.cursor = "";
 
         // Clear text selection that Safari may apply after pointer release
         const sel = window.getSelection();
@@ -488,6 +489,7 @@ export const withSortable = <T extends VListItem = VListItem>(
           sorting = true;
           dropIndex = dragIndex;
           dom.root.classList.add(`${classPrefix}--sorting`);
+          document.body.style.cursor = "grabbing";
 
           // Cache the dragged item's size for shift calculations
           draggedItemSize = ctx.sizeCache.getSize(dragIndex);
@@ -536,18 +538,23 @@ export const withSortable = <T extends VListItem = VListItem>(
 
       // ── Animate ghost to drop target, then finalize ──
       const animateDrop = (fromIndex: number, toIndex: number): void => {
-        if (!ghost) {
-          // Disable sorting flag before emit so that the consumer's
-          // setItems() render doesn't trigger stale shifts in afterRenderBatch
+        const posChanged = fromIndex !== toIndex && fromIndex >= 0 && toIndex >= 0;
+
+        const finalize = (): void => {
           sorting = false;
-          const posChanged = fromIndex !== toIndex && fromIndex >= 0 && toIndex >= 0;
           if (posChanged) {
             emitter.emit("sort:end", { fromIndex, toIndex });
             if (dragFocusedItemId !== null) {
               focusById(dragFocusedItemId);
             }
+          } else {
+            emitter.emit("sort:cancel", { originalItems: ctx.getAllLoadedItems() });
           }
           cleanupDrag(false);
+        };
+
+        if (!ghost) {
+          finalize();
           return;
         }
 
@@ -575,19 +582,7 @@ export const withSortable = <T extends VListItem = VListItem>(
           if (settled) return;
           settled = true;
           ghost?.removeEventListener("transitionend", onEnd);
-
-          // Disable sorting flag before emit so that the consumer's
-          // setItems() render doesn't trigger stale shifts in afterRenderBatch
-          sorting = false;
-
-          const positionChanged = fromIndex !== toIndex && fromIndex >= 0 && toIndex >= 0;
-          if (positionChanged) {
-            emitter.emit("sort:end", { fromIndex, toIndex });
-            if (dragFocusedItemId !== null) {
-              focusById(dragFocusedItemId);
-            }
-          }
-          cleanupDrag(false);
+          finalize();
         };
 
         ghost.addEventListener("transitionend", onEnd);
@@ -617,8 +612,19 @@ export const withSortable = <T extends VListItem = VListItem>(
         animateDrop(dragIndex, dropIndex);
       };
 
+      const cancelPointerDrag = (): void => {
+        if (!dragInitiated) return;
+        document.removeEventListener("pointermove", onPointerMove);
+        document.removeEventListener("pointerup", onPointerUp);
+        document.removeEventListener("pointercancel", onPointerCancel);
+        stopEdgeScroll();
+        sorting = false;
+        emitter.emit("sort:cancel", { originalItems: ctx.getAllLoadedItems() });
+        cleanupDrag(false);
+      };
+
       const onPointerCancel = (): void => {
-        cleanupDrag();
+        cancelPointerDrag();
       };
 
       // ── Attach pointerdown to items container ──
@@ -865,8 +871,15 @@ export const withSortable = <T extends VListItem = VListItem>(
       // stopImmediatePropagation to prevent selection from processing keys.
       const onKeydown = (event: KeyboardEvent): void => {
         if (ctx.state.isDestroyed) return;
-        // Ignore when a pointer drag is active
-        if (sorting) return;
+        // Escape cancels an active pointer drag
+        if (sorting) {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            cancelPointerDrag();
+          }
+          return;
+        }
 
         if (kbGrabbed) {
           switch (event.key) {

--- a/src/features/sortable/feature.ts
+++ b/src/features/sortable/feature.ts
@@ -81,6 +81,13 @@ export interface SortableConfig {
    * Prevents accidental drags on click.
    */
   dragThreshold?: number;
+
+  /**
+   * Container element for the drag ghost (default: document.body).
+   * Set this to keep the ghost inside a specific ancestor so it inherits
+   * scoped CSS (e.g. theme variables, list-specific item styles).
+   */
+  ghostContainer?: HTMLElement;
 }
 
 // =============================================================================
@@ -117,6 +124,7 @@ export const withSortable = <T extends VListItem = VListItem>(
   const edgeScrollZone = config?.edgeScrollZone ?? 40;
   const edgeScrollSpeed = config?.edgeScrollSpeed ?? 20;
   const dragThreshold = config?.dragThreshold ?? 5;
+  const ghostContainer = config?.ghostContainer ?? null;
 
   return {
     name: "withSortable",
@@ -189,7 +197,7 @@ export const withSortable = <T extends VListItem = VListItem>(
           "transition:none",
           "will-change:transform",
         ].join(";");
-        document.body.appendChild(clone);
+        (ghostContainer || document.body).appendChild(clone);
         return clone;
       };
 

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -547,6 +547,7 @@
 
 /* Sorting state on root */
 .vlist--sorting {
+    cursor: grabbing;
     -webkit-user-select: none;
     user-select: none;
     -webkit-touch-callout: none;

--- a/test/features/scrollbar/scrollbar.test.ts
+++ b/test/features/scrollbar/scrollbar.test.ts
@@ -303,7 +303,7 @@ describe("createScrollbar", () => {
         width: 8, height: 400, x: 0, y: 0, toJSON: () => ({}),
       });
 
-      // Default is 'page' — uses mousedown
+      // Default is 'scroll' — uses mousedown
       track.dispatchEvent(new MouseEvent("mousedown", { clientY: 350, bubbles: true }));
       document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
 
@@ -352,7 +352,7 @@ describe("createScrollbar", () => {
       expect(onScrollMock).not.toHaveBeenCalled();
     });
 
-    it("'page' — scrolls forward by containerSize when pressing below thumb", () => {
+    it("'page' is accepted as a backwards-compatible alias for 'scroll'", () => {
       scrollbar = createScrollbar(viewport, onScrollMock, {
         autoHide: false,
         clickBehavior: 'page',
@@ -373,10 +373,31 @@ describe("createScrollbar", () => {
       expect(position).toBe(400);
     });
 
-    it("'page' — scrolls backward by containerSize when pressing above thumb", () => {
+    it("'scroll' — scrolls forward by containerSize when pressing below thumb", () => {
       scrollbar = createScrollbar(viewport, onScrollMock, {
         autoHide: false,
-        clickBehavior: 'page',
+        clickBehavior: 'scroll',
+      });
+      scrollbar.updateBounds(1000, 400);
+      scrollbar.show();
+
+      const track = viewport.querySelector(".vlist-scrollbar") as HTMLElement;
+      track.getBoundingClientRect = () => ({
+        top: 0, left: 0, right: 8, bottom: 400,
+        width: 8, height: 400, x: 0, y: 0, toJSON: () => ({}),
+      });
+
+      track.dispatchEvent(new MouseEvent("mousedown", { clientY: 350, bubbles: true }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+      const position = onScrollMock.mock.calls[0]?.[0] as number;
+      expect(position).toBe(400);
+    });
+
+    it("'scroll' — scrolls backward by containerSize when pressing above thumb", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, {
+        autoHide: false,
+        clickBehavior: 'scroll',
       });
       scrollbar.updateBounds(1000, 400);
       scrollbar.show();
@@ -395,10 +416,10 @@ describe("createScrollbar", () => {
       expect(position).toBe(200);
     });
 
-    it("'page' — clamps to 0 when scrolling backward at start", () => {
+    it("'scroll' — clamps to 0 when scrolling backward at start", () => {
       scrollbar = createScrollbar(viewport, onScrollMock, {
         autoHide: false,
-        clickBehavior: 'page',
+        clickBehavior: 'scroll',
       });
       scrollbar.updateBounds(1000, 400);
       scrollbar.show();
@@ -417,10 +438,10 @@ describe("createScrollbar", () => {
       expect(position).toBe(0);
     });
 
-    it("'page' — clamps to maxScroll when scrolling forward at end", () => {
+    it("'scroll' — clamps to maxScroll when scrolling forward at end", () => {
       scrollbar = createScrollbar(viewport, onScrollMock, {
         autoHide: false,
-        clickBehavior: 'page',
+        clickBehavior: 'scroll',
       });
       scrollbar.updateBounds(1000, 400);
       scrollbar.show();
@@ -439,10 +460,10 @@ describe("createScrollbar", () => {
       expect(position).toBe(600);
     });
 
-    it("'page' — repeats scroll while held, stops on mouseup", async () => {
+    it("'scroll' — repeats scroll while held, stops on mouseup", async () => {
       scrollbar = createScrollbar(viewport, onScrollMock, {
         autoHide: false,
-        clickBehavior: 'page',
+        clickBehavior: 'scroll',
       });
       scrollbar.updateBounds(1000, 400);
       scrollbar.show();
@@ -466,10 +487,10 @@ describe("createScrollbar", () => {
       expect(onScrollMock.mock.calls.length).toBeGreaterThan(1);
     });
 
-    it("'page' — stops repeating when thumb catches cursor", async () => {
+    it("'scroll' — stops repeating when thumb catches cursor", async () => {
       scrollbar = createScrollbar(viewport, onScrollMock, {
         autoHide: false,
-        clickBehavior: 'page',
+        clickBehavior: 'scroll',
       });
       // Small list — thumb covers most of the track, one page scroll reaches the end
       scrollbar.updateBounds(500, 400);
@@ -496,11 +517,11 @@ describe("createScrollbar", () => {
       expect(calls).toBeGreaterThanOrEqual(1);
     });
 
-    it("'page' — schedules auto-hide after mouse release", async () => {
+    it("'scroll' — schedules auto-hide after mouse release", async () => {
       scrollbar = createScrollbar(viewport, onScrollMock, {
         autoHide: true,
         autoHideDelay: 50,
-        clickBehavior: 'page',
+        clickBehavior: 'scroll',
       });
       scrollbar.updateBounds(1000, 400);
       scrollbar.show();
@@ -803,7 +824,7 @@ describe("createScrollbar", () => {
     it("clicking in the padding margin above the track triggers page scroll upward", () => {
       scrollbar = createScrollbar(viewport, onScrollMock, {
         padding: 20,
-        clickBehavior: "page",
+        clickBehavior: "scroll",
         autoHide: false,
       });
       scrollbar.updateBounds(1000, 400);
@@ -828,7 +849,7 @@ describe("createScrollbar", () => {
     it("clicking in the padding margin below the track triggers page scroll downward", () => {
       scrollbar = createScrollbar(viewport, onScrollMock, {
         padding: 20,
-        clickBehavior: "page",
+        clickBehavior: "scroll",
         autoHide: false,
       });
       scrollbar.updateBounds(1000, 400);
@@ -873,7 +894,7 @@ describe("createScrollbar", () => {
     it("clicking in the padding margin works even when showOnHover is false", () => {
       scrollbar = createScrollbar(viewport, onScrollMock, {
         padding: 20,
-        clickBehavior: "page",
+        clickBehavior: "scroll",
         showOnHover: false,
         autoHide: false,
       });
@@ -996,7 +1017,7 @@ describe("createScrollbar", () => {
         toJSON: () => ({}),
       });
 
-      // Default is 'page' — uses mousedown
+      // Default is 'scroll' — uses mousedown
       track.dispatchEvent(new MouseEvent("mousedown", { clientX: 350, bubbles: true }));
       document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
 

--- a/test/features/scrollbar/scrollbar.test.ts
+++ b/test/features/scrollbar/scrollbar.test.ts
@@ -171,6 +171,46 @@ describe("createScrollbar", () => {
 
       expect(thumbHeight).toBeGreaterThanOrEqual(50);
     });
+
+    it("should auto-show scrollbar when autoHide is false", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, { autoHide: false });
+      scrollbar.updateBounds(1000, 400);
+
+      expect(scrollbar.isVisible()).toBe(true);
+    });
+
+    it("should not auto-show scrollbar when autoHide is true", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, { autoHide: true });
+      scrollbar.updateBounds(1000, 400);
+
+      expect(scrollbar.isVisible()).toBe(false);
+    });
+
+    it("should remain visible after successive updateBounds calls when autoHide is false", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, { autoHide: false });
+      scrollbar.updateBounds(1000, 400);
+
+      expect(scrollbar.isVisible()).toBe(true);
+
+      scrollbar.updateBounds(2000, 400);
+
+      expect(scrollbar.isVisible()).toBe(true);
+    });
+
+    it("should hide then re-show on updateBounds when content toggles overflow with autoHide false", () => {
+      scrollbar = createScrollbar(viewport, onScrollMock, { autoHide: false });
+      scrollbar.updateBounds(1000, 400);
+
+      expect(scrollbar.isVisible()).toBe(true);
+
+      scrollbar.updateBounds(300, 400); // No overflow
+
+      expect(scrollbar.isVisible()).toBe(false);
+
+      scrollbar.updateBounds(1000, 400); // Overflow again
+
+      expect(scrollbar.isVisible()).toBe(true);
+    });
   });
 
   describe("updatePosition", () => {

--- a/test/features/sortable/feature.test.ts
+++ b/test/features/sortable/feature.test.ts
@@ -1481,6 +1481,100 @@ describe("withSortable — pointer cancel", () => {
 });
 
 // =============================================================================
+// Escape cancels pointer drag
+// =============================================================================
+
+describe("withSortable — escape cancels pointer drag", () => {
+  it("Escape during pointer drag emits sort:cancel and cleans up", async () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+
+    ctx.dom.viewport.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, right: 400, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => {} }) as DOMRect;
+
+    feature.setup(ctx);
+
+    const PointerEventCtor = dom.window.PointerEvent ?? dom.window.MouseEvent;
+    const itemEl = ctx.dom.items.querySelector("[data-index='2']") as HTMLElement;
+
+    itemEl.getBoundingClientRect = () =>
+      ({ left: 0, top: 112, right: 400, bottom: 168, width: 400, height: 56, x: 0, y: 112, toJSON: () => {} }) as DOMRect;
+
+    // Start drag past threshold
+    itemEl.dispatchEvent(new PointerEventCtor("pointerdown", {
+      bubbles: true, clientX: 200, clientY: 140, button: 0,
+    }));
+    document.dispatchEvent(new PointerEventCtor("pointermove", {
+      bubbles: true, clientX: 200, clientY: 300, button: 0,
+    }));
+
+    const isSorting = ctx.methods.get("isSorting") as () => boolean;
+    expect(isSorting()).toBe(true);
+
+    // Press Escape
+    ctx.dom.root.dispatchEvent(new dom.window.KeyboardEvent("keydown", {
+      key: "Escape", bubbles: true, cancelable: true,
+    }));
+
+    expect(isSorting()).toBe(false);
+
+    const cancelCall = (ctx.emitter.emit as ReturnType<typeof mock>).mock.calls.find(
+      (c: unknown[]) => c[0] === "sort:cancel",
+    );
+    expect(cancelCall).toBeDefined();
+  });
+});
+
+// =============================================================================
+// Drop at same position emits sort:cancel
+// =============================================================================
+
+describe("withSortable — drop at same position", () => {
+  it("emits sort:cancel when item is returned to original position", async () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+
+    ctx.dom.viewport.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, right: 400, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => {} }) as DOMRect;
+
+    feature.setup(ctx);
+
+    const PointerEventCtor = dom.window.PointerEvent ?? dom.window.MouseEvent;
+    const itemEl = ctx.dom.items.querySelector("[data-index='3']") as HTMLElement;
+
+    itemEl.getBoundingClientRect = () =>
+      ({ left: 0, top: 168, right: 400, bottom: 224, width: 400, height: 56, x: 0, y: 168, toJSON: () => {} }) as DOMRect;
+
+    // Start drag with small move (stays within same item zone)
+    itemEl.dispatchEvent(new PointerEventCtor("pointerdown", {
+      bubbles: true, clientX: 200, clientY: 196, button: 0,
+    }));
+    document.dispatchEvent(new PointerEventCtor("pointermove", {
+      bubbles: true, clientX: 200, clientY: 216, button: 0,
+    }));
+
+    // Release — dropIndex should still equal dragIndex
+    document.dispatchEvent(new PointerEventCtor("pointerup", {
+      bubbles: true, clientX: 200, clientY: 216, button: 0,
+    }));
+
+    await new Promise((r) => setTimeout(r, 300));
+
+    const emitSpy = ctx.emitter.emit as ReturnType<typeof mock>;
+
+    const cancelCall = emitSpy.mock.calls.find(
+      (c: unknown[]) => c[0] === "sort:cancel",
+    );
+    expect(cancelCall).toBeDefined();
+
+    const endCall = emitSpy.mock.calls.find(
+      (c: unknown[]) => c[0] === "sort:end",
+    );
+    expect(endCall).toBeUndefined();
+  });
+});
+
+// =============================================================================
 // Keyboard grab cancelled by pointer drag
 // =============================================================================
 

--- a/test/features/sortable/feature.test.ts
+++ b/test/features/sortable/feature.test.ts
@@ -272,6 +272,7 @@ describe("withSortable — factory", () => {
       edgeScrollZone: 60,
       edgeScrollSpeed: 12,
       dragThreshold: 10,
+      ghostContainer: document.createElement("div"),
     });
     expect(feature.name).toBe("withSortable");
   });
@@ -735,6 +736,133 @@ describe("withSortable — sort events", () => {
       expect(payload.toIndex).not.toBe(1);
       expect(payload.toIndex).toBeGreaterThanOrEqual(0);
     }
+  });
+});
+
+// =============================================================================
+// Ghost Container Tests
+// =============================================================================
+
+describe("withSortable — ghostContainer", () => {
+  function startDrag(
+    ctx: BuilderContext<TestItem>,
+    fromIndex: number,
+  ): void {
+    const PointerEventCtor =
+      dom.window.PointerEvent ?? dom.window.MouseEvent;
+
+    const itemEl = ctx.dom.items.querySelector(
+      `[data-index='${fromIndex}']`,
+    ) as HTMLElement;
+
+    itemEl.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        top: fromIndex * 56,
+        right: 400,
+        bottom: fromIndex * 56 + 56,
+        width: 400,
+        height: 56,
+        x: 0,
+        y: fromIndex * 56,
+        toJSON: () => {},
+      }) as DOMRect;
+
+    itemEl.dispatchEvent(
+      new PointerEventCtor("pointerdown", {
+        bubbles: true,
+        clientX: 200,
+        clientY: fromIndex * 56 + 28,
+        button: 0,
+      }),
+    );
+
+    document.dispatchEvent(
+      new PointerEventCtor("pointermove", {
+        bubbles: true,
+        clientX: 200,
+        clientY: fromIndex * 56 + 28 + 20,
+        button: 0,
+      }),
+    );
+  }
+
+  it("appends ghost to document.body by default", () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+    feature.setup(ctx);
+
+    startDrag(ctx, 2);
+
+    const ghost = document.body.querySelector(".vlist-sort-ghost");
+    expect(ghost).not.toBeNull();
+
+    for (const h of ctx.destroyHandlers) h();
+    ghost?.remove();
+  });
+
+  it("appends ghost to ghostContainer when specified", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const feature = withSortable({ ghostContainer: container });
+    const ctx = createMockContext();
+    feature.setup(ctx);
+
+    startDrag(ctx, 2);
+
+    const ghost = container.querySelector(".vlist-sort-ghost");
+    expect(ghost).not.toBeNull();
+    expect(
+      document.body.querySelectorAll(":scope > .vlist-sort-ghost").length,
+    ).toBe(0);
+
+    for (const h of ctx.destroyHandlers) h();
+    ghost?.remove();
+    container.remove();
+  });
+
+  it("removes ghost from ghostContainer on cleanup", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const feature = withSortable({ ghostContainer: container });
+    const ctx = createMockContext();
+
+    ctx.dom.viewport.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        top: 0,
+        right: 400,
+        bottom: 600,
+        width: 400,
+        height: 600,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      }) as DOMRect;
+
+    feature.setup(ctx);
+
+    startDrag(ctx, 2);
+    expect(container.querySelector(".vlist-sort-ghost")).not.toBeNull();
+
+    const PointerEventCtor =
+      dom.window.PointerEvent ?? dom.window.MouseEvent;
+    document.dispatchEvent(
+      new PointerEventCtor("pointerup", {
+        bubbles: true,
+        clientX: 200,
+        clientY: 2 * 56 + 28 + 20,
+        button: 0,
+      }),
+    );
+
+    await new Promise((r) => setTimeout(r, 250));
+
+    expect(container.querySelector(".vlist-sort-ghost")).toBeNull();
+
+    container.remove();
   });
 });
 


### PR DESCRIPTION
## Summary

- **fix(scrollbar):** show scrollbar immediately when `autoHide` is false (#43)
- **feat(sortable):** add `ghostContainer` config option
- **fix(sortable):** keep grabbing cursor during drag, escape cancels drag, emit `sort:cancel` on drop at same position (#42)
- **fix(build):** preserve spaces around `+` and `-` in CSS minifier (calc expressions)
- **refactor(scrollbar):** rename `clickBehavior` value `'page'` to `'scroll'` (backwards-compatible)

## Test plan
- [x] All 3257 tests pass
- [ ] Verify scrollbar visibility with `autoHide: false` on staging
- [ ] Verify sortable cursor, escape cancel, and drop-at-same-position on staging
- [ ] Verify `clickBehavior: 'page'` still works (compat alias)