### PR TITLE
v1.8.3 — fix selection with groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This changelog starts at v1.5.4, the first version published under the `vlist` p
 
 ## [Unreleased]
 
+## [1.8.3] - 2026-05-13
+
+### Fixed
+
+- **selection**: Use data manager `getIndexById` instead of internal `idToIndexMap` — the selection feature maintained its own index map with data-space indices, but `ctx.dataManager.getItem()` expects layout-space indices when `withGroups` wraps the data manager. This caused `selection:change` to emit group headers instead of real items, breaking forms, players, and detail panels.
+- **selection**: Skip group headers in range selection and `selectAll` — `selectItemRange`, `selectAll()`, and Ctrl+A used `getAllLoadedItems()` which includes group header pseudo-items, leaking header IDs (e.g. `__group_header_0`) into the selected set and breaking the Ctrl+A select/deselect toggle.
+
 ## [1.8.2] - 2026-05-13
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The virtual list library for every framework. Accessible by default, batteries-included, with composable features — in 11.0 KB.
 
-**v1.8.2** — [Changelog](./CHANGELOG.md)
+**v1.8.3** — [Changelog](./CHANGELOG.md)
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![CI](https://github.com/floor/vlist/actions/workflows/ci.yml/badge.svg)](https://github.com/floor/vlist/actions/workflows/ci.yml)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/src/features/selection/feature.ts
+++ b/src/features/selection/feature.ts
@@ -243,12 +243,13 @@ export const withSelection = <T extends VListItem = VListItem>(
         else selectOne(id);
       };
 
-      const selectItemRange = (items: T[], fromIndex: number, toIndex: number): void => {
+      const selectItemRange = (fromIndex: number, toIndex: number): void => {
         if (mode !== "multiple") return;
         const start = Math.min(fromIndex, toIndex);
         const end = Math.max(fromIndex, toIndex);
         for (let i = start; i <= end; i++) {
-          const item = items[i];
+          if (isHeader(i)) continue;
+          const item = ctx.dataManager.getItem(i);
           if (item) selected.add(item.id);
         }
       };
@@ -264,7 +265,6 @@ export const withSelection = <T extends VListItem = VListItem>(
         return items;
       };
 
-      // ── ID → index map for O(1) lookups (selection feature only) ──
       // Clean selection after data mutations (removeItem).
       emitter.on("data:change", ({ type, id }) => {
         if (type === "remove") {
@@ -311,20 +311,8 @@ export const withSelection = <T extends VListItem = VListItem>(
       // a full re-render when selection state changes (click, API call).
       const { forceRender: capturedForceRender } = ctx.getRenderFns();
 
-      // ── Shared index/item-by-ID resolvers ──
-      // Uses ctx.dataManager.getIndexById when available (returns layout-space
-      // indices, correct when withGroups wraps the data manager).
-      // Falls back to linear scan for simple data managers without getIndexById.
       const getIndexById = (id: string | number): number => {
-        if (ctx.dataManager.getIndexById) {
-          return ctx.dataManager.getIndexById(id);
-        }
-        const total = ctx.dataManager.getTotal();
-        for (let i = 0; i < total; i++) {
-          const item = ctx.dataManager.getItem(i);
-          if (item && item.id === id) return i;
-        }
-        return -1;
+        return ctx.dataManager.getIndexById(id);
       };
 
       const getItemById = (id: string | number): T | undefined => {
@@ -554,7 +542,7 @@ export const withSelection = <T extends VListItem = VListItem>(
 
         if (mode === "multiple" && event.shiftKey && selectionState.focusedIndex >= 0) {
           const anchor = lastSelectedIndex >= 0 ? lastSelectedIndex : selectionState.focusedIndex;
-          selectItemRange(ctx.getAllLoadedItems(), anchor, index);
+          selectItemRange(anchor, index);
           focusItem(index);
           forceRenderAndEmit();
           return;
@@ -713,8 +701,7 @@ export const withSelection = <T extends VListItem = VListItem>(
             // Shift+Space: range select from lastSelectedIndex to focused (ARIA model)
             if (event.key === " " && event.shiftKey && mode === "multiple" && selectionState.focusedIndex >= 0) {
               if (lastSelectedIndex >= 0) {
-                const items = ctx.getAllLoadedItems();
-                selectItemRange(items, lastSelectedIndex, selectionState.focusedIndex);
+                selectItemRange(lastSelectedIndex, selectionState.focusedIndex);
                 newState = selectionState;
               }
               newState.focusVisible = true;
@@ -738,12 +725,17 @@ export const withSelection = <T extends VListItem = VListItem>(
 
           case "a":
             if ((event.ctrlKey || event.metaKey) && mode === "multiple") {
-              const allItems = ctx.getAllLoadedItems();
-              // If all selected, deselect all; otherwise select all
-              if (selected.size === allItems.length) {
+              const total = ctx.dataManager.getTotal();
+              const dataIds: Array<string | number> = [];
+              for (let i = 0; i < total; i++) {
+                if (isHeader(i)) continue;
+                const item = ctx.dataManager.getItem(i);
+                if (item) dataIds.push(item.id);
+              }
+              if (selected.size === dataIds.length) {
                 selected.clear();
               } else {
-                for (const item of allItems) selected.add(item.id);
+                for (const id of dataIds) selected.add(id);
               }
               newState = selectionState;
               newState.focusVisible = true;
@@ -799,10 +791,8 @@ export const withSelection = <T extends VListItem = VListItem>(
             lastSelectedIndex = newState.focusedIndex;
             focusOnly = false; // trigger full re-render + selection:change event
           } else if (isCtrlHomeEnd) {
-            // Ctrl+Shift+Home/End: select from previous focus to first/last item
-            const items = ctx.getAllLoadedItems();
             const anchor = previousFocusIndex >= 0 ? previousFocusIndex : newState.focusedIndex;
-            selectItemRange(items, anchor, newState.focusedIndex);
+            selectItemRange(anchor, newState.focusedIndex);
             newState = selectionState;
             lastSelectedIndex = newState.focusedIndex;
             focusOnly = false; // trigger full re-render + selection:change event
@@ -905,9 +895,13 @@ export const withSelection = <T extends VListItem = VListItem>(
 
       ctx.methods.set("selectAll", (): void => {
         if (mode !== "multiple") return;
-        const allItems = ctx.getAllLoadedItems();
         selected.clear();
-        for (const item of allItems) selected.add(item.id);
+        const total = ctx.dataManager.getTotal();
+        for (let i = 0; i < total; i++) {
+          if (isHeader(i)) continue;
+          const item = ctx.dataManager.getItem(i);
+          if (item) selected.add(item.id);
+        }
         forceRenderAndEmit();
       });
 

--- a/src/features/selection/feature.ts
+++ b/src/features/selection/feature.ts
@@ -265,56 +265,10 @@ export const withSelection = <T extends VListItem = VListItem>(
       };
 
       // ── ID → index map for O(1) lookups (selection feature only) ──
-      // Incrementally indexed: items are added as they load via the load:end
-      // event, avoiding a full 0..total scan that would generate millions of
-      // placeholders when using sparse/async data.
-      const idToIndexMap = new Map<string | number, number>();
-
-      const rebuildIdIndex = (): void => {
-        idToIndexMap.clear();
-        const total = ctx.dataManager.getTotal();
-        const cached = ctx.dataManager.getCached();
-
-        // Nothing cached — skip entirely (common for async data at setup)
-        if (cached === 0) return;
-
-        // Fast path: all items are in memory (SimpleDataManager or fully cached).
-        // Safe to iterate 0..total without placeholder overhead.
-        if (cached >= total) {
-          for (let i = 0; i < total; i++) {
-            const item = ctx.dataManager.getItem(i);
-            if (item) idToIndexMap.set(item.id, i);
-          }
-          return;
-        }
-
-        // Sparse path: only a fraction of items are loaded. Iterate via
-        // storage loaded ranges to avoid an O(total) scan that would touch
-        // millions of unloaded indices and generate placeholder objects.
-        const storage = ctx.dataManager.getStorage();
-        if (storage && typeof (storage as any).getLoadedRanges === "function") {
-          const ranges = (storage as any).getLoadedRanges() as Array<{ start: number; end: number }>;
-          for (const range of ranges) {
-            for (let i = range.start; i <= range.end; i++) {
-              const item = ctx.dataManager.getItem(i);
-              if (item && !(item as any)._isPlaceholder) {
-                idToIndexMap.set(item.id, i);
-              }
-            }
-          }
-        }
-      };
-
-      // Rebuild index and clean selection after data mutations (removeItem).
-      // Without this, idToIndexMap holds stale indices after items shift,
-      // causing getSelectedItems() to return wrong items.
+      // Clean selection after data mutations (removeItem).
       emitter.on("data:change", ({ type, id }) => {
         if (type === "remove") {
-          // Remove the deleted id from selection state
           selected.delete(id);
-
-          // Rebuild index — all indices after the removed item shifted
-          rebuildIdIndex();
 
           // After removal, focusedIndex may now point to a group header
           // (the item that was below the removed one shifted into its slot).
@@ -326,32 +280,6 @@ export const withSelection = <T extends VListItem = VListItem>(
           }
         }
       });
-
-      // Incrementally index newly loaded items via load:end event.
-      // Items arrive in small batches (25-50) with a known offset, so
-      // indexing is O(batch_size) — no scanning required.
-      emitter.on(
-        "load:end",
-        ({ items: loadedItems, offset }: { items: T[]; offset?: number }) => {
-          if (!loadedItems || loadedItems.length === 0) return;
-
-          if (offset !== undefined) {
-            // Fast path: offset known — direct index assignment
-            for (let i = 0; i < loadedItems.length; i++) {
-              const item = loadedItems[i];
-              if (item && item.id !== undefined) {
-                idToIndexMap.set(item.id, offset + i);
-              }
-            }
-          } else {
-            // Fallback: no offset (e.g. SimpleDataManager) — full rebuild
-            rebuildIdIndex();
-          }
-        },
-      );
-
-      // Build initial index (no-op when nothing is cached yet, e.g. async)
-      rebuildIdIndex();
 
       // ── Register internal getters for renderer integration ──
       // These allow the core/grid/masonry renderers to read real selection
@@ -383,22 +311,37 @@ export const withSelection = <T extends VListItem = VListItem>(
       // a full re-render when selection state changes (click, API call).
       const { forceRender: capturedForceRender } = ctx.getRenderFns();
 
+      // ── Shared index/item-by-ID resolvers ──
+      // Uses ctx.dataManager.getIndexById when available (returns layout-space
+      // indices, correct when withGroups wraps the data manager).
+      // Falls back to linear scan for simple data managers without getIndexById.
+      const getIndexById = (id: string | number): number => {
+        if (ctx.dataManager.getIndexById) {
+          return ctx.dataManager.getIndexById(id);
+        }
+        const total = ctx.dataManager.getTotal();
+        for (let i = 0; i < total; i++) {
+          const item = ctx.dataManager.getItem(i);
+          if (item && item.id === id) return i;
+        }
+        return -1;
+      };
+
+      const getItemById = (id: string | number): T | undefined => {
+        const index = getIndexById(id);
+        if (index < 0) return undefined;
+        return ctx.dataManager.getItem(index);
+      };
+
       // ── Helper: force render + emit selection change ──
       const forceRenderAndEmit = (): void => {
         // Force render — renderers will pick up the new selection state
         // via _getSelectedIds / _getFocusedIndex getters
         capturedForceRender();
 
-        // O(1) lookup using ID → index map
-        const getItemByIdFn = (id: string | number): T | undefined => {
-          const index = idToIndexMap.get(id);
-          if (index === undefined) return undefined;
-          return ctx.dataManager.getItem(index);
-        };
-
         emitter.emit("selection:change", {
           selected: selectedArray(),
-          items: selectedItems(getItemByIdFn),
+          items: selectedItems(getItemById),
         });
       };
 
@@ -812,13 +755,9 @@ export const withSelection = <T extends VListItem = VListItem>(
           case "Delete":
           case "Backspace":
             if (selected.size > 0) {
-              const getItemByIdFn = (id: string | number): T | undefined => {
-                const index = idToIndexMap.get(id);
-                return index === undefined ? undefined : ctx.dataManager.getItem(index);
-              };
               emitter.emit("delete", {
                 selected: selectedArray(),
-                items: selectedItems(getItemByIdFn),
+                items: selectedItems(getItemById),
               });
               handled = true;
             }
@@ -946,12 +885,8 @@ export const withSelection = <T extends VListItem = VListItem>(
       ctx.methods.set("select", (...ids: Array<string | number>): void => {
         selectIds(ids);
         if (ids.length > 0) {
-          let index = idToIndexMap.get(ids[0]!);
-          if (index === undefined) {
-            rebuildIdIndex();
-            index = idToIndexMap.get(ids[0]!);
-          }
-          if (index !== undefined) {
+          const index = getIndexById(ids[0]!);
+          if (index >= 0) {
             setFocus(index);
           }
         }
@@ -973,7 +908,6 @@ export const withSelection = <T extends VListItem = VListItem>(
         const allItems = ctx.getAllLoadedItems();
         selected.clear();
         for (const item of allItems) selected.add(item.id);
-        rebuildIdIndex(); // Ensure index is current
         forceRenderAndEmit();
       });
 
@@ -987,12 +921,7 @@ export const withSelection = <T extends VListItem = VListItem>(
       });
 
       ctx.methods.set("getSelectedItems", (): T[] => {
-        // O(1) lookup using ID → index map
-        const getItemByIdFn = (id: string | number): T | undefined => {
-          const index = idToIndexMap.get(id);
-          return index === undefined ? undefined : ctx.dataManager.getItem(index);
-        };
-        return selectedItems(getItemByIdFn);
+        return selectedItems(getItemById);
       });
 
       // ── Shared helper: move focus + select + scroll-if-needed + emit ──
@@ -1035,17 +964,8 @@ export const withSelection = <T extends VListItem = VListItem>(
 
       // ── Internal: restore focus by item ID (used by withSnapshots, withSortable) ──
       ctx.methods.set("_focusById", (id: string | number): void => {
-        let index = idToIndexMap.get(id);
-        // Validate — map may be stale after setItems() reorders data
-        if (index !== undefined) {
-          const check = ctx.dataManager.getItem(index);
-          if (!check || check.id !== id) index = undefined;
-        }
-        if (index === undefined) {
-          rebuildIdIndex();
-          index = idToIndexMap.get(id);
-          if (index === undefined) return;
-        }
+        const index = getIndexById(id);
+        if (index < 0) return;
         // Set the index without focusVisible — the ring will appear when
         // the user tabs into the list and focusin fires.
         setFocus(index);

--- a/test/features/selection/feature.test.ts
+++ b/test/features/selection/feature.test.ts
@@ -140,6 +140,12 @@ function createMockContext(): BuilderContext<TestItem> {
       getTotal: () => testItems.length,
       getCached: () => testItems.length,
       getItem: (index: number) => testItems[index],
+      getIndexById: (id: string | number) => {
+        for (let i = 0; i < testItems.length; i++) {
+          if (testItems[i]?.id === id) return i;
+        }
+        return -1;
+      },
       getItemsInRange: (start: number, end: number) =>
         testItems.slice(start, end + 1),
       isItemLoaded: () => true,
@@ -841,30 +847,29 @@ function createMockContextWithEmitter(): BuilderContext<TestItem> {
 }
 
 // =============================================================================
-// withSelection — load:end Incremental Indexing
+// withSelection — ID Resolution
 // =============================================================================
 
-describe("withSelection — load:end indexing", () => {
-  it("should index items incrementally via load:end with offset", () => {
+describe("withSelection — ID resolution", () => {
+  it("should resolve items after async batch load via data manager", () => {
     const feature = withSelection<TestItem>({ mode: "multiple" });
     const ctx = createMockContextWithEmitter();
 
-    // Start with 0 cached (async scenario)
-    (ctx.dataManager as any).getCached = () => 0;
-
-    feature.setup!(ctx);
-
-    // Simulate a batch load at offset 0
     const batch: TestItem[] = [
       { id: 100, name: "A" },
       { id: 101, name: "B" },
     ];
-    (ctx.dataManager as any).getItem = (i: number) =>
-      i === 0 ? batch[0] : i === 1 ? batch[1] : undefined;
+    (ctx.dataManager as any).getTotal = () => batch.length;
+    (ctx.dataManager as any).getItem = (i: number) => batch[i];
+    (ctx.dataManager as any).getIndexById = (id: string | number) => {
+      for (let i = 0; i < batch.length; i++) {
+        if (batch[i]?.id === id) return i;
+      }
+      return -1;
+    };
 
-    ctx.emitter.emit("load:end", { items: batch, offset: 0 });
+    feature.setup!(ctx);
 
-    // Now select by ID — getSelectedItems should resolve via the index
     const select = ctx.methods.get("select") as (...ids: any[]) => void;
     const getSelectedItems = ctx.methods.get("getSelectedItems") as () => TestItem[];
 
@@ -874,14 +879,11 @@ describe("withSelection — load:end indexing", () => {
     expect(items[0].id).toBe(100);
   });
 
-  it("should fallback to rebuildIdIndex when load:end has no offset", () => {
+  it("should resolve items by ID via linear scan fallback", () => {
     const feature = withSelection<TestItem>({ mode: "multiple" });
     const ctx = createMockContextWithEmitter();
 
     feature.setup!(ctx);
-
-    // Emit load:end without offset — triggers rebuildIdIndex fallback
-    ctx.emitter.emit("load:end", { items: [{ id: 0, name: "Item 0" }] });
 
     const select = ctx.methods.get("select") as (...ids: any[]) => void;
     const getSelectedItems = ctx.methods.get("getSelectedItems") as () => TestItem[];
@@ -904,11 +906,11 @@ describe("withSelection — load:end indexing", () => {
 });
 
 // =============================================================================
-// withSelection — Sparse rebuildIdIndex
+// withSelection — Sparse Data ID Resolution
 // =============================================================================
 
 describe("withSelection — sparse ID indexing", () => {
-  it("should use getLoadedRanges for sparse data", () => {
+  it("should resolve items in sparse data via data manager", () => {
     const feature = withSelection<TestItem>({ mode: "multiple" });
     const ctx = createMockContextWithEmitter();
 
@@ -918,21 +920,17 @@ describe("withSelection — sparse ID indexing", () => {
       50: { id: 150, name: "C" },
     };
 
-    // Simulate sparse data: total=100, cached=3
     (ctx.dataManager as any).getTotal = () => 100;
     (ctx.dataManager as any).getCached = () => 3;
     (ctx.dataManager as any).getItem = (i: number) => sparseItems[i];
-    (ctx.dataManager as any).getStorage = () => ({
-      getLoadedRanges: () => [
-        { start: 0, end: 1 },
-        { start: 50, end: 50 },
-      ],
-    });
+    (ctx.dataManager as any).getIndexById = (id: string | number) => {
+      for (const [idx, item] of Object.entries(sparseItems)) {
+        if (item.id === id) return Number(idx);
+      }
+      return -1;
+    };
 
     feature.setup!(ctx);
-
-    // Trigger rebuildIdIndex via load:end without offset
-    ctx.emitter.emit("load:end", { items: [sparseItems[0]!] });
 
     const select = ctx.methods.get("select") as (...ids: any[]) => void;
     const getSelectedItems = ctx.methods.get("getSelectedItems") as () => TestItem[];


### PR DESCRIPTION
## Summary

- **fix(selection):** ID-to-index resolution used a private `idToIndexMap` with data-space indices — broke when `withGroups` wraps the data manager (layout-space). Removed the map, all lookups now delegate to `ctx.dataManager.getIndexById()`.
- **fix(selection):** `selectItemRange`, `selectAll()`, and Ctrl+A iterated `getAllLoadedItems()` which includes group header pseudo-items — leaked header IDs into the selected set and broke the Ctrl+A toggle. Now iterates via data manager with `isHeader()` skip.

## Test plan

- [x] All 3401 tests pass
- [x] Typecheck clean
- [x] Build succeeds, bundle sizes unchanged (11.0 KB base)