### PR TITLE
v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ This changelog starts at v1.5.4, the first version published under the `vlist` p
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-05-13
+
+### Added
+
+- **table**: Keyboard support for header sort and resize — header cells are navigable with roving tabindex, Enter/Space triggers sort, Ctrl+Arrow resizes columns, Home/End jumps to first/last header, ArrowDown returns focus to grid body.
+
+### Fixed
+
+- **a11y**: Downgrade ARIA roles when `interactive: false` — use `role="list"` / `role="listitem"` instead of `role="listbox"` / `role="option"` so screen readers don't announce items as selectable options in display-only lists. `aria-setsize` and `aria-posinset` are preserved for positional context.
+
 ## [1.7.9] - 2026-05-13
 
 ### Fixed
@@ -270,7 +280,8 @@ This changelog starts at v1.5.4, the first version published under the `vlist` p
 
 - **selection**: Implement ARIA multi-select keyboard model with configurable shiftArrowToggle
 
-[Unreleased]: https://github.com/floor/vlist/compare/v1.7.9...HEAD
+[Unreleased]: https://github.com/floor/vlist/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/floor/vlist/compare/v1.7.9...v1.8.0
 [1.7.9]: https://github.com/floor/vlist/compare/v1.7.8...v1.7.9
 [1.7.8]: https://github.com/floor/vlist/compare/v1.7.7...v1.7.8
 [1.7.7]: https://github.com/floor/vlist/compare/v1.7.6...v1.7.7

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The virtual list library for every framework. Accessible by default, batteries-included, with composable features — in 10.8 KB.
 
-**v1.7.9** — [Changelog](./CHANGELOG.md)
+**v1.8.0** — [Changelog](./CHANGELOG.md)
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![CI](https://github.com/floor/vlist/actions/workflows/ci.yml/badge.svg)](https://github.com/floor/vlist/actions/workflows/ci.yml)
@@ -98,12 +98,12 @@ const list = vlist({
 | `withAsync()` | +4.4 KB | Lazy loading with velocity-aware fetching |
 | `withSelection()` | +3.0 KB | Single/multiple selection with 2D keyboard nav |
 | `withScale()` | +3.6 KB | 1M+ items via scroll compression |
-| `withGroups()` | +4.4 KB | Sticky/inline headers with async group discovery |
+| `withGroups()` | +4.5 KB | Sticky/inline headers with async group discovery |
 | `withAutoSize()` | +0.9 KB | Auto-measure items via ResizeObserver |
 | `withScrollbar()` | +1.8 KB | Custom scrollbar UI |
-| `withGrid()` | +4.0 KB | 2D grid layout |
-| `withMasonry()` | +3.4 KB | Pinterest-style masonry with lane-aware keyboard nav |
-| `withTable()` | +5.5 KB | Data table with columns, resize, sort |
+| `withGrid()` | +4.1 KB | 2D grid layout |
+| `withMasonry()` | +3.5 KB | Pinterest-style masonry with lane-aware keyboard nav |
+| `withTable()` | +5.8 KB | Data table with columns, resize, sort |
 | `withPage()` | +0.7 KB | Window-level scrolling |
 | `withSortable()` | +2.9 KB | Drag-and-drop reordering with auto-scroll |
 | `withSnapshots()` | +1.2 KB | Scroll position save/restore |

--- a/npm-readme.md
+++ b/npm-readme.md
@@ -2,7 +2,7 @@
 
 The virtual list library for every framework. Accessible by default, batteries-included, with composable features — in 10.8 KB.
 
-**v1.7.9** — [Changelog](https://github.com/floor/vlist/blob/main/CHANGELOG.md)
+**v1.8.0** — [Changelog](https://github.com/floor/vlist/blob/main/CHANGELOG.md)
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![CI](https://github.com/floor/vlist/actions/workflows/ci.yml/badge.svg)](https://github.com/floor/vlist/actions/workflows/ci.yml)
@@ -60,12 +60,12 @@ const list = vlist({ container: '#app', items, item: { height: 200, template: re
 | `withAsync()` | +4.4 KB | Lazy loading with velocity-aware fetching |
 | `withSelection()` | +3.0 KB | Single/multiple selection with 2D keyboard nav |
 | `withScale()` | +3.6 KB | 1M+ items via scroll compression |
-| `withGroups()` | +4.4 KB | Sticky/inline headers with async group discovery |
+| `withGroups()` | +4.5 KB | Sticky/inline headers with async group discovery |
 | `withAutoSize()` | +0.9 KB | Auto-measure items via ResizeObserver |
 | `withScrollbar()` | +1.8 KB | Custom scrollbar UI |
-| `withGrid()` | +4.0 KB | 2D grid layout |
-| `withMasonry()` | +3.4 KB | Pinterest-style masonry with lane-aware keyboard nav |
-| `withTable()` | +5.5 KB | Data table with columns, resize, sort |
+| `withGrid()` | +4.1 KB | 2D grid layout |
+| `withMasonry()` | +3.5 KB | Pinterest-style masonry with lane-aware keyboard nav |
+| `withTable()` | +5.8 KB | Data table with columns, resize, sort |
 | `withPage()` | +0.7 KB | Window-level scrolling |
 | `withSortable()` | +2.9 KB | Drag-and-drop reordering with auto-scroll |
 | `withSnapshots()` | +1.2 KB | Scroll position save/restore |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "1.7.9",
+  "version": "1.8.0",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/src/builder/context.ts
+++ b/src/builder/context.ts
@@ -266,6 +266,7 @@ export const createBuilderContext = <T extends VListItem = VListItem>(
       rawConfig.item?.striped,
       () => stripeIndexFn,
       aria.getPosInSet,
+      resolvedConfig.interactive,
     );
     renderer = newRenderer;
   };

--- a/src/builder/core.ts
+++ b/src/builder/core.ts
@@ -552,7 +552,7 @@ function materialize<T extends VListItem = VListItem>(
       el.removeAttribute("aria-setsize");
       el.removeAttribute("aria-posinset");
       el.removeAttribute("id");
-    } else {
+    } else if (interactiveMode) {
       el.setAttribute("role", "option");
       if (fresh) {
         el.ariaSelected = "false";
@@ -560,6 +560,14 @@ function materialize<T extends VListItem = VListItem>(
         el.setAttribute("aria-setsize", $.la);
       }
       el.id = `${ariaIdPrefix}-item-${index}`;
+      el.setAttribute("aria-posinset", String(aria.getPosInSet(index)));
+    } else {
+      el.setAttribute("role", "listitem");
+      el.removeAttribute("aria-selected");
+      if (fresh) {
+        $.la = String(aria.getSetSize());
+        el.setAttribute("aria-setsize", $.la);
+      }
       el.setAttribute("aria-posinset", String(aria.getPosInSet(index)));
     }
   };

--- a/src/builder/dom.ts
+++ b/src/builder/dom.ts
@@ -71,7 +71,7 @@ export const createDOMStructure = (
     `${classPrefix}-items`,
     hz ? "position:relative;height:100%" : "position:relative;width:100%",
   );
-  items.setAttribute("role", "listbox");
+  items.setAttribute("role", interactive !== false ? "listbox" : "list");
   if (interactive !== false) items.setAttribute("tabindex", "0");
   if (ariaLabel) items.setAttribute("aria-label", ariaLabel);
   if (hz) items.setAttribute("aria-orientation", "horizontal");

--- a/src/features/grid/feature.ts
+++ b/src/features/grid/feature.ts
@@ -265,6 +265,7 @@ export const withGrid = <T extends VListItem = VListItem>(
           resolvedConfig.ariaIdPrefix,
           resolvedConfig.horizontal,
           aria.getPosInSet,
+          resolvedConfig.interactive,
         );
 
         // ── Replace the list renderer with the grid renderer ──

--- a/src/features/grid/renderer.ts
+++ b/src/features/grid/renderer.ts
@@ -204,6 +204,7 @@ export const createGridRenderer = <T extends VListItem = VListItem>(
   ariaIdPrefix?: string,
   isHorizontal: boolean = false,
   ariaPosInSetGetter?: (layoutIndex: number) => number,
+  interactive?: boolean,
 ): GridRenderer<T> => {
   const pool = createElementPool();
   const rendered = new Map<number, TrackedItem>();
@@ -398,12 +399,25 @@ export const createGridRenderer = <T extends VListItem = VListItem>(
       element.removeAttribute("aria-setsize");
       element.removeAttribute("aria-posinset");
       element.removeAttribute("id");
-    } else {
+    } else if (interactive !== false) {
       element.setAttribute("role", "option");
       element.ariaSelected = String(isSelected);
       if (ariaIdPrefix) {
         element.id = `${ariaIdPrefix}-item-${itemIndex}`;
       }
+      if (totalItemsGetter) {
+        const total = totalItemsGetter();
+        if (total !== lastAriaTotal) {
+          lastAriaTotal = total;
+          lastAriaSetSize = String(total);
+        }
+        element.setAttribute("aria-setsize", lastAriaSetSize);
+        const posInSet = ariaPosInSetGetter ? ariaPosInSetGetter(itemIndex) : itemIndex + 1;
+        element.setAttribute("aria-posinset", String(posInSet));
+      }
+    } else {
+      element.setAttribute("role", "listitem");
+      element.removeAttribute("aria-selected");
       if (totalItemsGetter) {
         const total = totalItemsGetter();
         if (total !== lastAriaTotal) {

--- a/src/features/groups/feature.ts
+++ b/src/features/groups/feature.ts
@@ -341,7 +341,7 @@ export const withGroups = <T extends VListItem = VListItem>(
 function setupStaticPath<T extends VListItem>(
   ctx: BuilderContext<T>,
   config: GroupsFeatureConfig & { header: { height: number; template: (key: string, groupIndex: number) => HTMLElement | string } },
-  resolvedConfig: { horizontal: boolean; classPrefix: string; ariaIdPrefix: string },
+  resolvedConfig: { horizontal: boolean; classPrefix: string; ariaIdPrefix: string; interactive: boolean },
   rawConfig: { item: { height?: any; template: any; striped?: any }; items?: T[] },
   baseSize: number | ((index: number) => number),
   stickyEnabled: boolean,
@@ -456,6 +456,7 @@ function setupStaticPath<T extends VListItem>(
       resolvedConfig.ariaIdPrefix,
       resolvedConfig.horizontal,
       (layoutIndex: number): number => groupLayout.layoutToDataIndex(layoutIndex) + 1,
+      resolvedConfig.interactive,
     );
     replaceGridRenderer(newGridRenderer);
   } else if (getTableLayout && updateTableForGroups) {
@@ -592,7 +593,7 @@ function setupStaticPath<T extends VListItem>(
 function setupAsyncPath<T extends VListItem>(
   ctx: BuilderContext<T>,
   config: GroupsFeatureConfig & { header: { height: number; template: (key: string, groupIndex: number) => HTMLElement | string } },
-  resolvedConfig: { horizontal: boolean; classPrefix: string; ariaIdPrefix: string },
+  resolvedConfig: { horizontal: boolean; classPrefix: string; ariaIdPrefix: string; interactive: boolean },
   rawConfig: { item: { height?: any; template: any; striped?: any }; items?: T[] },
   baseSize: number | ((index: number) => number),
   stickyEnabled: boolean,

--- a/src/features/masonry/feature.ts
+++ b/src/features/masonry/feature.ts
@@ -219,6 +219,7 @@ export const withMasonry = <T extends VListItem = VListItem>(
         aria.getSetSize,
         resolvedConfig.ariaIdPrefix,
         aria.getPosInSet,
+        resolvedConfig.interactive,
       );
 
       // ── Wire updateItemClasses to the masonry renderer ──

--- a/src/features/masonry/renderer.ts
+++ b/src/features/masonry/renderer.ts
@@ -175,6 +175,7 @@ export const createMasonryRenderer = <T extends VListItem = VListItem>(
   totalItemsGetter?: () => number,
   ariaIdPrefix?: string,
   ariaPosInSetGetter?: (layoutIndex: number) => number,
+  interactive?: boolean,
 ): MasonryRenderer<T> => {
   const pool = createElementPool();
   const rendered = new Map<number, TrackedItem>();
@@ -285,12 +286,25 @@ export const createMasonryRenderer = <T extends VListItem = VListItem>(
       element.removeAttribute("aria-setsize");
       element.removeAttribute("aria-posinset");
       element.removeAttribute("id");
-    } else {
+    } else if (interactive !== false) {
       element.setAttribute("role", "option");
       element.ariaSelected = String(isSelected);
       if (ariaIdPrefix) {
         element.id = `${ariaIdPrefix}-item-${itemIndex}`;
       }
+      if (totalItemsGetter) {
+        const total = totalItemsGetter();
+        if (total !== lastAriaTotal) {
+          lastAriaTotal = total;
+          lastAriaSetSize = String(total);
+        }
+        element.setAttribute("aria-setsize", lastAriaSetSize);
+        const posInSet = ariaPosInSetGetter ? ariaPosInSetGetter(itemIndex) : itemIndex + 1;
+        element.setAttribute("aria-posinset", String(posInSet));
+      }
+    } else {
+      element.setAttribute("role", "listitem");
+      element.removeAttribute("aria-selected");
       if (totalItemsGetter) {
         const total = totalItemsGetter();
         if (total !== lastAriaTotal) {

--- a/src/features/table/feature.ts
+++ b/src/features/table/feature.ts
@@ -717,7 +717,7 @@ export const withTable = <T extends VListItem = VListItem>(
           dom.root.removeAttribute("aria-label");
         }
         dom.root.removeAttribute("aria-rowcount");
-        dom.items.setAttribute("role", "listbox");
+        dom.items.setAttribute("role", resolvedConfig.interactive ? "listbox" : "list");
         if (resolvedConfig.interactive) dom.items.setAttribute("tabindex", "0");
       });
     },

--- a/src/features/table/header.ts
+++ b/src/features/table/header.ts
@@ -48,6 +48,9 @@ import type {
 /** Minimum drag distance (px) before resize is committed */
 const MIN_DRAG_DELTA = 1;
 
+/** Keyboard resize step in pixels */
+const RESIZE_STEP = 10;
+
 /** Sort indicator characters */
 const SORT_ASC = "\u25B2"; // ▲
 const SORT_DESC = "\u25BC"; // ▼
@@ -125,6 +128,9 @@ export const createTableHeader = <T extends VListItem = VListItem>(
   let dragStartX = 0;
   let dragStartWidth = 0;
 
+  // Keyboard focus state (roving tabindex)
+  let focusedCellIndex = 0;
+
   // =========================================================================
   // Cell Creation
   // =========================================================================
@@ -137,6 +143,7 @@ export const createTableHeader = <T extends VListItem = VListItem>(
     cell.className = `${classPrefix}-table-header-cell`;
     cell.setAttribute("role", "columnheader");
     cell.setAttribute("aria-colindex", String(colIndex + 1));
+    cell.setAttribute("tabindex", colIndex === 0 ? "0" : "-1");
     cell.dataset.columnKey = col.def.key;
 
     // Alignment modifier class (left is the default — no class needed)
@@ -421,11 +428,109 @@ export const createTableHeader = <T extends VListItem = VListItem>(
   };
 
   // =========================================================================
+  // Keyboard Navigation (roving tabindex on header cells)
+  // =========================================================================
+
+  const moveFocusToCell = (index: number): void => {
+    if (index < 0 || index >= cells.length) return;
+    cells[focusedCellIndex]?.setAttribute("tabindex", "-1");
+    focusedCellIndex = index;
+    const cell = cells[focusedCellIndex]!;
+    cell.setAttribute("tabindex", "0");
+    cell.focus();
+  };
+
+  const onKeyDown = (e: KeyboardEvent): void => {
+    const key = e.key;
+
+    if (key === "ArrowRight") {
+      if (e.ctrlKey || e.metaKey) {
+        // Ctrl+Right: resize column wider
+        if (!currentLayout) return;
+        const col = currentLayout.getColumn(focusedCellIndex);
+        if (col?.resizable) {
+          onResize(focusedCellIndex, col.width + RESIZE_STEP);
+          e.preventDefault();
+        }
+      } else {
+        // Move focus to next header cell
+        if (focusedCellIndex < cells.length - 1) {
+          moveFocusToCell(focusedCellIndex + 1);
+          e.preventDefault();
+        }
+      }
+      e.stopPropagation();
+      return;
+    }
+
+    if (key === "ArrowLeft") {
+      if (e.ctrlKey || e.metaKey) {
+        // Ctrl+Left: resize column narrower
+        if (!currentLayout) return;
+        const col = currentLayout.getColumn(focusedCellIndex);
+        if (col?.resizable) {
+          onResize(focusedCellIndex, col.width - RESIZE_STEP);
+          e.preventDefault();
+        }
+      } else {
+        // Move focus to previous header cell
+        if (focusedCellIndex > 0) {
+          moveFocusToCell(focusedCellIndex - 1);
+          e.preventDefault();
+        }
+      }
+      e.stopPropagation();
+      return;
+    }
+
+    if (key === "Home") {
+      moveFocusToCell(0);
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+
+    if (key === "End") {
+      moveFocusToCell(cells.length - 1);
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+
+    if (key === "Enter" || key === " ") {
+      // Trigger sort on sortable columns
+      if (!currentLayout) return;
+      const col = currentLayout.getColumn(focusedCellIndex);
+      if (col?.def.sortable && onSort) {
+        let direction: "asc" | "desc" | null;
+        if (currentSortKey === col.def.key) {
+          direction = currentSortDirection === "asc" ? "desc" : null;
+        } else {
+          direction = "asc";
+        }
+        onSort({ key: col.def.key, index: focusedCellIndex, direction });
+        e.preventDefault();
+      }
+      e.stopPropagation();
+      return;
+    }
+
+    if (key === "ArrowDown") {
+      // Return focus to the grid body
+      root.focus();
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+  };
+
+  // =========================================================================
   // Event Binding
   // =========================================================================
 
   element.addEventListener("pointerdown", onPointerDown);
   element.addEventListener("click", onCellClick);
+  element.addEventListener("keydown", onKeyDown);
 
   // =========================================================================
   // Visibility
@@ -450,6 +555,7 @@ export const createTableHeader = <T extends VListItem = VListItem>(
   const destroy = (): void => {
     element.removeEventListener("pointerdown", onPointerDown);
     element.removeEventListener("click", onCellClick);
+    element.removeEventListener("keydown", onKeyDown);
 
     // Clear the CSS variable set during setup
     root.style.removeProperty('--vlist-table-header-height');

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -238,6 +238,7 @@ export const createRenderer = <T extends VListItem = VListItem>(
   striped?: boolean | "data" | "even" | "odd",
   stripeIndexFn?: () => (index: number) => number,
   ariaPosInSetGetter?: (layoutIndex: number) => number,
+  interactive?: boolean,
 ): Renderer<T> => {
   const pool = createElementPool("div");
   const rendered = new Map<number, TrackedItem>();
@@ -408,12 +409,25 @@ export const createRenderer = <T extends VListItem = VListItem>(
       element.removeAttribute("aria-setsize");
       element.removeAttribute("aria-posinset");
       element.removeAttribute("id");
-    } else {
+    } else if (interactive !== false) {
       element.setAttribute("role", "option");
       element.ariaSelected = String(isSelected);
       if (ariaIdPrefix) {
         element.id = `${ariaIdPrefix}-item-${index}`;
       }
+      if (totalItemsGetter) {
+        const total = totalItemsGetter();
+        if (total !== lastAriaTotal) {
+          lastAriaTotal = total;
+          lastAriaSetSize = String(total);
+        }
+        element.setAttribute("aria-setsize", lastAriaSetSize);
+        const posInSet = ariaPosInSetGetter ? ariaPosInSetGetter(index) : index + 1;
+        element.setAttribute("aria-posinset", String(posInSet));
+      }
+    } else {
+      element.setAttribute("role", "listitem");
+      element.removeAttribute("aria-selected");
       if (totalItemsGetter) {
         const total = totalItemsGetter();
         if (total !== lastAriaTotal) {
@@ -782,7 +796,7 @@ export const createDOMStructure = (
   // Items container (holds rendered items)
   const items = document.createElement("div");
   items.className = `${classPrefix}-items`;
-  items.setAttribute("role", "listbox");
+  items.setAttribute("role", interactive !== false ? "listbox" : "list");
   if (interactive !== false) items.setAttribute("tabindex", "0");
   if (ariaLabel) items.setAttribute("aria-label", ariaLabel);
   if (horizontal) items.setAttribute("aria-orientation", "horizontal");

--- a/test/builder/dom.test.ts
+++ b/test/builder/dom.test.ts
@@ -108,6 +108,22 @@ describe("createDOMStructure", () => {
     expect(items.getAttribute("tabindex")).toBe("0");
   });
 
+  it("should downgrade to list role when interactive is false", () => {
+    const container = document.createElement("div");
+    const { items } = createDOMStructure(container, "vlist", undefined, false, false);
+
+    expect(items.getAttribute("role")).toBe("list");
+    expect(items.hasAttribute("tabindex")).toBe(false);
+  });
+
+  it("should use listbox role when interactive is true", () => {
+    const container = document.createElement("div");
+    const { items } = createDOMStructure(container, "vlist", undefined, false, true);
+
+    expect(items.getAttribute("role")).toBe("listbox");
+    expect(items.getAttribute("tabindex")).toBe("0");
+  });
+
   it("should add aria-label when provided", () => {
     const container = document.createElement("div");
     const { items } = createDOMStructure(container, "vlist", "My List");

--- a/test/features/table/header.test.ts
+++ b/test/features/table/header.test.ts
@@ -823,6 +823,257 @@ describe("createTableHeader - resize interaction", () => {
 });
 
 // =============================================================================
+// Keyboard Navigation
+// =============================================================================
+
+describe("createTableHeader - keyboard navigation", () => {
+  it("should set tabindex on header cells (first=0, rest=-1)", () => {
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
+    const layout = createResolvedLayout([col("a"), col("b"), col("c")]);
+    header.rebuild(layout);
+
+    const scrollContainer = header.element.firstChild as HTMLElement;
+    expect((scrollContainer.children[0] as HTMLElement).getAttribute("tabindex")).toBe("0");
+    expect((scrollContainer.children[1] as HTMLElement).getAttribute("tabindex")).toBe("-1");
+    expect((scrollContainer.children[2] as HTMLElement).getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("should move focus right with ArrowRight", () => {
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
+    const layout = createResolvedLayout([col("a"), col("b"), col("c")]);
+    header.rebuild(layout);
+
+    const scrollContainer = header.element.firstChild as HTMLElement;
+    const cell0 = scrollContainer.children[0] as HTMLElement;
+    const cell1 = scrollContainer.children[1] as HTMLElement;
+
+    cell0.focus();
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+
+    expect(cell0.getAttribute("tabindex")).toBe("-1");
+    expect(cell1.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("should move focus left with ArrowLeft", () => {
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
+    const layout = createResolvedLayout([col("a"), col("b"), col("c")]);
+    header.rebuild(layout);
+
+    const scrollContainer = header.element.firstChild as HTMLElement;
+    const cell0 = scrollContainer.children[0] as HTMLElement;
+
+    // Move right first, then left
+    cell0.focus();
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+
+    expect(cell0.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("should not move past first cell on ArrowLeft", () => {
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
+    const layout = createResolvedLayout([col("a"), col("b")]);
+    header.rebuild(layout);
+
+    const scrollContainer = header.element.firstChild as HTMLElement;
+    const cell0 = scrollContainer.children[0] as HTMLElement;
+
+    cell0.focus();
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+
+    expect(cell0.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("should not move past last cell on ArrowRight", () => {
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
+    const layout = createResolvedLayout([col("a"), col("b")]);
+    header.rebuild(layout);
+
+    const scrollContainer = header.element.firstChild as HTMLElement;
+    const cell1 = scrollContainer.children[1] as HTMLElement;
+
+    // Move to last cell
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+
+    expect(cell1.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("should jump to first cell on Home", () => {
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
+    const layout = createResolvedLayout([col("a"), col("b"), col("c")]);
+    header.rebuild(layout);
+
+    const scrollContainer = header.element.firstChild as HTMLElement;
+    const cell0 = scrollContainer.children[0] as HTMLElement;
+
+    // Move to last cell first
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
+
+    expect(cell0.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("should jump to last cell on End", () => {
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
+    const layout = createResolvedLayout([col("a"), col("b"), col("c")]);
+    header.rebuild(layout);
+
+    const scrollContainer = header.element.firstChild as HTMLElement;
+    const cell2 = scrollContainer.children[2] as HTMLElement;
+
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+
+    expect(cell2.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("should trigger sort on Enter for sortable columns", () => {
+    const { root } = createTestDOM();
+    const onSort = mock(() => {});
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock(), onSort);
+    const layout = createResolvedLayout([col("name", { sortable: true }), col("value")]);
+    header.rebuild(layout);
+
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+    expect(onSort).toHaveBeenCalledWith({
+      key: "name",
+      index: 0,
+      direction: "asc",
+    });
+  });
+
+  it("should trigger sort on Space for sortable columns", () => {
+    const { root } = createTestDOM();
+    const onSort = mock(() => {});
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock(), onSort);
+    const layout = createResolvedLayout([col("name", { sortable: true })]);
+    header.rebuild(layout);
+
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+
+    expect(onSort).toHaveBeenCalledWith({
+      key: "name",
+      index: 0,
+      direction: "asc",
+    });
+  });
+
+  it("should cycle sort direction via keyboard: asc → desc → null", () => {
+    const { root } = createTestDOM();
+    const sortCalls: any[] = [];
+    const onSort = mock((e: any) => sortCalls.push(e));
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock(), onSort);
+    const layout = createResolvedLayout([col("name", { sortable: true })]);
+    header.rebuild(layout);
+
+    // First Enter: asc
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(sortCalls[0].direction).toBe("asc");
+
+    header.updateSort("name", "asc");
+
+    // Second Enter: desc
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(sortCalls[1].direction).toBe("desc");
+
+    header.updateSort("name", "desc");
+
+    // Third Enter: null (clear)
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(sortCalls[2].direction).toBeNull();
+  });
+
+  it("should not trigger sort on non-sortable columns", () => {
+    const { root } = createTestDOM();
+    const onSort = mock(() => {});
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock(), onSort);
+    const layout = createResolvedLayout([col("name", { sortable: false })]);
+    header.rebuild(layout);
+
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+    expect(onSort).not.toHaveBeenCalled();
+  });
+
+  it("should resize column wider with Ctrl+ArrowRight", () => {
+    const { root } = createTestDOM();
+    const onResize = mock(() => {});
+    const header = createTableHeader<TestItem>(root, 40, "vlist", onResize);
+    const layout = createResolvedLayout([
+      col("name", { width: 200, resizable: true }),
+      col("value", { width: 200 }),
+    ]);
+    header.rebuild(layout);
+
+    header.element.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "ArrowRight",
+      ctrlKey: true,
+      bubbles: true,
+    }));
+
+    expect(onResize).toHaveBeenCalledWith(0, 210);
+  });
+
+  it("should resize column narrower with Ctrl+ArrowLeft", () => {
+    const { root } = createTestDOM();
+    const onResize = mock(() => {});
+    const header = createTableHeader<TestItem>(root, 40, "vlist", onResize);
+    const layout = createResolvedLayout([
+      col("name", { width: 200, resizable: true }),
+      col("value", { width: 200 }),
+    ]);
+    header.rebuild(layout);
+
+    header.element.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "ArrowLeft",
+      ctrlKey: true,
+      bubbles: true,
+    }));
+
+    expect(onResize).toHaveBeenCalledWith(0, 190);
+  });
+
+  it("should not resize non-resizable columns", () => {
+    const { root } = createTestDOM();
+    const onResize = mock(() => {});
+    const header = createTableHeader<TestItem>(root, 40, "vlist", onResize);
+    const layout = createResolvedLayout([
+      col("name", { width: 200, resizable: false }),
+    ]);
+    header.rebuild(layout);
+
+    header.element.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "ArrowRight",
+      ctrlKey: true,
+      bubbles: true,
+    }));
+
+    expect(onResize).not.toHaveBeenCalled();
+  });
+
+  it("should return focus to grid body on ArrowDown", () => {
+    const { root } = createTestDOM();
+    const header = createTableHeader<TestItem>(root, 40, "vlist", mock());
+    const layout = createResolvedLayout([col("a")]);
+    header.rebuild(layout);
+
+    root.focus = mock(() => {});
+
+    header.element.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+
+    expect(root.focus).toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
 // Visibility
 // =============================================================================
 


### PR DESCRIPTION
## Summary
- **feat(table)**: Keyboard support for header sort and resize (#55) — roving tabindex, Enter/Space sort, Ctrl+Arrow resize
- **fix(a11y)**: Downgrade ARIA roles when `interactive: false` (#54) — `role="list"`/`role="listitem"` instead of `role="listbox"`/`role="option"`

## Bundle sizes
- Base: 10.8 KB (unchanged)
- withGrid: +4.1 KB (+0.1)
- withMasonry: +3.5 KB (+0.1)
- withGroups: +4.5 KB (+0.1)
- withTable: +5.8 KB (+0.3)

## Test plan
- [x] 3,390 tests pass (17 new)
- [x] Typecheck passes
- [x] Bundle sizes measured and updated