### PR TITLE
chore(release): v1.7.3

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -209,7 +209,13 @@ Triggered by `push: tags: v*.*.*` (not manual GitHub Release). On trigger:
 7. Checks out `main`, pulls, pushes the version tag (triggers publish.yml)
 8. Returns to `staging`
 
-Bundle sizes in README/npm-readme are updated **manually** when features change significantly.
+### Pre-Release Checklist
+Before tagging a new version, complete ALL of these steps:
+1. Bump the version in `package.json`
+2. Update `changelog.txt` with the new version entries
+3. Run `bun run size` to get current bundle sizes
+4. Update `README.md` — version reference AND bundle size numbers
+5. Update `npm-readme.md` — bundle size numbers
 
 ### Cross-Repo Staging Deploy (`notify-staging.yml`)
 When `staging` is pushed, dispatches a `vlist-staging-updated` event to `floor/vlist.io` via `repository_dispatch`. This triggers a redeploy of `staging.vlist.io` with the latest vlist code — no manual intervention needed.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The virtual list library for every framework. Accessible by default, batteries-included, with composable features — in 10.5 KB.
 
-**v1.7.1** — [Changelog](./changelog.txt)
+**v1.7.2** — [Changelog](./changelog.txt)
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![CI](https://github.com/floor/vlist/actions/workflows/ci.yml/badge.svg)](https://github.com/floor/vlist/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The virtual list library for every framework. Accessible by default, batteries-included, with composable features — in 10.5 KB.
 
-**v1.7.2** — [Changelog](./changelog.txt)
+**v1.7.3** — [Changelog](./changelog.txt)
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![CI](https://github.com/floor/vlist/actions/workflows/ci.yml/badge.svg)](https://github.com/floor/vlist/actions/workflows/ci.yml)
@@ -100,13 +100,13 @@ const list = vlist({
 | `withScale()` | +3.7 KB | 1M+ items via scroll compression |
 | `withGroups()` | +2.7 KB | Sticky/inline headers |
 | `withAutoSize()` | +0.9 KB | Auto-measure items via ResizeObserver |
-| `withScrollbar()` | +1.7 KB | Custom scrollbar UI |
+| `withScrollbar()` | +1.8 KB | Custom scrollbar UI |
 | `withGrid()` | +3.9 KB | 2D grid layout |
 | `withMasonry()` | +3.4 KB | Pinterest-style masonry with lane-aware keyboard nav |
 | `withTable()` | +5.5 KB | Data table with columns, resize, sort |
 | `withPage()` | +0.8 KB | Window-level scrolling |
-| `withSortable()` | +2.9 KB | Drag-and-drop reordering with auto-scroll |
-| `withSnapshots()` | +0.8 KB | Scroll position save/restore |
+| `withSortable()` | +3.0 KB | Drag-and-drop reordering with auto-scroll |
+| `withSnapshots()` | +0.9 KB | Scroll position save/restore |
 
 ## Examples
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,31 @@
 vlist — full changelog
 initial commit → latest
-626 commits · 89 days · Feb 2 – May 1, 2026
+639 commits · 89 days · Feb 2 – May 1, 2026
+
+
+2026-05-01  v1.7.3
+
+  fix(sortable): prevent neighbor item blink on drop
+    Add --settling CSS class to suppress background-color/opacity
+    transitions during sort finalize. When setItems() reorders data,
+    the renderer toggles selection/focus classes on reordered items —
+    the CSS transition was causing a visible blink on neighbor items.
+
+  fix(sortable): smooth drop transition for drag source item
+    Replace inline opacity:0 with a CSS class (vlist-item--drag-source)
+    for the dragged item's original element. The --settling class
+    suppresses the opacity transition on drop, preventing the fade-in
+    blink when the ghost returns to the original position.
+
+  fix(sortable): animate ghost back to origin on Escape cancel
+    Pressing Escape during a pointer drag now animates the ghost back
+    to the original position before emitting sort:cancel, matching the
+    behavior of dropping outside the viewport.
+
+  fix(selection): seed selection state before first render on snapshot restore
+    Add _seedSelection internal method to populate selection state
+    synchronously before the first render, eliminating the selection
+    blink when recreating a list with snapshot restore.
 
 
 2026-05-01  v1.7.2

--- a/npm-readme.md
+++ b/npm-readme.md
@@ -60,13 +60,13 @@ const list = vlist({ container: '#app', items, item: { height: 200, template: re
 | `withScale()` | +3.7 KB | 1M+ items via scroll compression |
 | `withGroups()` | +2.7 KB | Sticky/inline headers |
 | `withAutoSize()` | +0.9 KB | Auto-measure items via ResizeObserver |
-| `withScrollbar()` | +1.7 KB | Custom scrollbar UI |
+| `withScrollbar()` | +1.8 KB | Custom scrollbar UI |
 | `withGrid()` | +3.9 KB | 2D grid layout |
 | `withMasonry()` | +3.4 KB | Pinterest-style masonry with lane-aware keyboard nav |
 | `withTable()` | +5.5 KB | Data table with columns, resize, sort |
 | `withPage()` | +0.8 KB | Window-level scrolling |
-| `withSortable()` | +2.9 KB | Drag-and-drop reordering with auto-scroll |
-| `withSnapshots()` | +0.8 KB | Scroll position save/restore |
+| `withSortable()` | +3.0 KB | Drag-and-drop reordering with auto-scroll |
+| `withSnapshots()` | +0.9 KB | Scroll position save/restore |
 
 ## Framework Adapters
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/src/features/selection/feature.ts
+++ b/src/features/selection/feature.ts
@@ -302,6 +302,14 @@ export const withSelection = <T extends VListItem = VListItem>(
         return selectionState.focusVisible ? selectionState.focusedIndex : -1;
       });
 
+      // Seed selection state before the first render (used by snapshots).
+      // Adds IDs to the Set without emitting events or triggering re-render.
+      ctx.methods.set("_seedSelection", (ids: Array<string | number>): void => {
+        for (const id of ids) {
+          selectionState.selected.add(id);
+        }
+      });
+
       // ── Capture force render for triggering re-renders on selection change ──
       // We do NOT wrap renderIfNeeded — the renderers now read our state
       // directly via the getters above. We only need forceRender to trigger

--- a/src/features/snapshots/feature.ts
+++ b/src/features/snapshots/feature.ts
@@ -358,17 +358,16 @@ export const withSnapshots = <T extends VListItem = VListItem>(
 
       // ── Auto-save ──
       // When autoSave is configured, save snapshots to sessionStorage
-      // on scroll idle and selection change.
+      // on scroll idle, selection change, and focus change.
       //
-      // During restore, ALL saves are guarded until the position has
-      // settled. The first scroll:idle after restore marks the settle
-      // point — we save once (capturing the fully settled state) and
-      // lift the guard. After that, every idle and selection change
-      // saves immediately.
-      if (autoSaveKey) {
-        let restoreGuard = !!restoreSnapshot;
+      // During restore, saves are guarded until restoreScroll completes.
+      // The guard is lifted in the same microtask as restoreScroll, then
+      // an immediate save captures the fully settled state.
+      let restoreGuard = !!restoreSnapshot && !!autoSaveKey;
+      let saveToStorage: (() => void) | null = null;
 
-        const saveToStorage = (): void => {
+      if (autoSaveKey) {
+        saveToStorage = (): void => {
           if (restoreGuard) return;
           const getSnapshotFn = ctx.methods.get("getScrollSnapshot") as
             | (() => ScrollSnapshot)
@@ -382,46 +381,45 @@ export const withSnapshots = <T extends VListItem = VListItem>(
           }
         };
 
-        // Save on scroll idle (fires after scroll.idleTimeout, default 150ms).
-        // During restore, the first idle lifts the guard and saves the
-        // settled state. Subsequent idles save normally.
-        ctx.idleHandlers.push(() => {
-          if (restoreGuard) {
-            restoreGuard = false;
-          }
-          saveToStorage();
-        });
-
-        // Save on selection change (guarded during restore like everything else)
-        ctx.emitter.on("selection:change", saveToStorage);
-
-        // Save on focus change so arrow-key navigation is preserved on reload
-        ctx.emitter.on("focus:change", saveToStorage);
+        const saveFn = saveToStorage;
+        ctx.idleHandlers.push(saveFn);
+        ctx.emitter.on("selection:change", saveFn);
+        ctx.emitter.on("focus:change", saveFn);
 
         // ── Coordinate with withAsync ──
-        // When restoring a snapshot, cancel withAsync's deferred autoLoad
-        // and bootstrap the total from the snapshot. This eliminates the
-        // need for the user to manually pass autoLoad/total to withAsync.
         if (restoreSnapshot && restoreSnapshot.total && restoreSnapshot.total > 0) {
           const cancelAutoLoad = ctx.methods.get("_cancelAutoLoad") as
             | (() => void)
             | undefined;
           if (cancelAutoLoad) cancelAutoLoad();
-
-          // Bootstrap total so sizeCache/compression are ready for restore
           ctx.dataManager.setTotal(restoreSnapshot.total);
         }
       }
 
       // ── Auto-restore ──
-      // If a restore snapshot was provided via config (or read from
-      // sessionStorage by autoSave), schedule restoration via
-      // queueMicrotask. This runs right after build() returns (all
-      // synchronous setup, isInitialized=true, initial render) but before
-      // the browser paints — so the user never sees position 0.
+      // Seed selection synchronously so the first render already shows
+      // the correct selection state (no blink). Scroll position still
+      // needs queueMicrotask because DOM layout isn't ready yet.
       if (restoreSnapshot) {
+        let selectionSeeded = false;
+        if (restoreSnapshot.selectedIds && restoreSnapshot.selectedIds.length > 0) {
+          const seedFn = ctx.methods.get("_seedSelection") as
+            | ((ids: Array<string | number>) => void)
+            | undefined;
+          if (seedFn) {
+            seedFn(restoreSnapshot.selectedIds);
+            selectionSeeded = true;
+          }
+        }
+
+        const snapshotForScroll = selectionSeeded
+          ? (({ selectedIds: _, ...rest }) => rest as ScrollSnapshot)(restoreSnapshot)
+          : restoreSnapshot;
+
         queueMicrotask(() => {
-          restoreScroll(restoreSnapshot);
+          restoreScroll(snapshotForScroll);
+          restoreGuard = false;
+          if (saveToStorage) saveToStorage();
         });
       }
     },

--- a/src/features/sortable/feature.ts
+++ b/src/features/sortable/feature.ts
@@ -630,9 +630,8 @@ export const withSortable = <T extends VListItem = VListItem>(
         document.removeEventListener("pointerup", onPointerUp);
         document.removeEventListener("pointercancel", onPointerCancel);
         stopEdgeScroll();
-        sorting = false;
-        emitter.emit("sort:cancel", { originalItems: ctx.getAllLoadedItems() });
-        cleanupDrag(false);
+        clearShifts();
+        animateDrop(dragIndex, dragIndex);
       };
 
       const onPointerCancel = (): void => {

--- a/src/features/sortable/feature.ts
+++ b/src/features/sortable/feature.ts
@@ -395,16 +395,15 @@ export const withSortable = <T extends VListItem = VListItem>(
         ghost = null;
         draggedElement = null;
 
-        // Reset opacity/pointerEvents/transforms on ALL children.
-        // During drag, the afterRenderBatch handler may have set opacity: 0
-        // on multiple elements (as they were recycled through dragIndex).
-        // clearShifts only resets transforms — we also need to clear
-        // inline opacity and pointerEvents to avoid stale styles.
+        // Reset drag styles on ALL children.
+        // During drag, the afterRenderBatch handler may have added the
+        // drag-source class to multiple elements (as they were recycled
+        // through dragIndex). Also clear inline shift transitions/transforms.
+        const dragSourceClass = `${classPrefix}-item--drag-source`;
         const children = dom.items.children;
         for (let i = 0; i < children.length; i++) {
           const el = children[i] as HTMLElement;
-          el.style.opacity = "";
-          el.style.pointerEvents = "";
+          el.classList.remove(dragSourceClass);
           const idx = getIndex(el);
           if (idx >= 0) {
             el.style.transform = `${prop}(${Math.round(ctx.sizeCache.getOffset(idx))}px)`;
@@ -499,8 +498,7 @@ export const withSortable = <T extends VListItem = VListItem>(
             ghost = createGhost(draggedElement);
 
             // Hide the original element
-            draggedElement.style.opacity = "0";
-            draggedElement.style.pointerEvents = "none";
+            draggedElement.classList.add(`${classPrefix}-item--drag-source`);
           }
 
           // Capture focused item ID so we can restore focus after reorder
@@ -558,8 +556,12 @@ export const withSortable = <T extends VListItem = VListItem>(
               dom.root.classList.remove(`${classPrefix}--settling`);
             });
           } else {
+            dom.root.classList.add(`${classPrefix}--settling`);
             emitter.emit("sort:cancel", { originalItems: ctx.getAllLoadedItems() });
             cleanupDrag(false);
+            requestAnimationFrame(() => {
+              dom.root.classList.remove(`${classPrefix}--settling`);
+            });
           }
         };
 
@@ -975,12 +977,10 @@ export const withSortable = <T extends VListItem = VListItem>(
           for (let i = 0; i < items.length; i++) {
             const { index, element } = items[i]!;
             if (index === dragIndex) {
-              element.style.opacity = "0";
-              element.style.pointerEvents = "none";
+              element.classList.add(`${classPrefix}-item--drag-source`);
               draggedElement = element;
             } else {
-              element.style.opacity = "";
-              element.style.pointerEvents = "";
+              element.classList.remove(`${classPrefix}-item--drag-source`);
               let shift = 0;
               if (dropIndex > dragIndex) {
                 if (index > dragIndex && index <= dropIndex) shift = -draggedItemSize;

--- a/src/features/sortable/feature.ts
+++ b/src/features/sortable/feature.ts
@@ -543,14 +543,24 @@ export const withSortable = <T extends VListItem = VListItem>(
         const finalize = (): void => {
           sorting = false;
           if (posChanged) {
+            // Suppress CSS transitions (background-color/opacity) during settle.
+            // setItems() causes the renderer to toggle selection/focus classes on
+            // reordered items — without this, the CSS transition blinks neighbors.
+            dom.root.classList.add(`${classPrefix}--settling`);
+
             emitter.emit("sort:end", { fromIndex, toIndex });
             if (dragFocusedItemId !== null) {
               focusById(dragFocusedItemId);
             }
+            cleanupDrag(true);
+
+            requestAnimationFrame(() => {
+              dom.root.classList.remove(`${classPrefix}--settling`);
+            });
           } else {
             emitter.emit("sort:cancel", { originalItems: ctx.getAllLoadedItems() });
+            cleanupDrag(false);
           }
-          cleanupDrag(false);
         };
 
         if (!ghost) {

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -546,6 +546,12 @@
     cursor: grabbing;
 }
 
+/* Hide the original item while its ghost is being dragged */
+.vlist-item--drag-source {
+    opacity: 0 !important;
+    pointer-events: none;
+}
+
 /* Sorting state on root */
 .vlist--sorting {
     cursor: grabbing;

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -263,7 +263,8 @@
 }
 
 /* Suppress transitions during active scroll for better performance */
-.vlist--scrolling .vlist-item {
+.vlist--scrolling .vlist-item,
+.vlist--settling .vlist-item {
     transition: none;
 }
 

--- a/test/features/selection/feature.test.ts
+++ b/test/features/selection/feature.test.ts
@@ -417,20 +417,38 @@ describe("withSelection — Methods", () => {
     expect(typeof ctx.methods.get("getSelectedItems")).toBe("function");
   });
 
-  it("should register 7 public + 4 internal methods", () => {
+  it("should register 7 public + 5 internal methods", () => {
     const feature = withSelection<TestItem>();
     const ctx = createMockContext();
 
     feature.setup!(ctx);
 
-    // 9 public methods + 4 internal methods (_getSelectedIds, _getFocusedIndex, _focusById, _getFocusedId)
-    expect(ctx.methods.size).toBe(13);
+    // 9 public methods + 5 internal methods (_getSelectedIds, _getFocusedIndex, _focusById, _getFocusedId, _seedSelection)
+    expect(ctx.methods.size).toBe(14);
     expect(ctx.methods.has("_getSelectedIds")).toBe(true);
     expect(ctx.methods.has("_getFocusedIndex")).toBe(true);
     expect(ctx.methods.has("_focusById")).toBe(true);
     expect(ctx.methods.has("_getFocusedId")).toBe(true);
+    expect(ctx.methods.has("_seedSelection")).toBe(true);
     expect(ctx.methods.has("selectNext")).toBe(true);
     expect(ctx.methods.has("selectPrevious")).toBe(true);
+  });
+
+  it("_seedSelection should populate selection state without events", () => {
+    const feature = withSelection<TestItem>();
+    const ctx = createMockContext();
+    feature.setup!(ctx);
+
+    const seedSelection = ctx.methods.get("_seedSelection") as (ids: Array<string | number>) => void;
+    const getSelectedIds = ctx.methods.get("_getSelectedIds") as () => Set<string | number>;
+
+    seedSelection([1, 2, 3]);
+
+    const selected = getSelectedIds();
+    expect(selected.has(1)).toBe(true);
+    expect(selected.has(2)).toBe(true);
+    expect(selected.has(3)).toBe(true);
+    expect(selected.size).toBe(3);
   });
 
   it("selectNext should move focus and select next item", () => {

--- a/test/features/snapshots/feature.test.ts
+++ b/test/features/snapshots/feature.test.ts
@@ -1388,7 +1388,7 @@ describe("withSnapshots - autoSave", () => {
     expect(JSON.parse(stored!)).toEqual(originalSnapshot);
   });
 
-  it("should lift guard and save on first scroll idle after restore", () => {
+  it("should lift guard and save after restoreScroll completes", async () => {
     clearAutoSave();
     const savedSnapshot: ScrollSnapshot = { index: 50, offsetInItem: 0, total: 100 };
     sessionStorage.setItem(AUTO_SAVE_KEY, JSON.stringify(savedSnapshot));
@@ -1400,16 +1400,15 @@ describe("withSnapshots - autoSave", () => {
     const newSnapshot: ScrollSnapshot = { index: 75, offsetInItem: 0, total: 100 };
     ctx.methods.set("getScrollSnapshot", () => newSnapshot);
 
-    // Call idle handler — should lift guard AND save
-    expect(ctx.idleHandlers.length).toBeGreaterThan(0);
-    ctx.idleHandlers[ctx.idleHandlers.length - 1]();
+    // Guard is lifted after restoreScroll completes in microtask
+    await flushAsync();
 
     const stored = sessionStorage.getItem(AUTO_SAVE_KEY);
     expect(stored).not.toBeNull();
     expect(JSON.parse(stored!)).toEqual(newSnapshot);
   });
 
-  it("should save normally after guard is lifted", () => {
+  it("should save normally after guard is lifted", async () => {
     clearAutoSave();
     const savedSnapshot: ScrollSnapshot = { index: 50, offsetInItem: 0, total: 100 };
     sessionStorage.setItem(AUTO_SAVE_KEY, JSON.stringify(savedSnapshot));
@@ -1418,13 +1417,9 @@ describe("withSnapshots - autoSave", () => {
     const feature = withSnapshots<TestItem>({ autoSave: AUTO_SAVE_KEY });
     feature.setup(ctx);
 
-    const postGuardSnapshot: ScrollSnapshot = { index: 30, offsetInItem: 5, total: 100 };
-    ctx.methods.set("getScrollSnapshot", () => postGuardSnapshot);
+    // Flush microtask to lift guard
+    await flushAsync();
 
-    // First idle call lifts the guard
-    ctx.idleHandlers[ctx.idleHandlers.length - 1]();
-
-    // Now update the snapshot to something new
     const afterLiftSnapshot: ScrollSnapshot = { index: 42, offsetInItem: 12, total: 100 };
     ctx.methods.set("getScrollSnapshot", () => afterLiftSnapshot);
 
@@ -1543,7 +1538,7 @@ describe("withSnapshots - autoSave", () => {
     expect(JSON.parse(stored!)).toEqual(originalSnapshot);
   });
 
-  it("should save focus:change normally after restore guard is lifted", () => {
+  it("should save focus:change normally after restore guard is lifted", async () => {
     clearAutoSave();
     const savedSnapshot: ScrollSnapshot = { index: 50, offsetInItem: 0, total: 100 };
     sessionStorage.setItem(AUTO_SAVE_KEY, JSON.stringify(savedSnapshot));
@@ -1552,8 +1547,8 @@ describe("withSnapshots - autoSave", () => {
     const feature = withSnapshots<TestItem>({ autoSave: AUTO_SAVE_KEY });
     feature.setup(ctx);
 
-    // Lift guard via idle
-    ctx.idleHandlers[ctx.idleHandlers.length - 1]();
+    // Flush microtask to lift guard
+    await flushAsync();
 
     const newSnapshot: ScrollSnapshot = { index: 30, offsetInItem: 0, total: 100, focusedId: 31 };
     ctx.methods.set("getScrollSnapshot", () => newSnapshot);
@@ -1563,6 +1558,113 @@ describe("withSnapshots - autoSave", () => {
 
     const stored = sessionStorage.getItem(AUTO_SAVE_KEY);
     expect(JSON.parse(stored!)).toEqual(newSnapshot);
+  });
+});
+
+// =============================================================================
+// withSnapshots - Selection Seeding
+// =============================================================================
+
+describe("withSnapshots - Selection Seeding", () => {
+  const AUTO_SAVE_KEY = "test-seed-selection";
+
+  const clearAutoSave = (): void => {
+    sessionStorage.removeItem(AUTO_SAVE_KEY);
+  };
+
+  it("should seed selection synchronously via _seedSelection before first render", () => {
+    clearAutoSave();
+    const savedSnapshot: ScrollSnapshot = { index: 10, offsetInItem: 0, total: 100, selectedIds: [42, 99] };
+    sessionStorage.setItem(AUTO_SAVE_KEY, JSON.stringify(savedSnapshot));
+
+    const seeded: Array<string | number> = [];
+    const ctx = createMockContext({
+      totalItems: 100,
+      scrollTop: 0,
+      itemHeight: 48,
+      extraMethods: { _seedSelection: (ids: Array<string | number>) => { seeded.push(...ids); } },
+    });
+
+    const feature = withSnapshots<TestItem>({ autoSave: AUTO_SAVE_KEY });
+    feature.setup(ctx);
+
+    // _seedSelection called synchronously during setup, before any microtask
+    expect(seeded).toEqual([42, 99]);
+  });
+
+  it("should strip selectedIds from restoreScroll when seeded", async () => {
+    clearAutoSave();
+    const savedSnapshot: ScrollSnapshot = { index: 10, offsetInItem: 0, total: 100, selectedIds: [42] };
+    sessionStorage.setItem(AUTO_SAVE_KEY, JSON.stringify(savedSnapshot));
+
+    let selectCalled = false;
+    const ctx = createMockContext({
+      totalItems: 100,
+      scrollTop: 0,
+      itemHeight: 48,
+      extraMethods: {
+        _seedSelection: () => {},
+        select: (..._ids: any[]) => { selectCalled = true; },
+      },
+    });
+
+    const feature = withSnapshots<TestItem>({ autoSave: AUTO_SAVE_KEY });
+    feature.setup(ctx);
+
+    await flushAsync();
+
+    // select() should NOT have been called since selectedIds was stripped
+    expect(selectCalled).toBe(false);
+  });
+
+  it("should persist seeded selection via post-restore save", async () => {
+    clearAutoSave();
+    const savedSnapshot: ScrollSnapshot = { index: 10, offsetInItem: 0, total: 100, selectedIds: [42] };
+    sessionStorage.setItem(AUTO_SAVE_KEY, JSON.stringify(savedSnapshot));
+
+    const ctx = createMockContext({
+      totalItems: 100,
+      scrollTop: 0,
+      itemHeight: 48,
+      extraMethods: { _seedSelection: () => {} },
+    });
+
+    const feature = withSnapshots<TestItem>({ autoSave: AUTO_SAVE_KEY });
+    feature.setup(ctx);
+
+    // Mock getScrollSnapshot to return snapshot with selectedIds (as if selection was seeded)
+    const snapshotWithSelection: ScrollSnapshot = { index: 10, offsetInItem: 0, total: 100, selectedIds: [42] };
+    ctx.methods.set("getScrollSnapshot", () => snapshotWithSelection);
+
+    await flushAsync();
+
+    const stored = sessionStorage.getItem(AUTO_SAVE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!).selectedIds).toEqual([42]);
+  });
+
+  it("should not seed when _seedSelection is not registered", async () => {
+    clearAutoSave();
+    const savedSnapshot: ScrollSnapshot = { index: 10, offsetInItem: 0, total: 100, selectedIds: [42] };
+    sessionStorage.setItem(AUTO_SAVE_KEY, JSON.stringify(savedSnapshot));
+
+    let selectCalled = false;
+    const ctx = createMockContext({
+      totalItems: 100,
+      scrollTop: 0,
+      itemHeight: 48,
+      extraMethods: {
+        select: (..._ids: any[]) => { selectCalled = true; },
+      },
+    });
+
+    const feature = withSnapshots<TestItem>({ autoSave: AUTO_SAVE_KEY });
+    feature.setup(ctx);
+
+    await flushAsync();
+
+    // Without _seedSelection, restoreScroll gets the full snapshot and calls select()
+    expect(selectCalled).toBe(true);
   });
 });
 

--- a/test/features/sortable/feature.test.ts
+++ b/test/features/sortable/feature.test.ts
@@ -1511,10 +1511,13 @@ describe("withSortable — escape cancels pointer drag", () => {
     const isSorting = ctx.methods.get("isSorting") as () => boolean;
     expect(isSorting()).toBe(true);
 
-    // Press Escape
+    // Press Escape — triggers animateDrop(dragIndex, dragIndex) with ghost animation
     ctx.dom.root.dispatchEvent(new dom.window.KeyboardEvent("keydown", {
       key: "Escape", bubbles: true, cancelable: true,
     }));
+
+    // Wait for ghost animation to complete (setTimeout fallback)
+    await new Promise((r) => setTimeout(r, 300));
 
     expect(isSorting()).toBe(false);
 
@@ -1958,5 +1961,231 @@ describe("withSortable — drop index calculation", () => {
     expect(session.getDropIndices()).toEqual([4, 5, 6, 5, 4, 3]);
 
     session.cleanup();
+  });
+});
+
+// =============================================================================
+// Settling class — transition suppression during finalize
+// =============================================================================
+
+describe("withSortable — settling class", () => {
+  it("adds --settling class during finalize when position changed", async () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+
+    ctx.dom.viewport.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, right: 400, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => {} }) as DOMRect;
+
+    feature.setup(ctx);
+
+    const PointerEventCtor = dom.window.PointerEvent ?? dom.window.MouseEvent;
+    const itemEl = ctx.dom.items.querySelector("[data-index='1']") as HTMLElement;
+
+    itemEl.getBoundingClientRect = () =>
+      ({ left: 0, top: 56, right: 400, bottom: 112, width: 400, height: 56, x: 0, y: 56, toJSON: () => {} }) as DOMRect;
+
+    // Drag item 1 down past item 2
+    itemEl.dispatchEvent(new PointerEventCtor("pointerdown", {
+      bubbles: true, clientX: 200, clientY: 84, button: 0,
+    }));
+    document.dispatchEvent(new PointerEventCtor("pointermove", {
+      bubbles: true, clientX: 200, clientY: 200, button: 0,
+    }));
+    document.dispatchEvent(new PointerEventCtor("pointerup", {
+      bubbles: true, clientX: 200, clientY: 200, button: 0,
+    }));
+
+    // Wait for ghost animation + finalize
+    await new Promise((r) => setTimeout(r, 300));
+
+    // --settling should have been removed after rAF
+    expect(ctx.dom.root.classList.contains("vlist--settling")).toBe(false);
+  });
+
+  it("adds --settling class during finalize when dropped at same position", async () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+
+    ctx.dom.viewport.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, right: 400, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => {} }) as DOMRect;
+
+    feature.setup(ctx);
+
+    const PointerEventCtor = dom.window.PointerEvent ?? dom.window.MouseEvent;
+    const itemEl = ctx.dom.items.querySelector("[data-index='3']") as HTMLElement;
+
+    itemEl.getBoundingClientRect = () =>
+      ({ left: 0, top: 168, right: 400, bottom: 224, width: 400, height: 56, x: 0, y: 168, toJSON: () => {} }) as DOMRect;
+
+    // Drag just past threshold but within same index zone
+    itemEl.dispatchEvent(new PointerEventCtor("pointerdown", {
+      bubbles: true, clientX: 200, clientY: 196, button: 0,
+    }));
+    document.dispatchEvent(new PointerEventCtor("pointermove", {
+      bubbles: true, clientX: 200, clientY: 216, button: 0,
+    }));
+    document.dispatchEvent(new PointerEventCtor("pointerup", {
+      bubbles: true, clientX: 200, clientY: 216, button: 0,
+    }));
+
+    // Wait for ghost animation + finalize + rAF
+    await new Promise((r) => setTimeout(r, 300));
+
+    // --settling added and removed in both paths
+    expect(ctx.dom.root.classList.contains("vlist--settling")).toBe(false);
+  });
+});
+
+// =============================================================================
+// Drag-source class — replaces inline opacity during drag
+// =============================================================================
+
+describe("withSortable — drag-source class", () => {
+  it("adds drag-source class to dragged item instead of inline opacity", () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+
+    ctx.dom.viewport.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, right: 400, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => {} }) as DOMRect;
+
+    feature.setup(ctx);
+
+    const PointerEventCtor = dom.window.PointerEvent ?? dom.window.MouseEvent;
+    const itemEl = ctx.dom.items.querySelector("[data-index='2']") as HTMLElement;
+
+    itemEl.getBoundingClientRect = () =>
+      ({ left: 0, top: 112, right: 400, bottom: 168, width: 400, height: 56, x: 0, y: 112, toJSON: () => {} }) as DOMRect;
+
+    // Start drag past threshold
+    itemEl.dispatchEvent(new PointerEventCtor("pointerdown", {
+      bubbles: true, clientX: 200, clientY: 140, button: 0,
+    }));
+    document.dispatchEvent(new PointerEventCtor("pointermove", {
+      bubbles: true, clientX: 200, clientY: 200, button: 0,
+    }));
+
+    expect(itemEl.classList.contains("vlist-item--drag-source")).toBe(true);
+    expect(itemEl.style.opacity).toBe("");
+  });
+
+  it("removes drag-source class on cleanup", async () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+
+    ctx.dom.viewport.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, right: 400, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => {} }) as DOMRect;
+
+    feature.setup(ctx);
+
+    const PointerEventCtor = dom.window.PointerEvent ?? dom.window.MouseEvent;
+    const itemEl = ctx.dom.items.querySelector("[data-index='2']") as HTMLElement;
+
+    itemEl.getBoundingClientRect = () =>
+      ({ left: 0, top: 112, right: 400, bottom: 168, width: 400, height: 56, x: 0, y: 112, toJSON: () => {} }) as DOMRect;
+
+    itemEl.dispatchEvent(new PointerEventCtor("pointerdown", {
+      bubbles: true, clientX: 200, clientY: 140, button: 0,
+    }));
+    document.dispatchEvent(new PointerEventCtor("pointermove", {
+      bubbles: true, clientX: 200, clientY: 200, button: 0,
+    }));
+    document.dispatchEvent(new PointerEventCtor("pointerup", {
+      bubbles: true, clientX: 200, clientY: 200, button: 0,
+    }));
+
+    await new Promise((r) => setTimeout(r, 300));
+
+    expect(itemEl.classList.contains("vlist-item--drag-source")).toBe(false);
+  });
+
+  it("re-applies drag-source class via afterRenderBatch when element is recycled", () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+
+    ctx.dom.viewport.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, right: 400, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => {} }) as DOMRect;
+
+    feature.setup(ctx);
+
+    const PointerEventCtor = dom.window.PointerEvent ?? dom.window.MouseEvent;
+    const itemEl = ctx.dom.items.querySelector("[data-index='2']") as HTMLElement;
+
+    itemEl.getBoundingClientRect = () =>
+      ({ left: 0, top: 112, right: 400, bottom: 168, width: 400, height: 56, x: 0, y: 112, toJSON: () => {} }) as DOMRect;
+
+    // Start drag
+    itemEl.dispatchEvent(new PointerEventCtor("pointerdown", {
+      bubbles: true, clientX: 200, clientY: 140, button: 0,
+    }));
+    document.dispatchEvent(new PointerEventCtor("pointermove", {
+      bubbles: true, clientX: 200, clientY: 200, button: 0,
+    }));
+
+    // Simulate element recycling via afterRenderBatch
+    const newEl = document.createElement("div");
+    newEl.setAttribute("data-index", "2");
+    for (const handler of ctx.afterRenderBatch) {
+      handler([{ index: 2, element: newEl }]);
+    }
+
+    expect(newEl.classList.contains("vlist-item--drag-source")).toBe(true);
+  });
+});
+
+// =============================================================================
+// Escape cancel animates ghost back
+// =============================================================================
+
+describe("withSortable — escape animates ghost return", () => {
+  it("Escape during pointer drag goes through animateDrop to animate ghost back", async () => {
+    const feature = withSortable();
+    const ctx = createMockContext();
+
+    ctx.dom.viewport.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, right: 400, bottom: 600, width: 400, height: 600, x: 0, y: 0, toJSON: () => {} }) as DOMRect;
+
+    feature.setup(ctx);
+
+    const PointerEventCtor = dom.window.PointerEvent ?? dom.window.MouseEvent;
+    const itemEl = ctx.dom.items.querySelector("[data-index='2']") as HTMLElement;
+
+    itemEl.getBoundingClientRect = () =>
+      ({ left: 0, top: 112, right: 400, bottom: 168, width: 400, height: 56, x: 0, y: 112, toJSON: () => {} }) as DOMRect;
+
+    // Start drag past threshold — moves item down
+    itemEl.dispatchEvent(new PointerEventCtor("pointerdown", {
+      bubbles: true, clientX: 200, clientY: 140, button: 0,
+    }));
+    document.dispatchEvent(new PointerEventCtor("pointermove", {
+      bubbles: true, clientX: 200, clientY: 300, button: 0,
+    }));
+
+    const isSorting = ctx.methods.get("isSorting") as () => boolean;
+    expect(isSorting()).toBe(true);
+
+    // Press Escape — should NOT finalize immediately (ghost animates back)
+    ctx.dom.root.dispatchEvent(new dom.window.KeyboardEvent("keydown", {
+      key: "Escape", bubbles: true, cancelable: true,
+    }));
+
+    // Ghost animation is in progress — sorting is still true
+    expect(isSorting()).toBe(true);
+
+    // sort:cancel should NOT have fired yet
+    const emitSpy = ctx.emitter.emit as ReturnType<typeof mock>;
+    const earlyCancel = emitSpy.mock.calls.find(
+      (c: unknown[]) => c[0] === "sort:cancel",
+    );
+    expect(earlyCancel).toBeUndefined();
+
+    // Wait for animation to complete
+    await new Promise((r) => setTimeout(r, 300));
+
+    // Now sorting is done and sort:cancel has been emitted
+    expect(isSorting()).toBe(false);
+    const cancelCall = emitSpy.mock.calls.find(
+      (c: unknown[]) => c[0] === "sort:cancel",
+    );
+    expect(cancelCall).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- **fix(sortable):** prevent neighbor item blink on drop via `--settling` CSS class
- **fix(sortable):** smooth drop transition using `drag-source` CSS class instead of inline opacity
- **fix(sortable):** animate ghost back to origin on Escape cancel
- **fix(selection):** seed selection state before first render on snapshot restore

## Test plan
- [x] 3268 tests pass, 0 failures
- [x] Bundle size verified via `bun run size`
- [x] Sortable drag-drop tested: no neighbor blink, smooth source item transition, Escape animates ghost back
- [x] Selection snapshot restore tested: no blink on config change recreation