### PR TITLE
chore(release): v1.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This changelog starts at v1.5.4, the first version published under the `vlist` p
 
 ## [Unreleased]
 
+## [1.7.9] - 2026-05-13
+
+### Fixed
+
+- **a11y**: Align `aria-activedescendant` with ARIA role owner — move `tabindex="0"` from `.vlist` root to `.vlist-items` (the `role="listbox"` element) so the focused element and composite widget role are on the same DOM node. `withTable` reverses this when it promotes root to `role="grid"`.
+- **a11y**: Unify table row ID format to `${ariaIdPrefix}-item-${index}`, matching selection's `aria-activedescendant` references — fixes broken ARIA in table + selection mode.
+- **a11y**: Make visible range announcements opt-in via `accessibility.announceVisibleRange` (default: `false`). Range announcements were noisy during keyboard navigation and touchpad scrolling. Add configurable `accessibility.rangeAnnouncementDebounce` (default: 750ms).
+
 ## [1.7.8] - 2026-05-12
 
 ### Performance
@@ -262,7 +270,10 @@ This changelog starts at v1.5.4, the first version published under the `vlist` p
 
 - **selection**: Implement ARIA multi-select keyboard model with configurable shiftArrowToggle
 
-[Unreleased]: https://github.com/floor/vlist/compare/v1.7.6...HEAD
+[Unreleased]: https://github.com/floor/vlist/compare/v1.7.9...HEAD
+[1.7.9]: https://github.com/floor/vlist/compare/v1.7.8...v1.7.9
+[1.7.8]: https://github.com/floor/vlist/compare/v1.7.7...v1.7.8
+[1.7.7]: https://github.com/floor/vlist/compare/v1.7.6...v1.7.7
 [1.7.6]: https://github.com/floor/vlist/compare/v1.7.5...v1.7.6
 [1.7.5]: https://github.com/floor/vlist/compare/v1.7.4...v1.7.5
 [1.7.4]: https://github.com/floor/vlist/compare/v1.7.3...v1.7.4

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # vlist
 
-The virtual list library for every framework. Accessible by default, batteries-included, with composable features — in 10.7 KB.
+The virtual list library for every framework. Accessible by default, batteries-included, with composable features — in 10.8 KB.
 
-**v1.7.8** — [Changelog](./CHANGELOG.md)
+**v1.7.9** — [Changelog](./CHANGELOG.md)
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![CI](https://github.com/floor/vlist/actions/workflows/ci.yml/badge.svg)](https://github.com/floor/vlist/actions/workflows/ci.yml)
 [![license](https://img.shields.io/npm/l/vlist.svg)](https://github.com/floor/vlist/blob/main/LICENSE)
 
-- **New: 10.7 KB base** — optimized from 11.2 KB, every feature bundle reduced
+- **New: 10.8 KB base** — optimized from 11.2 KB, every feature bundle reduced
 - **Accessible** — WAI-ARIA, 2D keyboard navigation, focus recovery, screen-reader DOM ordering, ARIA live region
 - **Zero dependencies** — framework-agnostic core with tiny adapters for Vue, Svelte, Solid, React
-- **10.7 KB gzipped** — composable features with perfect tree-shaking
+- **10.8 KB gzipped** — composable features with perfect tree-shaking
 - **Constant memory** — ~0.1 MB overhead at any scale, from 10K to 1M+ items
 - **Grid, masonry, table, groups, async, selection, sortable, scale** — all opt-in
 - **Vertical & horizontal** — single axis-neutral code path, every feature works in both orientations
@@ -94,7 +94,7 @@ const list = vlist({
 
 | Feature | Size | Description |
 |---------|------|-------------|
-| **Base** | 10.7 KB | Virtualization, ARIA, keyboard nav, gap, padding |
+| **Base** | 10.8 KB | Virtualization, ARIA, keyboard nav, gap, padding |
 | `withAsync()` | +4.4 KB | Lazy loading with velocity-aware fetching |
 | `withSelection()` | +3.0 KB | Single/multiple selection with 2D keyboard nav |
 | `withScale()` | +3.6 KB | 1M+ items via scroll compression |

--- a/npm-readme.md
+++ b/npm-readme.md
@@ -1,17 +1,17 @@
 # vlist
 
-The virtual list library for every framework. Accessible by default, batteries-included, with composable features — in 10.7 KB.
+The virtual list library for every framework. Accessible by default, batteries-included, with composable features — in 10.8 KB.
 
-**v1.7.8** — [Changelog](https://github.com/floor/vlist/blob/main/CHANGELOG.md)
+**v1.7.9** — [Changelog](https://github.com/floor/vlist/blob/main/CHANGELOG.md)
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![CI](https://github.com/floor/vlist/actions/workflows/ci.yml/badge.svg)](https://github.com/floor/vlist/actions/workflows/ci.yml)
 [![license](https://img.shields.io/npm/l/vlist.svg)](https://github.com/floor/vlist/blob/main/LICENSE)
 
-- **New: 10.7 KB base** — optimized from 11.2 KB, every feature bundle reduced
+- **New: 10.8 KB base** — optimized from 11.2 KB, every feature bundle reduced
 - **Zero dependencies** — framework-agnostic core, tiny adapters for Vue, Svelte, Solid, React
 - **Accessible** — WAI-ARIA, 2D keyboard navigation, focus recovery, screen-reader DOM ordering
-- **10.7 KB gzipped** — composable features with perfect tree-shaking
+- **10.8 KB gzipped** — composable features with perfect tree-shaking
 - **Constant memory** — ~0.1 MB overhead at any scale, from 10K to 1M+ items
 - **Vertical & horizontal** — single axis-neutral code path, every feature works in both orientations
 
@@ -56,7 +56,7 @@ const list = vlist({ container: '#app', items, item: { height: 200, template: re
 
 | Feature | Size | Description |
 |---------|------|-------------|
-| **Base** | 10.7 KB | Virtualization, ARIA, keyboard nav, gap, padding |
+| **Base** | 10.8 KB | Virtualization, ARIA, keyboard nav, gap, padding |
 | `withAsync()` | +4.4 KB | Lazy loading with velocity-aware fetching |
 | `withSelection()` | +3.0 KB | Single/multiple selection with 2D keyboard nav |
 | `withScale()` | +3.6 KB | 1M+ items via scroll compression |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/src/builder/a11y.ts
+++ b/src/builder/a11y.ts
@@ -47,8 +47,11 @@ export const setupBaselineA11y = <T extends VListItem>(
 
   methods.set("_getFocusedIndex", (): number => fv ? $.fi : -1);
 
+  const activeOwner = (): HTMLElement =>
+    dom.root.getAttribute("role") === "grid" ? dom.root : dom.items;
+
   const commit = (idx: number, scroll = true): void => {
-    dom.root.setAttribute("aria-activedescendant", `${ap}-item-${idx}`);
+    activeOwner().setAttribute("aria-activedescendant", `${ap}-item-${idx}`);
 
     if (scroll) {
       const siv = methods.get("_scrollItemIntoView") as ((index: number) => void) | undefined;
@@ -104,7 +107,8 @@ export const setupBaselineA11y = <T extends VListItem>(
 
   const onFocusIn = (): void => {
     if ($.id) return;
-    if (!dom.root.matches(":focus-visible")) return;
+    const owner = activeOwner();
+    if (!owner.matches(":focus-visible") && !dom.root.matches(":focus-visible")) return;
     const t = nTotal();
     if (t === 0) return;
     let tgt = $.fi >= 0 ? Math.min($.fi, t - 1) : 0;
@@ -121,7 +125,7 @@ export const setupBaselineA11y = <T extends VListItem>(
     if ($.fi >= 0) {
       rendered.get($.fi)?.classList.remove(focusedClass);
     }
-    dom.root.removeAttribute("aria-activedescendant");
+    activeOwner().removeAttribute("aria-activedescendant");
   };
   dom.root.addEventListener("focusout", onFocusOut);
 
@@ -198,7 +202,7 @@ export const setupBaselineA11y = <T extends VListItem>(
     const item = ($.dm?.getItem(idx) ?? $.it[idx]) as T | undefined;
     if (!item || (item as Record<string, unknown>).__groupHeader) return;
     fv = false;
-    dom.root.focus({ preventScroll: true });
+    activeOwner().focus({ preventScroll: true });
     select(idx, false);
   });
 

--- a/src/builder/core.ts
+++ b/src/builder/core.ts
@@ -194,6 +194,7 @@ function materialize<T extends VListItem = VListItem>(
     overscan = OVERSCAN,
     classPrefix = CLASS_PREFIX,
     ariaLabel,
+    accessibility,
     padding: paddingConfig,
     reverse: reverseMode = false,
     scroll: scrollConfig,
@@ -207,6 +208,8 @@ function materialize<T extends VListItem = VListItem>(
 
   const wheelEnabled = scrollCfg?.wheel ?? true;
   const wrapEnabled = scrollCfg?.wrap ?? false;
+  const announceVisibleRange = accessibility?.announceVisibleRange ?? false;
+  const rangeAnnouncementDebounce = accessibility?.rangeAnnouncementDebounce ?? 750;
   const isReverse = reverseMode;
   const ariaIdPrefix = `${classPrefix}-${builderInstanceId++}`;
   // Grid and masonry features manage their own gap — ignore item.gap when active
@@ -1129,7 +1132,7 @@ function materialize<T extends VListItem = VListItem>(
   dom.root.addEventListener("keydown", handleKeydown);
 
   // ── ARIA live region: announce visible range changes (#13b) ─────
-  if (interactiveMode) {
+  if (interactiveMode && announceVisibleRange) {
     let lrt: ReturnType<typeof setTimeout> | null = null;
     const ulr = (data: { range: { start: number; end: number } }): void => {
       if (lrt) clearTimeout(lrt);
@@ -1138,7 +1141,7 @@ function materialize<T extends VListItem = VListItem>(
         if ($.id) return;
         const t = $.vtf();
         dom.liveRegion.textContent = `Showing items ${data.range.start + 1} to ${Math.min(data.range.end + 1, t)} of ${t}`;
-      }, 300);
+      }, rangeAnnouncementDebounce);
     };
     emitter.on("range:change", ulr);
     destroyHandlers.push(() => { if (lrt) clearTimeout(lrt); emitter.off("range:change", ulr); });

--- a/src/builder/dom.ts
+++ b/src/builder/dom.ts
@@ -53,7 +53,6 @@ export const createDOMStructure = (
   const hz = horizontal;
   const root = el(classPrefix);
   if (hz) root.classList.add(`${classPrefix}--horizontal`);
-  if (interactive !== false) root.setAttribute("tabindex", "0");
 
   const viewport = el(
     `${classPrefix}-viewport`,
@@ -73,6 +72,7 @@ export const createDOMStructure = (
     hz ? "position:relative;height:100%" : "position:relative;width:100%",
   );
   items.setAttribute("role", "listbox");
+  if (interactive !== false) items.setAttribute("tabindex", "0");
   if (ariaLabel) items.setAttribute("aria-label", ariaLabel);
   if (hz) items.setAttribute("aria-orientation", "horizontal");
 

--- a/src/builder/types.ts
+++ b/src/builder/types.ts
@@ -97,6 +97,24 @@ export interface BuilderConfig<T extends VListItem = VListItem> {
   /** Accessible label for the listbox */
   ariaLabel?: string;
 
+  /** Accessibility behavior configuration. */
+  accessibility?: {
+    /**
+     * Announce visible range changes through the built-in live region.
+     *
+     * Defaults to false because frequent range updates can be noisy during
+     * keyboard navigation, touchpad scrolling, and repeated scroll pauses.
+     */
+    announceVisibleRange?: boolean;
+
+    /**
+     * Debounce delay in ms for visible range announcements.
+     *
+     * Only used when `announceVisibleRange` is true. Default: 750.
+     */
+    rangeAnnouncementDebounce?: number;
+  };
+
   /**
    * Layout orientation (default: 'vertical')
    * - 'vertical' — Standard top-to-bottom scrolling

--- a/src/features/selection/feature.ts
+++ b/src/features/selection/feature.ts
@@ -150,6 +150,8 @@ export const withSelection = <T extends VListItem = VListItem>(
     setup(ctx: BuilderContext<T>): void {
       const { dom, emitter, config: resolvedConfig } = ctx;
       const { classPrefix, ariaIdPrefix } = resolvedConfig;
+      const activeOwner = (): HTMLElement =>
+        dom.root.getAttribute("role") === "grid" ? dom.root : dom.items;
 
       // If mode is 'none', register stub methods for backwards compatibility
       if (mode === "none") {
@@ -515,7 +517,8 @@ export const withSelection = <T extends VListItem = VListItem>(
       // Uses :focus-visible to detect keyboard focus — no extra listeners needed.
       const onFocusIn = (): void => {
         if (ctx.state.isDestroyed) return;
-        if (!dom.root.matches(":focus-visible")) return;
+        const owner = activeOwner();
+        if (!owner.matches(":focus-visible") && !dom.root.matches(":focus-visible")) return;
 
         const totalItems = ctx.dataManager.getTotal();
         if (totalItems === 0) return;
@@ -532,7 +535,7 @@ export const withSelection = <T extends VListItem = VListItem>(
         setFocus(idx);
         selectionState.focusVisible = true;
 
-        dom.root.setAttribute(
+        owner.setAttribute(
           "aria-activedescendant",
           `${ariaIdPrefix}-item-${idx}`,
         );
@@ -563,7 +566,7 @@ export const withSelection = <T extends VListItem = VListItem>(
         const prevIdx = selectionState.focusedIndex;
         selectionState.focusVisible = false;
 
-        dom.root.removeAttribute("aria-activedescendant");
+        activeOwner().removeAttribute("aria-activedescendant");
 
         // Remove the focused class from the previously focused item
         if (prevIdx >= 0) {
@@ -594,7 +597,7 @@ export const withSelection = <T extends VListItem = VListItem>(
         setFocus(index);
         selectionState.focusVisible = focusOnClick;
         lastSelectedIndex = index;
-        dom.root.setAttribute("aria-activedescendant", `${ariaIdPrefix}-item-${index}`);
+        activeOwner().setAttribute("aria-activedescendant", `${ariaIdPrefix}-item-${index}`);
       };
 
       // ── Click handler ──
@@ -888,12 +891,12 @@ export const withSelection = <T extends VListItem = VListItem>(
           if (newFocusIndex >= 0) {
             scrollToFocus(newFocusIndex);
 
-            dom.root.setAttribute(
+            activeOwner().setAttribute(
               "aria-activedescendant",
               `${ariaIdPrefix}-item-${newFocusIndex}`,
             );
           } else {
-            dom.root.removeAttribute("aria-activedescendant");
+            activeOwner().removeAttribute("aria-activedescendant");
           }
 
           if (focusOnly) {
@@ -1065,7 +1068,7 @@ export const withSelection = <T extends VListItem = VListItem>(
         setFocus(index);
         selectionState.focusVisible = true;
         scrollToFocus(index);
-        dom.root.setAttribute("aria-activedescendant", `${ariaIdPrefix}-item-${index}`);
+        activeOwner().setAttribute("aria-activedescendant", `${ariaIdPrefix}-item-${index}`);
         ctx.renderIfNeeded();
       });
 

--- a/src/features/table/feature.ts
+++ b/src/features/table/feature.ts
@@ -184,14 +184,18 @@ export const withTable = <T extends VListItem = VListItem>(
       config.columnBorders && dom.root.classList.add(`${classPrefix}--table-col-borders`);
       // ARIA: promote root to grid so both the header and body rowgroups
       // are contained within the required parent role.
+      if (resolvedConfig.interactive) {
+        dom.root.setAttribute("tabindex", "0");
+        dom.items.removeAttribute("tabindex");
+      }
       dom.root.setAttribute("role", "grid");
       dom.root.setAttribute("aria-colcount", `${config.columns.length}`);
       // aria-rowcount includes the header row (+1); updated in render loop
       // when item count changes. Initial value uses current total.
       let lastAriaRowCount = -1;
 
-      // Move aria-label from items (where dom.ts sets it on listbox) to root
-      const ariaLabel = dom.items.getAttribute("aria-label");
+      // Move aria-label from the listbox owner to the grid root.
+      const ariaLabel = dom.root.getAttribute("aria-label") ?? dom.items.getAttribute("aria-label");
       if (ariaLabel) {
         dom.root.setAttribute("aria-label", ariaLabel);
         dom.items.removeAttribute("aria-label");
@@ -703,6 +707,7 @@ export const withTable = <T extends VListItem = VListItem>(
         // Restore ARIA roles to pre-table state
         dom.root.removeAttribute("role");
         dom.root.removeAttribute("aria-colcount");
+        dom.root.removeAttribute("tabindex");
         dom.viewport.removeAttribute("role");
         dom.viewport.setAttribute("tabindex", "-1");
         dom.content.removeAttribute("role");
@@ -713,6 +718,7 @@ export const withTable = <T extends VListItem = VListItem>(
         }
         dom.root.removeAttribute("aria-rowcount");
         dom.items.setAttribute("role", "listbox");
+        if (resolvedConfig.interactive) dom.items.setAttribute("tabindex", "0");
       });
     },
 

--- a/src/features/table/renderer.ts
+++ b/src/features/table/renderer.ts
@@ -464,7 +464,7 @@ export const createTableRenderer = <T extends VListItem = VListItem>(
 
     // ARIA attributes
     setRowAttrs(element, "row", item.id, index);
-    element.id = `${ariaIdPrefix}-${index}`;
+    element.id = `${ariaIdPrefix}-item-${index}`;
     element.setAttribute("aria-rowindex", String(index + 2)); // +2: header is row 1
 
     setAriaSelected(element, isSelected);

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -747,7 +747,6 @@ export const createDOMStructure = (
   // Root element
   const root = document.createElement("div");
   root.className = `${classPrefix}`;
-  if (interactive !== false) root.setAttribute("tabindex", "0");
 
   if (horizontal) {
     root.classList.add(`${classPrefix}--horizontal`);
@@ -784,6 +783,7 @@ export const createDOMStructure = (
   const items = document.createElement("div");
   items.className = `${classPrefix}-items`;
   items.setAttribute("role", "listbox");
+  if (interactive !== false) items.setAttribute("tabindex", "0");
   if (ariaLabel) items.setAttribute("aria-label", ariaLabel);
   if (horizontal) items.setAttribute("aria-orientation", "horizontal");
   items.style.position = "relative";

--- a/test/builder/context.test.ts
+++ b/test/builder/context.test.ts
@@ -538,7 +538,7 @@ describe("createBuilderContext", () => {
           wrap: false,
           horizontal: true,
           ariaIdPrefix: "vlist",
-      interactive: true,
+          interactive: true,
         },
       });
 

--- a/test/builder/core.test.ts
+++ b/test/builder/core.test.ts
@@ -1064,6 +1064,7 @@ describe("builder/core — core baseline single-select", () => {
 
     const root = list.element;
     const items = () => root.querySelector("[role='listbox']")!;
+    const activeOwner = () => items();
 
     // Controllable :focus-visible stub (JSDOM doesn't support it)
     let focusVisibleOverride = true;
@@ -1105,7 +1106,7 @@ describe("builder/core — core baseline single-select", () => {
     const ariaSelected = (index: number) =>
       itemEl(index)?.getAttribute("aria-selected");
 
-    return { list, root, focusIn, focusOut, fireKey, clickItem, itemEl, hasClass, ariaSelected, setFocusVisible };
+    return { list, root, activeOwner, focusIn, focusOut, fireKey, clickItem, itemEl, hasClass, ariaSelected, setFocusVisible };
   };
 
   // ── Smoke / no-throw ─────────────────────────────────────────────
@@ -1128,25 +1129,25 @@ describe("builder/core — core baseline single-select", () => {
   // ── ARIA activedescendant ────────────────────────────────────────
 
   it("should set aria-activedescendant on focusin with focus-visible", () => {
-    const { list, root, focusIn } = setup();
+    const { list, activeOwner, focusIn } = setup();
 
     focusIn();
-    expect(root.getAttribute("aria-activedescendant")).toMatch(/item-0$/);
+    expect(activeOwner().getAttribute("aria-activedescendant")).toMatch(/item-0$/);
 
     list.destroy();
   });
 
   it("should clear aria-activedescendant on focusout to external target", () => {
-    const { list, root, focusIn, focusOut } = setup();
+    const { list, activeOwner, focusIn, focusOut } = setup();
 
     focusIn();
-    expect(root.getAttribute("aria-activedescendant")).toBeTruthy();
+    expect(activeOwner().getAttribute("aria-activedescendant")).toBeTruthy();
 
     const external = document.createElement("button");
     document.body.appendChild(external);
     focusOut(external);
 
-    expect(root.getAttribute("aria-activedescendant")).toBeNull();
+    expect(activeOwner().getAttribute("aria-activedescendant")).toBeNull();
 
     list.destroy();
   });
@@ -1154,22 +1155,22 @@ describe("builder/core — core baseline single-select", () => {
   // ── Arrow keys move focus only (no selection) ────────────────────
 
   it("should navigate with ArrowDown/ArrowUp/Home/End after focus", () => {
-    const { list, root, focusIn, fireKey } = setup();
+    const { list, activeOwner, focusIn, fireKey } = setup();
 
     focusIn();
-    expect(root.getAttribute("aria-activedescendant")).toMatch(/item-0$/);
+    expect(activeOwner().getAttribute("aria-activedescendant")).toMatch(/item-0$/);
 
     fireKey("ArrowDown");
-    expect(root.getAttribute("aria-activedescendant")).toMatch(/item-1$/);
+    expect(activeOwner().getAttribute("aria-activedescendant")).toMatch(/item-1$/);
 
     fireKey("ArrowUp");
-    expect(root.getAttribute("aria-activedescendant")).toMatch(/item-0$/);
+    expect(activeOwner().getAttribute("aria-activedescendant")).toMatch(/item-0$/);
 
     fireKey("Home");
-    expect(root.getAttribute("aria-activedescendant")).toMatch(/item-0$/);
+    expect(activeOwner().getAttribute("aria-activedescendant")).toMatch(/item-0$/);
 
     fireKey("End");
-    expect(root.getAttribute("aria-activedescendant")).toMatch(/item-19$/);
+    expect(activeOwner().getAttribute("aria-activedescendant")).toMatch(/item-19$/);
 
     list.destroy();
   });
@@ -1195,25 +1196,25 @@ describe("builder/core — core baseline single-select", () => {
   // ── No wrapping ──────────────────────────────────────────────────
 
   it("should not wrap ArrowUp past first item", () => {
-    const { list, root, focusIn, fireKey } = setup();
+    const { list, activeOwner, focusIn, fireKey } = setup();
 
     focusIn(); // focus item 0
     fireKey("ArrowUp"); // should stay at 0
 
-    expect(root.getAttribute("aria-activedescendant")).toMatch(/item-0$/);
+    expect(activeOwner().getAttribute("aria-activedescendant")).toMatch(/item-0$/);
 
     list.destroy();
   });
 
   it("should not wrap ArrowDown past last item", () => {
-    const { list, root, focusIn, fireKey } = setup(5);
+    const { list, activeOwner, focusIn, fireKey } = setup(5);
 
     focusIn();
     fireKey("End"); // focus item 4
-    expect(root.getAttribute("aria-activedescendant")).toMatch(/item-4$/);
+    expect(activeOwner().getAttribute("aria-activedescendant")).toMatch(/item-4$/);
 
     fireKey("ArrowDown"); // should stay at 4
-    expect(root.getAttribute("aria-activedescendant")).toMatch(/item-4$/);
+    expect(activeOwner().getAttribute("aria-activedescendant")).toMatch(/item-4$/);
 
     list.destroy();
   });
@@ -1395,16 +1396,16 @@ describe("builder/core — core baseline single-select", () => {
   // ── PageUp / PageDown ────────────────────────────────────────────
 
   it("should move focus by page on PageDown/PageUp", () => {
-    const { list, root, focusIn, fireKey } = setup(100);
+    const { list, activeOwner, focusIn, fireKey } = setup(100);
 
     focusIn(); // focus item 0
 
     // Container 600px / item 40px = 15 items per page
     fireKey("PageDown");
-    expect(root.getAttribute("aria-activedescendant")).toMatch(/item-15$/);
+    expect(activeOwner().getAttribute("aria-activedescendant")).toMatch(/item-15$/);
 
     fireKey("PageUp");
-    expect(root.getAttribute("aria-activedescendant")).toMatch(/item-0$/);
+    expect(activeOwner().getAttribute("aria-activedescendant")).toMatch(/item-0$/);
 
     list.destroy();
   });
@@ -1412,7 +1413,7 @@ describe("builder/core — core baseline single-select", () => {
   // ── Focusout preserves state for re-focus ────────────────────────
 
   it("should restore focus position on re-focus after blur", () => {
-    const { list, root, focusIn, focusOut, fireKey } = setup();
+    const { list, activeOwner, focusIn, focusOut, fireKey } = setup();
 
     focusIn();
     fireKey("ArrowDown");
@@ -1421,11 +1422,11 @@ describe("builder/core — core baseline single-select", () => {
     const external = document.createElement("button");
     document.body.appendChild(external);
     focusOut(external);
-    expect(root.getAttribute("aria-activedescendant")).toBeNull();
+    expect(activeOwner().getAttribute("aria-activedescendant")).toBeNull();
 
     // Re-focus — should resume at item 2
     focusIn();
-    expect(root.getAttribute("aria-activedescendant")).toMatch(/item-2$/);
+    expect(activeOwner().getAttribute("aria-activedescendant")).toMatch(/item-2$/);
 
     list.destroy();
   });

--- a/test/builder/dom.test.ts
+++ b/test/builder/dom.test.ts
@@ -98,13 +98,14 @@ describe("createDOMStructure", () => {
     expect(items.className).toBe("my-list-items");
   });
 
-  it("should set listbox role on items and tabindex on root", () => {
+  it("should set listbox role and tabindex on items", () => {
     const container = document.createElement("div");
     const { root, items } = createDOMStructure(container, "vlist");
 
     expect(root.getAttribute("role")).toBeNull();
-    expect(root.getAttribute("tabindex")).toBe("0");
+    expect(root.getAttribute("tabindex")).toBeNull();
     expect(items.getAttribute("role")).toBe("listbox");
+    expect(items.getAttribute("tabindex")).toBe("0");
   });
 
   it("should add aria-label when provided", () => {

--- a/test/builder/index.test.ts
+++ b/test/builder/index.test.ts
@@ -470,7 +470,7 @@ describe("builder core", () => {
     list = null;
   });
 
-  it("should set ARIA attributes on items container and tabindex on root", () => {
+  it("should set ARIA attributes and tabindex on items container", () => {
     list = vlist<TestItem>({
       container,
       item: { height: 40, template },
@@ -482,7 +482,8 @@ describe("builder core", () => {
     expect(items).not.toBeNull();
     expect(items!.getAttribute("role")).toBe("listbox");
     expect(items!.getAttribute("aria-label")).toBe("Test list");
-    expect(list.element.getAttribute("tabindex")).toBe("0");
+    expect(items!.getAttribute("tabindex")).toBe("0");
+    expect(list.element.getAttribute("tabindex")).toBeNull();
   });
 
   it("should set ARIA attributes on rendered items", () => {
@@ -5760,7 +5761,9 @@ describe("withSelection plugin keyboard navigation", () => {
 
     // aria-activedescendant should point to last item (index 19)
     // Note: The last item may not be rendered due to virtual scrolling
-    const activeDescendant = list.element.getAttribute("aria-activedescendant");
+    const activeDescendant = list.element
+      .querySelector(".vlist-items")!
+      .getAttribute("aria-activedescendant");
     expect(activeDescendant).toContain("item-19");
   });
 
@@ -5885,7 +5888,9 @@ describe("withSelection plugin keyboard navigation", () => {
     }
 
     // aria-activedescendant should be set
-    const activeDescendant = list.element.getAttribute("aria-activedescendant");
+    const activeDescendant = list.element
+      .querySelector(".vlist-items")!
+      .getAttribute("aria-activedescendant");
     expect(activeDescendant).toContain("item-3");
   });
 

--- a/test/builder/index.test.ts
+++ b/test/builder/index.test.ts
@@ -515,6 +515,42 @@ describe("builder core", () => {
     expect(liveRegion!.getAttribute("role")).toBe("status");
   });
 
+  it("should not announce visible range changes by default", async () => {
+    list = vlist<TestItem>({
+      container,
+      item: { height: 40, template },
+      items: createTestItems(100),
+    }).build();
+
+    const liveRegion = list.element.querySelector(".vlist-live");
+    expect(liveRegion).not.toBeNull();
+
+    simulateScroll(list, 800);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(liveRegion!.textContent).toBe("");
+  });
+
+  it("should announce visible range changes when opted in", async () => {
+    list = vlist<TestItem>({
+      container,
+      item: { height: 40, template },
+      items: createTestItems(100),
+      accessibility: {
+        announceVisibleRange: true,
+        rangeAnnouncementDebounce: 5,
+      },
+    }).build();
+
+    const liveRegion = list.element.querySelector(".vlist-live");
+    expect(liveRegion).not.toBeNull();
+
+    simulateScroll(list, 800);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(liveRegion!.textContent).toMatch(/^Showing items \d+ to \d+ of 100$/);
+  });
+
   it("should re-render when scrolling through the list", () => {
     const items = createTestItems(500);
     list = vlist<TestItem>({

--- a/test/features/selection/feature.test.ts
+++ b/test/features/selection/feature.test.ts
@@ -971,7 +971,7 @@ describe("withSelection — focusin handler", () => {
     const focusEvent = new (dom.window as any).FocusEvent("focusin", { bubbles: true });
     ctx.dom.root.dispatchEvent(focusEvent);
 
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBe("vlist-item-0");
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBe("vlist-item-0");
     // scrollToFocus uses scroll-if-needed: item 0 at scroll position 0 is
     // already visible, so no scroll is performed. We only assert that the
     // focus class update happened.
@@ -1022,7 +1022,7 @@ describe("withSelection — focusin handler", () => {
     const focusEvent = new (dom.window as any).FocusEvent("focusin", { bubbles: true });
     ctx.dom.root.dispatchEvent(focusEvent);
 
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBeNull();
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBeNull();
   });
 });
 
@@ -1045,7 +1045,7 @@ describe("withSelection — focusout handler", () => {
       new (dom.window as any).FocusEvent("focusin", { bubbles: true }),
     );
 
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBe("vlist-item-0");
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBe("vlist-item-0");
 
     // Now blur — relatedTarget outside the root
     const outsideElement = document.createElement("button");
@@ -1059,7 +1059,7 @@ describe("withSelection — focusout handler", () => {
       }),
     );
 
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBeNull();
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBeNull();
     expect(updateClassesSpy).toHaveBeenCalled();
 
     outsideElement.remove();
@@ -1093,7 +1093,7 @@ describe("withSelection — focusout handler", () => {
     );
 
     // Should still have aria-activedescendant since focus stayed inside
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBe("vlist-item-0");
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBe("vlist-item-0");
   });
 
   it("should not throw when destroyed", () => {
@@ -1130,7 +1130,7 @@ describe("withSelection — keyboard edge cases", () => {
     arrowDown.preventDefault = mock(() => {});
     ctx.keydownHandlers[0]!(arrowDown);
 
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBe("vlist-item-0");
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBe("vlist-item-0");
 
     // ArrowUp at index 0 with wrap=false — focus stays at 0
     const arrowUp = new (dom.window as any).KeyboardEvent("keydown", {
@@ -1141,7 +1141,7 @@ describe("withSelection — keyboard edge cases", () => {
     ctx.keydownHandlers[0]!(arrowUp);
 
     // Focus clamped at 0, aria-activedescendant unchanged
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBe("vlist-item-0");
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBe("vlist-item-0");
   });
 
   it("should not scroll when totalItems is 0", () => {
@@ -1677,7 +1677,7 @@ describe("withSelection — group header skipping", () => {
   it("focusin should skip header at index 0 and land on index 1", () => {
     const { ctx, focusIn } = setupGrouped();
     focusIn();
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBe("vlist-item-1");
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBe("vlist-item-1");
   });
 
   // ── ArrowDown ────────────────────────────────────────────────
@@ -1686,10 +1686,10 @@ describe("withSelection — group header skipping", () => {
     const { ctx, focusIn, fireKey } = setupGrouped();
     focusIn(); // → index 1
     fireKey("ArrowDown"); // → index 2
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBe("vlist-item-2");
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBe("vlist-item-2");
 
     fireKey("ArrowDown"); // would land on 3 (header) → skip to 4
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBe("vlist-item-4");
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBe("vlist-item-4");
   });
 
   // ── ArrowUp ──────────────────────────────────────────────────
@@ -1700,7 +1700,7 @@ describe("withSelection — group header skipping", () => {
     fireKey("ArrowDown"); // → 2
     fireKey("ArrowDown"); // → 4 (skipped 3)
     fireKey("ArrowUp"); // would land on 3 (header) → skip to 2
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBe("vlist-item-2");
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBe("vlist-item-2");
   });
 
   // ── Home / End ───────────────────────────────────────────────
@@ -1710,14 +1710,14 @@ describe("withSelection — group header skipping", () => {
     focusIn(); // → 1
     fireKey("ArrowDown"); // → 2
     fireKey("Home"); // would land on 0 (header) → skip to 1
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBe("vlist-item-1");
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBe("vlist-item-1");
   });
 
   it("End should land on last non-header item", () => {
     const { ctx, focusIn, fireKey } = setupGrouped();
     focusIn(); // → 1
     fireKey("End"); // index 7 (not a header)
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBe("vlist-item-7");
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBe("vlist-item-7");
   });
 
   // ── PageDown / PageUp ────────────────────────────────────────
@@ -1730,7 +1730,7 @@ describe("withSelection — group header skipping", () => {
     ctx.state.viewportState.containerSize = 150; // pageSize = 3
     focusIn(); // → 1
     fireKey("PageDown"); // 1+3=4 → not a header → lands on 4
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBe("vlist-item-4");
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBe("vlist-item-4");
   });
 
   // ── Click ────────────────────────────────────────────────────
@@ -1854,7 +1854,7 @@ describe("withSelection — group header skipping", () => {
     ctx.dom.root.matches = orig;
 
     // Should land on index 0 (no skipping)
-    expect(ctx.dom.root.getAttribute("aria-activedescendant")).toBe("vlist-item-0");
+    expect(ctx.dom.items.getAttribute("aria-activedescendant")).toBe("vlist-item-0");
   });
 
   // ── followFocus with headers ─────────────────────────────────

--- a/test/features/table/renderer.test.ts
+++ b/test/features/table/renderer.test.ts
@@ -275,10 +275,10 @@ describe("render", () => {
     expect((rows[0] as HTMLElement).getAttribute("data-id")).toBe("0");
     expect((rows[0] as HTMLElement).getAttribute("data-index")).toBe("0");
     expect((rows[0] as HTMLElement).getAttribute("aria-rowindex")).toBe("2"); // +2 for header
-    expect((rows[0] as HTMLElement).id).toBe("vlist-0");
+    expect((rows[0] as HTMLElement).id).toBe("vlist-item-0");
 
     expect((rows[1] as HTMLElement).getAttribute("aria-rowindex")).toBe("3");
-    expect((rows[1] as HTMLElement).id).toBe("vlist-1");
+    expect((rows[1] as HTMLElement).id).toBe("vlist-item-1");
 
     container.remove();
   });

--- a/test/integration/features.test.ts
+++ b/test/integration/features.test.ts
@@ -2688,6 +2688,41 @@ describe("integration — async + table", () => {
     const selected = (list as any).getSelected();
     expect(selected.length).toBe(1);
   });
+
+  it("should point aria-activedescendant at an existing table row", async () => {
+    const adapter = createMockAdapter(200);
+    list = vlist<TestItem>({
+      container,
+      item: { height: 40, template },
+    })
+      .use(withAsync({ adapter }))
+      .use(withTable({ columns: tableColumns, rowHeight: 40, headerHeight: 40 }))
+      .use(withSelection({ mode: "single" }))
+      .build();
+
+    await flush();
+
+    const root = list.element;
+    const origMatches = root.matches;
+    root.matches = (selector: string) =>
+      selector === ":focus-visible" ? true : origMatches.call(root, selector);
+
+    root.dispatchEvent(new dom.window.Event("focusin", { bubbles: true }));
+
+    let activeDescendant = root.getAttribute("aria-activedescendant");
+    expect(activeDescendant).toBeTruthy();
+    expect(root.querySelector(`#${activeDescendant}`)).not.toBeNull();
+
+    root.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+    );
+
+    activeDescendant = root.getAttribute("aria-activedescendant");
+    expect(activeDescendant).toBeTruthy();
+    expect(root.querySelector(`#${activeDescendant}`)).not.toBeNull();
+
+    root.matches = origMatches;
+  });
 });
 
 // =============================================================================
@@ -2722,7 +2757,10 @@ describe("integration — baseline a11y click vs keyboard scroll", () => {
   };
 
   const getFocusedIndex = (root: HTMLElement): number => {
-    const attr = root.getAttribute("aria-activedescendant");
+    const owner = root.getAttribute("role") === "grid"
+      ? root
+      : root.querySelector(".vlist-items") as HTMLElement | null;
+    const attr = owner?.getAttribute("aria-activedescendant");
     if (!attr) return -1;
     const match = attr.match(/item-(\d+)$/);
     return match ? parseInt(match[1], 10) : -1;

--- a/test/integration/grid-masonry-nav.test.ts
+++ b/test/integration/grid-masonry-nav.test.ts
@@ -171,7 +171,10 @@ const clickItem = (list: VList<any>, index: number) => {
 
 /** Extract the focused item index from aria-activedescendant (format: vlist-N-item-{index}) */
 const getFocusedIndex = (root: HTMLElement): number => {
-  const attr = root.getAttribute("aria-activedescendant");
+  const owner = root.getAttribute("role") === "grid"
+    ? root
+    : root.querySelector<HTMLElement>(".vlist-items") ?? root;
+  const attr = owner.getAttribute("aria-activedescendant");
   if (!attr) return -1;
   const match = attr.match(/item-(\d+)$/);
   return match ? parseInt(match[1], 10) : -1;

--- a/test/integration/scale-keyboard-nav.test.ts
+++ b/test/integration/scale-keyboard-nav.test.ts
@@ -169,7 +169,10 @@ const pressKey = (
 
 /** Extract the focused item index from aria-activedescendant */
 const getFocusedIndex = (root: HTMLElement): number => {
-  const attr = root.getAttribute("aria-activedescendant");
+  const owner = root.getAttribute("role") === "grid"
+    ? root
+    : root.querySelector<HTMLElement>(".vlist-items") ?? root;
+  const attr = owner.getAttribute("aria-activedescendant");
   if (!attr) return -1;
   const match = attr.match(/item-(\d+)$/);
   return match ? parseInt(match[1], 10) : -1;

--- a/test/rendering/renderer.test.ts
+++ b/test/rendering/renderer.test.ts
@@ -495,8 +495,9 @@ describe("createDOMStructure", () => {
     );
 
     expect(root.className).toBe("vlist");
-    expect(root.getAttribute("tabindex")).toBe("0");
+    expect(root.getAttribute("tabindex")).toBeNull();
     expect(items.getAttribute("role")).toBe("listbox");
+    expect(items.getAttribute("tabindex")).toBe("0");
     expect(viewport.className).toBe("vlist-viewport");
     expect(content.className).toBe("vlist-content");
     expect(items.className).toBe("vlist-items");


### PR DESCRIPTION
## Summary

- **fix(a11y):** Align `aria-activedescendant` with ARIA role owner — move `tabindex="0"` to the `role="listbox"` element, unify table row ID format
- **fix(a11y):** Make visible range announcements opt-in via `accessibility.announceVisibleRange`
- Base bundle: 10.8 KB gzipped

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 3,373 pass, 0 fail
- [x] `bun run size` — all 13 tree-shaking scenarios clean