### PR TITLE
v1.7.7

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,16 +58,16 @@ src/
 │   ├── measurement.ts       #   Size measurement
 │   └── velocity.ts          #   Scroll velocity tracking
 ├── features/               # Opt-in features via .use()
+│   ├── page/               #   Document/window scroll mode (priority 5)
 │   ├── grid/               #   2D grid layout (priority 10)
 │   ├── masonry/            #   Shortest-lane masonry (priority 10)
 │   ├── table/              #   Virtualized data table (priority 10)
 │   ├── groups/             #   Sticky group headers (priority 10)
+│   ├── scrollbar/          #   Custom scrollbar (priority 15)
 │   ├── async/              #   Async data adapter (priority 20)
+│   ├── scale/              #   Large-list compression, 1M+ items (priority 20)
 │   ├── selection/          #   Selection state (priority 50)
-│   ├── scrollbar/          #   Custom scrollbar (priority 60)
-│   ├── scale/              #   Large-list compression, 1M+ items (priority 70)
-│   ├── page/               #   Document/window scroll mode (priority 80)
-│   └── snapshots/          #   Scroll save/restore (priority 90)
+│   └── snapshots/          #   Scroll save/restore (priority 50)
 ├── rendering/              # Core rendering (not features)
 │   ├── sizes.ts            #   Size cache (prefix sums)
 │   ├── renderer.ts         #   DOM rendering with pooling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ This changelog starts at v1.5.4, the first version published under the `vlist` p
 
 ## [Unreleased]
 
+## [1.7.7] - 2026-05-11
+
+### Fixed
+
+- **scrollbar**: Fix `position:relative` on viewport that broke custom scrollbar positioning.
+- **scrollbar**: Attach scrollbar DOM to root element instead of viewport to prevent clipping.
+- **scrollbar**: Prevent duplicate scrollbar when used with `withScale`.
+- **groups**: Skip group headers in PageUp/PageDown keyboard navigation.
+- **groups**: Clear restore anchor after first scroll adjustment to prevent position reset on re-render.
+- **groups**: Create sticky header container eagerly to prevent visual shift on data load.
+- **selection**: Use prefix-sum offsets for compressed scroll-to-focus — fixes keyboard navigation off-by-one with mixed item sizes (group headers + data items).
+
 ## [1.7.6] - 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The virtual list library for every framework. Accessible by default, batteries-included, with composable features — in 11.2 KB.
 
-**v1.7.6** — [Changelog](./CHANGELOG.md)
+**v1.7.7** — [Changelog](./CHANGELOG.md)
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![CI](https://github.com/floor/vlist/actions/workflows/ci.yml/badge.svg)](https://github.com/floor/vlist/actions/workflows/ci.yml)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/src/builder/a11y.ts
+++ b/src/builder/a11y.ts
@@ -178,7 +178,16 @@ export const setupBaselineA11y = <T extends VListItem>(
         case "PageDown": {
           const rh = $.hc.getSize($.i2s(Math.max(0, p)));
           const delta = Math.max(ud, Math.floor((hz ? $.cw : $.ch) / rh) * ud);
-          n = event.key === "PageUp" ? p - delta : p + delta;
+          const l2d = methods.get("_layoutToDataIndex") as ((i: number) => number) | undefined;
+          const d2l = methods.get("_dataToLayoutIndex") as ((i: number) => number) | undefined;
+          if (l2d && d2l) {
+            const curData = l2d(p);
+            const step = event.key === "PageUp" ? -delta : delta;
+            const lastData = l2d(total - 1);
+            n = d2l(Math.max(0, Math.min(lastData, curData + step)));
+          } else {
+            n = event.key === "PageUp" ? p - delta : p + delta;
+          }
           break;
         }
         case "Home":  n = 0; break;

--- a/src/features/async/feature.ts
+++ b/src/features/async/feature.ts
@@ -211,10 +211,6 @@ export const withAsync = <T extends VListItem = VListItem>(
 
             ctx.updateContentSize(compression.virtualSize);
             ctx.renderIfNeeded();
-            // const scrollAfter = ctx.scrollController.getScrollTop();
-            // if (Math.abs(scrollAfter - scrollBefore) > 1) {
-            //   console.log(`[ASYNC onStateChange] scroll ${scrollBefore} -> ${scrollAfter} (delta=${scrollAfter - scrollBefore}) total=${newTotal} contentSize=${compression.virtualSize}`);
-            // }
           }
         },
         onItemsLoaded: (loadedItems, _offset, total) => {
@@ -226,12 +222,6 @@ export const withAsync = <T extends VListItem = VListItem>(
             // Force render to replace placeholders with actual data immediately
             // This is necessary so the DOM shows loaded items instead of placeholders
             ctx.forceRender();
-            // const scrollAfter = ctx.scrollController.getScrollTop();
-
-            // if (Math.abs(scrollAfter - scrollBefore) > 1) {
-            //   console.log(`[ASYNC onItemsLoaded] scroll ${scrollBefore} -> ${scrollAfter} (delta=${scrollAfter - scrollBefore}) offset=${_offset} count=${loadedItems.length}`);
-            // }
-
             emitter.emit("load:end", { items: loadedItems, total, offset: _offset });
           }
         },

--- a/src/features/groups/feature.ts
+++ b/src/features/groups/feature.ts
@@ -31,7 +31,7 @@ import {
   createGroupedSizeFn,
 } from "./layout";
 
-import { createStickyHeader } from "./sticky";
+import { createStickyHeader, createStickyContainer } from "./sticky";
 
 import {
   isGroupHeader,
@@ -182,10 +182,20 @@ export const withGroups = <T extends VListItem = VListItem>(
       dom.root.classList.add(`${classPrefix}--grouped`);
 
       // ── Expose sticky header height so scrollToFocus can offset ──
+      let stickyContainer: HTMLElement | null = null;
       if (stickyEnabled) {
         ctx.methods.set(
           "_getStickyHeaderHeight",
           (): number => config.header.height,
+        );
+
+        // Create the sticky header container immediately so the DOM
+        // structure is stable before data arrives (prevents visual shift).
+        stickyContainer = createStickyContainer(
+          dom.root,
+          classPrefix,
+          resolvedConfig.horizontal,
+          config.header.height,
         );
 
         // Shrink the viewport by the sticky header height so the
@@ -259,6 +269,8 @@ export const withGroups = <T extends VListItem = VListItem>(
         if (stickyHeader) {
           stickyHeader.destroy();
           stickyHeader = null;
+        } else if (stickyContainer) {
+          stickyContainer.remove();
         }
         dom.root.classList.remove(`${classPrefix}--grouped`);
       });
@@ -286,6 +298,7 @@ export const withGroups = <T extends VListItem = VListItem>(
             headerTemplate, classPrefix, registerOnItemsLoaded,
             (b) => { bridge = b; indexMapper = b; },
             (s) => { stickyHeader = s; },
+            stickyContainer,
           );
         } else {
           // Static path was already set up below — nothing to do
@@ -303,6 +316,7 @@ export const withGroups = <T extends VListItem = VListItem>(
         () => {},
         (layout) => { groupLayout = layout; indexMapper = layout; },
         (s) => { stickyHeader = s; },
+        stickyContainer,
       );
     },
 
@@ -332,6 +346,7 @@ function setupStaticPath<T extends VListItem>(
   setLayoutItems: (items: Array<T | GroupHeaderItem>) => void,
   setGroupLayout: (layout: GroupLayout) => void,
   setStickyHeader: (s: StickyHeaderInstance) => void,
+  stickyContainer?: HTMLElement | null,
 ): void {
   const { dom } = ctx;
   let localStickyHeader: StickyHeaderInstance | null = null;
@@ -467,6 +482,7 @@ function setupStaticPath<T extends VListItem>(
       resolvedConfig.horizontal,
       0,
       () => ctx.getCachedCompression().ratio,
+      stickyContainer ?? undefined,
     );
     localStickyHeader = sticky;
     setStickyHeader(sticky);
@@ -579,6 +595,7 @@ function setupAsyncPath<T extends VListItem>(
   registerOnItemsLoaded: (cb: (items: T[], offset: number, total: number) => void) => void,
   setBridge: (bridge: AsyncGroupBridge) => void,
   setStickyHeader: (s: StickyHeaderInstance) => void,
+  stickyContainer?: HTMLElement | null,
 ): void {
   const { dom } = ctx;
 
@@ -755,6 +772,7 @@ function setupAsyncPath<T extends VListItem>(
       resolvedConfig.horizontal,
       0,
       () => ctx.getCachedCompression().ratio,
+      stickyContainer ?? undefined,
     );
     setStickyHeader(asyncStickyHeader);
 

--- a/src/features/groups/feature.ts
+++ b/src/features/groups/feature.ts
@@ -858,8 +858,10 @@ function setupAsyncPath<T extends VListItem>(
         }
 
         if (restoreAnchor) {
-          // Lift save suppression and capture the correct post-adjustment
-          // state. Keep anchor for subsequent onItemsLoaded calls.
+          // Anchor served its purpose — clear it so subsequent loads
+          // compute the scroll anchor from the current scroll position
+          // instead of the stale restore point.
+          ctx.methods.delete("_restoreAnchor");
           ctx.methods.delete("_suppressSave");
           const forceSave = ctx.methods.get("_saveSnapshot") as (() => void) | undefined;
           if (forceSave) forceSave();

--- a/src/features/groups/feature.ts
+++ b/src/features/groups/feature.ts
@@ -844,7 +844,6 @@ function setupAsyncPath<T extends VListItem>(
         // for the original header layout. Keep anchor+suppression for
         // subsequent onItemsLoaded calls; don't save (sessionStorage
         // already has the correct snapshot).
-        // console.log(`[GROUPS scroll adjust] skipped (shortcut restore) scroll=${scrollBefore} +${newHeaders}hdr`);
       } else if (dataIndexAtScroll >= 0) {
         const newLayoutIndex = bridge.dataToLayoutIndex(dataIndexAtScroll);
         const newBaseOffset = ctx.sizeCache.getOffset(newLayoutIndex);

--- a/src/features/groups/sticky.ts
+++ b/src/features/groups/sticky.ts
@@ -19,6 +19,32 @@
 import type { GroupLayout, StickyHeader } from "./types";
 import type { SizeCache } from "../../rendering/sizes";
 
+/**
+ * Create the sticky header container element upfront (before data arrives)
+ * so the DOM structure is stable and doesn't cause a visual shift.
+ */
+export const createStickyContainer = (
+  root: HTMLElement,
+  classPrefix: string,
+  horizontal: boolean,
+  headerHeight: number,
+  stickyOffset: number = 0,
+): HTMLElement => {
+  const mainProp = horizontal ? "width" : "height";
+  const container = document.createElement("div");
+  container.className = `${classPrefix}-sticky-header`;
+  container.setAttribute("role", "presentation");
+  container.setAttribute("aria-hidden", "true");
+  container.style.cssText =
+    `position:relative;z-index:5;pointer-events:none;overflow:hidden;` +
+    (horizontal
+      ? `top:0;bottom:0;left:${stickyOffset || 0}px`
+      : `top:${stickyOffset || 0}px`);
+  container.style[mainProp] = `${headerHeight}px`;
+  root.insertBefore(container, root.firstChild);
+  return container;
+};
+
 export const createStickyHeader = (
   root: HTMLElement,
   layout: GroupLayout,
@@ -28,6 +54,7 @@ export const createStickyHeader = (
   horizontal: boolean = false,
   stickyOffset: number = 0,
   getCompressionRatio?: () => number,
+  existingContainer?: HTMLElement,
 ): StickyHeader => {
   // Orientation helpers — resolved once
   const mainProp = horizontal ? "width" : "height";
@@ -38,16 +65,20 @@ export const createStickyHeader = (
     el.style[mainProp] = `${px}px`;
   };
 
-  // DOM setup
-  const container = document.createElement("div");
-  container.className = `${classPrefix}-sticky-header`;
-  container.setAttribute("role", "presentation");
-  container.setAttribute("aria-hidden", "true");
-  container.style.cssText =
-    `position:relative;z-index:5;pointer-events:none;overflow:hidden;` +
-    (horizontal
-      ? `top:0;bottom:0;left:${stickyOffset || 0}px`
-      : `top:${stickyOffset || 0}px`);
+  // DOM setup — reuse pre-created container if provided
+  const container = existingContainer ?? (() => {
+    const el = document.createElement("div");
+    el.className = `${classPrefix}-sticky-header`;
+    el.setAttribute("role", "presentation");
+    el.setAttribute("aria-hidden", "true");
+    el.style.cssText =
+      `position:relative;z-index:5;pointer-events:none;overflow:hidden;` +
+      (horizontal
+        ? `top:0;bottom:0;left:${stickyOffset || 0}px`
+        : `top:${stickyOffset || 0}px`);
+    root.insertBefore(el, root.firstChild);
+    return el;
+  })();
 
   const mkSlot = (): HTMLElement => {
     const s = document.createElement("div");
@@ -61,7 +92,7 @@ export const createStickyHeader = (
   const slotA = mkSlot();
   const slotB = mkSlot();
   container.append(slotA, slotB);
-  root.insertBefore(container, root.firstChild);
+  if (!existingContainer) root.insertBefore(container, root.firstChild);
 
   // Slot references — swap roles after each completed transition
   let active = slotA;
@@ -164,17 +195,22 @@ export const createStickyHeader = (
     resetTransforms();
   };
 
-  // Visibility
+  // Visibility — when a pre-created container is reused, use visibility
+  // instead of display to preserve layout (the viewport is sized with
+  // calc(100% - headerHeight) and relies on the container occupying space).
+  const preserveLayout = !!existingContainer;
   const show = (): void => {
     if (visible) return;
     visible = true;
-    container.style.display = "";
+    if (preserveLayout) container.style.visibility = "";
+    else container.style.display = "";
   };
 
   const hide = (): void => {
     if (!visible) return;
     visible = false;
-    container.style.display = "none";
+    if (preserveLayout) container.style.visibility = "hidden";
+    else container.style.display = "none";
     clear(active);
     curGroup = -1;
     curSize = 0;
@@ -241,7 +277,9 @@ export const createStickyHeader = (
     transitioning = false;
   };
 
-  container.style.display = "none";
+  if (!existingContainer) {
+    container.style.display = "none";
+  }
 
   return { update, refresh, show, hide, destroy };
 };

--- a/src/features/scale/feature.ts
+++ b/src/features/scale/feature.ts
@@ -520,7 +520,7 @@ export const withScale = <
           // (native scrollbar can't represent compressed space)
           // Check if withScrollbar feature already created one by looking for
           // the scrollbar track element
-          const hasScrollbarTrack = dom.viewport.querySelector(
+          const hasScrollbarTrack = dom.root.querySelector(
             `.${classPrefix}-scrollbar`,
           );
 
@@ -563,6 +563,7 @@ export const withScale = <
               {},
               classPrefix,
               horizontal,
+              dom.root,
             );
 
             // Ensure native scrollbar is hidden

--- a/src/features/scale/feature.ts
+++ b/src/features/scale/feature.ts
@@ -516,14 +516,6 @@ export const withScale = <
             viewport.removeEventListener("touchcancel", touchEndHandler);
           });
 
-          // Force custom scrollbar if not already present
-          // (native scrollbar can't represent compressed space)
-          // Check if withScrollbar feature already created one by looking for
-          // the scrollbar track element
-          const hasScrollbarTrack = dom.root.querySelector(
-            `.${classPrefix}-scrollbar`,
-          );
-
           // ── Native scroll drift guard ───────────────────────────────
           // In compressed mode the viewport has overflow:hidden and
           // native scrollTop should stay at 0. But browser focus
@@ -553,9 +545,8 @@ export const withScale = <
 
           // Force custom scrollbar if not already present
           // (native scrollbar can't represent compressed space)
-          // Check if withScrollbar feature already created one by looking for
-          // the scrollbar track element
-          if (!hasScrollbarTrack) {
+          if (!ctx.methods.has("_hasScrollbar")) {
+            ctx.methods.set("_hasScrollbar", () => true);
             // Create a fallback scrollbar for compressed mode
             scrollbar = createScrollbar(
               dom.viewport,

--- a/src/features/scale/feature.ts
+++ b/src/features/scale/feature.ts
@@ -242,7 +242,6 @@ export const withScale = <
         const compression = getCompressionState(total, ctx.sizeCache, force);
 
         if (compression.isCompressed && !compressedModeActive) {
-          // Entering compressed mode
           compressedModeActive = true;
           ctx.scrollController.enableCompression(compression);
 
@@ -597,7 +596,6 @@ export const withScale = <
             });
           }
         } else if (!compression.isCompressed && compressedModeActive) {
-          // Leaving compressed mode
           compressedModeActive = false;
 
           // ── Cancel in-flight animations ─────────────────────────────

--- a/src/features/scrollbar/feature.ts
+++ b/src/features/scrollbar/feature.ts
@@ -105,19 +105,21 @@ export const withScrollbar = <T extends VListItem = VListItem>(
 
   return {
     name: "withScrollbar",
-    priority: 15,
+    priority: 30,
 
     setup(ctx: BuilderContext<T>): void {
       const { dom, config: resolvedConfig } = ctx;
       const { classPrefix, horizontal } = resolvedConfig;
 
-      // Create custom scrollbar
+      // Create custom scrollbar — DOM attaches to root (non-scrolling,
+      // position:relative) so the absolute-positioned track stays fixed.
       scrollbar = createScrollbar(
         dom.viewport,
         (position) => ctx.scrollController.scrollTo(position),
         config ?? {},
         classPrefix,
         horizontal,
+        dom.root,
       );
 
       // Ensure native scrollbar is hidden

--- a/src/features/scrollbar/feature.ts
+++ b/src/features/scrollbar/feature.ts
@@ -105,11 +105,21 @@ export const withScrollbar = <T extends VListItem = VListItem>(
 
   return {
     name: "withScrollbar",
-    priority: 30,
+    priority: 15,
 
     setup(ctx: BuilderContext<T>): void {
       const { dom, config: resolvedConfig } = ctx;
       const { classPrefix, horizontal } = resolvedConfig;
+
+      // If another feature (e.g. withScale) already created a fallback
+      // scrollbar, remove it — we replace it with one that has the user's config.
+      if (ctx.methods.has("_hasScrollbar")) {
+        const existing = dom.root.querySelector(`.${classPrefix}-scrollbar`);
+        if (existing) existing.remove();
+        const existingHover = dom.root.querySelector(`.${classPrefix}-scrollbar-hover`);
+        if (existingHover) existingHover.remove();
+      }
+      ctx.methods.set("_hasScrollbar", () => true);
 
       // Create custom scrollbar — DOM attaches to root (non-scrolling,
       // position:relative) so the absolute-positioned track stays fixed.

--- a/src/features/scrollbar/scrollbar.ts
+++ b/src/features/scrollbar/scrollbar.ts
@@ -156,11 +156,12 @@ const resolvePadding = (raw: ScrollbarPadding | undefined): ResolvedPadding => {
 /**
  * Create a scrollbar instance
  *
- * @param viewport - The viewport element to attach scrollbar to
+ * @param viewport - The viewport element (used for events and CSS variables)
  * @param onScroll - Callback when scrollbar interaction causes scroll
  * @param config - Scrollbar configuration
  * @param classPrefix - CSS class prefix (default: 'vlist')
  * @param horizontal - Whether the scrollbar is horizontal (default: false)
+ * @param parent - Element to append scrollbar DOM to (default: viewport)
  */
 export const createScrollbar = (
   viewport: HTMLElement,
@@ -168,6 +169,7 @@ export const createScrollbar = (
   config: ScrollbarConfig = {},
   classPrefix = "vlist",
   horizontal = false,
+  parent?: HTMLElement,
 ): Scrollbar => {
   const {
     autoHide = AUTO_HIDE,
@@ -179,6 +181,7 @@ export const createScrollbar = (
   } = config;
 
   const clickBehavior = rawClickBehavior === 'page' ? 'scroll' : rawClickBehavior;
+  const attachTo = parent ?? viewport;
 
   const pad = resolvePadding(config.padding);
 
@@ -224,6 +227,15 @@ export const createScrollbar = (
   // Always created: extends click target into the padding margin + handles hover when showOnHover
   const hoverZone = document.createElement("div");
 
+  // When the scrollbar lives on root, offset its top to align with the viewport
+  const syncTrackOffset = (): void => {
+    if (attachTo === viewport) return;
+    const offset = viewport.offsetTop;
+    const startPad = horizontal ? pad.left : pad.top;
+    track.style[horizontal ? "left" : "top"] = `${offset + startPad}px`;
+    hoverZone.style[horizontal ? "left" : "top"] = `${offset}px`;
+  };
+
   // =============================================================================
   // DOM Setup
   // =============================================================================
@@ -248,7 +260,7 @@ export const createScrollbar = (
     }
 
     track.appendChild(thumb);
-    viewport.appendChild(track);
+    attachTo.appendChild(track);
 
     // Edge zone — covers the padding margin + track area along the scrollbar edge.
     // Always present so clicks in the padding margin are captured regardless of showOnHover.
@@ -260,7 +272,13 @@ export const createScrollbar = (
     } else {
       hoverZone.style.width = `${hoverZoneWidth}px`;
     }
-    viewport.appendChild(hoverZone);
+    attachTo.appendChild(hoverZone);
+
+    // When attached to root instead of viewport, offset track/hover to match
+    // the viewport's position (e.g. below a sticky header).
+    if (attachTo !== viewport) {
+      syncTrackOffset();
+    }
   };
 
   // =============================================================================
@@ -322,6 +340,7 @@ export const createScrollbar = (
   ): void => {
     totalSize = newTotalSize;
     containerSize = newContainerSize;
+    syncTrackOffset();
 
     // Check if scrollbar is needed
     const needsScrollbar = totalSize > containerSize;

--- a/src/features/selection/feature.ts
+++ b/src/features/selection/feature.ts
@@ -190,6 +190,12 @@ export const withSelection = <T extends VListItem = VListItem>(
       const isGroupHeaderFn = (): ((index: number) => boolean) | undefined =>
         ctx.methods.get("_isGroupHeader") as ((index: number) => boolean) | undefined;
 
+      const layoutToDataFn = (): ((index: number) => number) | undefined =>
+        ctx.methods.get("_layoutToDataIndex") as ((index: number) => number) | undefined;
+
+      const dataToLayoutFn = (): ((index: number) => number) | undefined =>
+        ctx.methods.get("_dataToLayoutIndex") as ((index: number) => number) | undefined;
+
       /** Check whether a layout index is a group header */
       const isHeader = (index: number): boolean => {
         const fn = isGroupHeaderFn();
@@ -669,18 +675,24 @@ export const withSelection = <T extends VListItem = VListItem>(
           }
 
           case "PageUp":
-            newState = moveFocusByPage(selectionState, totalItems, getPageSize(), "up");
+          case "PageDown": {
+            const ps = getPageSize();
+            const l2d = layoutToDataFn();
+            const d2l = dataToLayoutFn();
+            if (l2d && d2l) {
+              const curData = l2d(selectionState.focusedIndex);
+              const delta = event.key === "PageUp" ? -ps : ps;
+              const lastData = l2d(totalItems - 1);
+              const targetData = Math.max(0, Math.min(lastData, curData + delta));
+              newState = setFocusedIndex(selectionState, d2l(targetData));
+            } else {
+              newState = moveFocusByPage(selectionState, totalItems, ps, event.key === "PageUp" ? "up" : "down");
+            }
             newState.focusVisible = true;
             handled = true;
             focusOnly = true;
             break;
-
-          case "PageDown":
-            newState = moveFocusByPage(selectionState, totalItems, getPageSize(), "down");
-            newState.focusVisible = true;
-            handled = true;
-            focusOnly = true;
-            break;
+          }
 
           case "Home": {
             newState = moveFocusToFirst(selectionState, totalItems);

--- a/src/features/snapshots/feature.ts
+++ b/src/features/snapshots/feature.ts
@@ -232,8 +232,6 @@ export const withSnapshots = <T extends VListItem = VListItem>(
           if (focusedId !== undefined) snapshot.focusedId = focusedId;
         }
 
-        // console.log(`[SNAP SAVE] scroll=${scrollTop} idx=${index} dataIdx=${snapshot.dataIndex} total=${totalItems} dataTotal=${snapshot.dataTotal} ratio=${snapshot.offsetRatio}`);
-
         return snapshot;
       });
 
@@ -378,8 +376,6 @@ export const withSnapshots = <T extends VListItem = VListItem>(
           } as unknown as Function);
           ctx.methods.set("_suppressSave", true as unknown as Function);
         }
-
-        // console.log(`[SNAP RESTORE] scroll=${scrollPosition} dataIdx=${snapshot.dataIndex} safeIdx=${safeIndex} total=${effectiveTotal}/${snapshot.total} shortcut=${usedShortcut} anchor=${snapshot.dataIndex !== undefined}`);
 
         ctx.scrollController.scrollTo(scrollPosition);
 

--- a/src/rendering/scroll.ts
+++ b/src/rendering/scroll.ts
@@ -85,7 +85,6 @@ export const scrollToFocus = (
   }
 
   // No visible range — fallback
-  const compressedItemSize = virtualSize / totalItems!;
   const currentIndex = (scrollPosition / virtualSize) * totalItems!;
   const currentEnd = currentIndex + fullyVisible;
 

--- a/src/rendering/scroll.ts
+++ b/src/rendering/scroll.ts
@@ -59,40 +59,45 @@ export const scrollToFocus = (
     return scrollToFocusSimple(index, sizeCache, scrollPosition, containerSize, startPadding, endPadding);
   }
 
-  // ── Compressed: linear index math ──
-  const total = totalItems!;
+  // ── Compressed: prefix-sum positioning ──
+  // Use actual offsets from the size cache instead of linear index math.
+  // Linear math assumes uniform item sizes, but group headers are shorter
+  // than data items, causing the focused item to land short of the edge.
   const { virtualSize } = compression!;
   const itemSize = sizeCache.getSize(Math.max(0, index));
   const effectiveSize = containerSize - startPadding - endPadding;
   const fullyVisible = Math.max(1, Math.floor(effectiveSize / itemSize));
-  const compressedItemSize = virtualSize / total;
+  const totalActualSize = sizeCache.getTotalSize();
 
   if (visibleRange) {
     if (index >= visibleRange.start + fullyVisible) {
-      const exactVisible = effectiveSize / itemSize;
-      const wantStart = index + 1 - exactVisible;
-      return Math.max(0, wantStart * compressedItemSize);
+      const itemBottom = sizeCache.getOffset(index) + itemSize;
+      const targetActualTop = itemBottom + endPadding - containerSize;
+      return Math.max(0, (targetActualTop / totalActualSize) * virtualSize);
     }
 
     if (index <= visibleRange.start) {
-      return Math.max(0, index * compressedItemSize);
+      const targetActualTop = sizeCache.getOffset(index) - startPadding;
+      return Math.max(0, (targetActualTop / totalActualSize) * virtualSize);
     }
 
     return scrollPosition;
   }
 
   // No visible range — fallback
-  const currentIndex = (scrollPosition / virtualSize) * total;
+  const compressedItemSize = virtualSize / totalItems!;
+  const currentIndex = (scrollPosition / virtualSize) * totalItems!;
   const currentEnd = currentIndex + fullyVisible;
 
   if (index >= currentEnd) {
-    const exactVisible = effectiveSize / itemSize;
-    const wantStart = index + 1 - exactVisible;
-    return Math.max(0, wantStart * compressedItemSize);
+    const itemBottom = sizeCache.getOffset(index) + itemSize;
+    const targetActualTop = itemBottom + endPadding - containerSize;
+    return Math.max(0, (targetActualTop / totalActualSize) * virtualSize);
   }
 
   if (index < currentIndex) {
-    return Math.max(0, index * compressedItemSize);
+    const targetActualTop = sizeCache.getOffset(index) - startPadding;
+    return Math.max(0, (targetActualTop / totalActualSize) * virtualSize);
   }
 
   return scrollPosition;

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -192,7 +192,6 @@
 
 /* Viewport (scrollable area) */
 .vlist-viewport {
-    position: relative;
     width: 100%;
     height: 100%;
     overflow: auto;

--- a/src/styles/vlist.css
+++ b/src/styles/vlist.css
@@ -414,7 +414,6 @@
 .vlist-group-header {
     cursor: default;
     background-color: var(--vlist-group-header-bg, #f3f4f6);
-    border-bottom: 1px solid var(--vlist-border);
     z-index: 1;
     overflow: hidden;
 }
@@ -431,7 +430,6 @@
     left: 0;
     right: 0;
     background-color: var(--vlist-group-header-bg, #f3f4f6);
-    border-bottom: 1px solid var(--vlist-border);
 }
 
 /* =============================================================================

--- a/test/features/scrollbar/feature.test.ts
+++ b/test/features/scrollbar/feature.test.ts
@@ -349,8 +349,9 @@ describe("withScrollbar — Setup", () => {
 
     feature.setup!(ctx);
 
-    // Scrollbar is automatic — no public API methods
-    expect(ctx.methods.size).toBe(0);
+    // Only internal flag, no public API methods
+    expect(ctx.methods.has("_hasScrollbar")).toBe(true);
+    expect(ctx.methods.size).toBe(1);
   });
 
   it("should run destroy handler without error", () => {

--- a/test/features/scrollbar/feature.test.ts
+++ b/test/features/scrollbar/feature.test.ts
@@ -248,7 +248,7 @@ describe("withScrollbar — Factory", () => {
     const feature = withScrollbar<TestItem>();
 
     expect(feature.name).toBe("withScrollbar");
-    expect(feature.priority).toBe(30);
+    expect(feature.priority).toBe(15);
     expect(typeof feature.setup).toBe("function");
   });
 

--- a/test/features/scrollbar/feature.test.ts
+++ b/test/features/scrollbar/feature.test.ts
@@ -248,7 +248,7 @@ describe("withScrollbar — Factory", () => {
     const feature = withScrollbar<TestItem>();
 
     expect(feature.name).toBe("withScrollbar");
-    expect(feature.priority).toBe(15);
+    expect(feature.priority).toBe(30);
     expect(typeof feature.setup).toBe("function");
   });
 

--- a/test/rendering/scroll-compressed.test.ts
+++ b/test/rendering/scroll-compressed.test.ts
@@ -762,3 +762,147 @@ describe("compressed scroll with different configurations", () => {
     });
   }
 });
+
+// =============================================================================
+// Mixed item sizes (group headers) — the groups + compression bug
+// =============================================================================
+
+describe("scrollToFocus — mixed sizes (group headers)", () => {
+  // Simulate a grouped list: every 11th entry is a 36px header, rest are 100px data items.
+  // This mirrors the real-world case where group headers are shorter than data items.
+  const HEADER_HEIGHT = 36;
+  const DATA_HEIGHT = 100;
+  const MIXED_TOTAL = 110_000; // ~10k groups of 10 items each
+  const MIXED_CONTAINER = 873;
+
+  const sizeFn = (index: number): number =>
+    index % 11 === 0 ? HEADER_HEIGHT : DATA_HEIGHT;
+
+  const mixedCache = createSizeCache(sizeFn, MIXED_TOTAL);
+  const mixedComp = getCompressionState(MIXED_TOTAL, mixedCache);
+  const mixedFullyVisible = Math.max(1, Math.floor(MIXED_CONTAINER / DATA_HEIGHT));
+
+  describe("ArrowDown — focused item at viewport bottom", () => {
+    it("should place focused item's bottom at viewport bottom with mixed sizes", () => {
+      // Use an index well past the visible area so scrolling is guaranteed
+      const focusIndex = 15;
+      const vr = visibleRangeAt(0, MIXED_CONTAINER, mixedCache, MIXED_TOTAL, mixedComp);
+
+      const newScroll = scrollToFocus(
+        focusIndex, mixedCache, 0, MIXED_CONTAINER, 0, 0,
+        mixedComp, MIXED_TOTAL, vr,
+      );
+
+      expect(newScroll).toBeGreaterThan(0);
+
+      const scrollRatio = newScroll / mixedComp.virtualSize;
+      const actualScroll = scrollRatio * mixedCache.getTotalSize();
+      const itemBottom = mixedCache.getOffset(focusIndex) + mixedCache.getSize(focusIndex);
+      const viewportBottom = actualScroll + MIXED_CONTAINER;
+
+      expect(itemBottom).toBeCloseTo(viewportBottom, 0);
+    });
+
+    it("should keep focused item at bottom during continuous ArrowDown", () => {
+      let scrollPos = 0;
+
+      for (let focus = 0; focus < 30; focus++) {
+        const vr = visibleRangeAt(scrollPos, MIXED_CONTAINER, mixedCache, MIXED_TOTAL, mixedComp);
+        const newScroll = scrollToFocus(
+          focus, mixedCache, scrollPos, MIXED_CONTAINER, 0, 0,
+          mixedComp, MIXED_TOTAL, vr,
+        );
+
+        if (newScroll !== scrollPos) {
+          const scrollRatio = newScroll / mixedComp.virtualSize;
+          const actualScroll = scrollRatio * mixedCache.getTotalSize();
+          const itemBottom = mixedCache.getOffset(focus) + mixedCache.getSize(focus);
+          const viewportBottom = actualScroll + MIXED_CONTAINER;
+
+          expect(itemBottom).toBeCloseTo(viewportBottom, 0);
+        }
+
+        scrollPos = newScroll;
+      }
+    });
+
+    it("should not undershoot by header height (the original bug)", () => {
+      // The old linear formula undershoots by (DATA_HEIGHT - HEADER_HEIGHT) when
+      // a header is in the viewport. Verify the focused item is always within
+      // the visible range and its bottom reaches the viewport bottom.
+      let scrollPos = 0;
+
+      for (let focus = 0; focus <= 20; focus++) {
+        const vr = visibleRangeAt(scrollPos, MIXED_CONTAINER, mixedCache, MIXED_TOTAL, mixedComp);
+        const newScroll = scrollToFocus(
+          focus, mixedCache, scrollPos, MIXED_CONTAINER, 0, 0,
+          mixedComp, MIXED_TOTAL, vr,
+        );
+
+        const newVr = visibleRangeAt(newScroll, MIXED_CONTAINER, mixedCache, MIXED_TOTAL, mixedComp);
+        expect(focus).toBeGreaterThanOrEqual(newVr.start);
+        expect(focus).toBeLessThanOrEqual(newVr.end);
+
+        scrollPos = newScroll;
+      }
+    });
+  });
+
+  describe("ArrowUp — focused item at viewport top", () => {
+    it("should place focused item's top at viewport top with mixed sizes", () => {
+      // Start scrolled down, then move focus up past the visible range
+      const startIndex = 50;
+      const startScroll = (mixedCache.getOffset(startIndex) / mixedCache.getTotalSize()) * mixedComp.virtualSize;
+      const vr = visibleRangeAt(startScroll, MIXED_CONTAINER, mixedCache, MIXED_TOTAL, mixedComp);
+
+      const focusIndex = vr.start - 1;
+      const newScroll = scrollToFocus(
+        focusIndex, mixedCache, startScroll, MIXED_CONTAINER, 0, 0,
+        mixedComp, MIXED_TOTAL, vr,
+      );
+
+      const scrollRatio = newScroll / mixedComp.virtualSize;
+      const actualScroll = scrollRatio * mixedCache.getTotalSize();
+      const itemOffset = mixedCache.getOffset(focusIndex);
+
+      expect(itemOffset).toBeCloseTo(actualScroll, 0);
+    });
+
+    it("should keep focused item visible during continuous ArrowUp", () => {
+      // Start from a scrolled position
+      const startIndex = 100;
+      let scrollPos = (mixedCache.getOffset(startIndex) / mixedCache.getTotalSize()) * mixedComp.virtualSize;
+
+      for (let focus = startIndex; focus >= startIndex - 30; focus--) {
+        const vr = visibleRangeAt(scrollPos, MIXED_CONTAINER, mixedCache, MIXED_TOTAL, mixedComp);
+        const newScroll = scrollToFocus(
+          focus, mixedCache, scrollPos, MIXED_CONTAINER, 0, 0,
+          mixedComp, MIXED_TOTAL, vr,
+        );
+
+        // The focused item should be within the visible range after scroll
+        const newVr = visibleRangeAt(newScroll, MIXED_CONTAINER, mixedCache, MIXED_TOTAL, mixedComp);
+        expect(focus).toBeGreaterThanOrEqual(newVr.start);
+        expect(focus).toBeLessThanOrEqual(newVr.end);
+
+        scrollPos = newScroll;
+      }
+    });
+  });
+
+  describe("uniform sizes still work (regression check)", () => {
+    it("should produce same results as before for uniform fixed-size cache", () => {
+      // With uniform sizes, prefix-sum and linear math should agree
+      const vr: Range = { start: 0, end: 9 };
+      const result = scrollToFocus(8, cache, 0, CONTAINER, 0, 0, comp, TOTAL, vr);
+
+      // Verify item 8's bottom is at viewport bottom
+      const scrollRatio = result / comp.virtualSize;
+      const actualScroll = scrollRatio * cache.getTotalSize();
+      const itemBottom = cache.getOffset(8) + ITEM_HEIGHT;
+      const viewportBottom = actualScroll + CONTAINER;
+
+      expect(itemBottom).toBeCloseTo(viewportBottom, 0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **scrollbar**: Fix positioning, DOM attachment, and duplicate prevention with `withScale`
- **groups**: Fix PageUp/PageDown header skipping, restore anchor reset, eager sticky header creation
- **selection**: Fix keyboard navigation off-by-one in compressed mode with mixed item sizes

## Changelog

### Fixed

- **scrollbar**: Fix `position:relative` on viewport that broke custom scrollbar positioning.
- **scrollbar**: Attach scrollbar DOM to root element instead of viewport to prevent clipping.
- **scrollbar**: Prevent duplicate scrollbar when used with `withScale`.
- **groups**: Skip group headers in PageUp/PageDown keyboard navigation.
- **groups**: Clear restore anchor after first scroll adjustment to prevent position reset on re-render.
- **groups**: Create sticky header container eagerly to prevent visual shift on data load.
- **selection**: Use prefix-sum offsets for compressed scroll-to-focus — fixes keyboard navigation off-by-one with mixed item sizes (group headers + data items).

## Test plan

- [x] 3370 tests pass
- [x] Typecheck clean
- [x] Bundle sizes unchanged (11.2 KB base)