### PR TITLE
feat(transition): FLIP-based enter/exit animations for insertItem and removeItem

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -28,10 +28,10 @@ async function build() {
   const wrapperCode = [
     `import { vlist, withGrid, withMasonry, withGroups, withAsync, withSelection,`,
     `  withScale, withScrollbar, withPage, withSnapshots, withTable, withSortable,`,
-    `  withAutoSize, createStats } from "${entryAbs}";`,
+    `  withAutoSize, withTransition, createStats } from "${entryAbs}";`,
     `export { vlist, withGrid, withMasonry, withGroups, withAsync, withSelection,`,
     `  withScale, withScrollbar, withPage, withSnapshots, withTable, withSortable,`,
-    `  withAutoSize, createStats };`,
+    `  withAutoSize, withTransition, createStats };`,
   ].join("\n");
   const wrapperPath = "/tmp/_vlist_build_entry.ts";
   writeFileSync(wrapperPath, wrapperCode);
@@ -145,7 +145,7 @@ async function build() {
   const ALL_FEATURES = [
     "withGrid", "withMasonry", "withGroups", "withAsync", "withSelection",
     "withScale", "withScrollbar", "withPage", "withSnapshots", "withTable",
-    "withSortable", "withAutoSize",
+    "withSortable", "withAutoSize", "withTransition",
   ] as const;
 
   const scenarios = [

--- a/scripts/measure-size.ts
+++ b/scripts/measure-size.ts
@@ -29,6 +29,7 @@ const ALL_FEATURES = [
   "withTable",
   "withAutoSize",
   "withSortable",
+  "withTransition",
 ] as const;
 
 type FeatureName = (typeof ALL_FEATURES)[number];
@@ -78,6 +79,7 @@ const FEATURE_MARKERS: Record<FeatureName, readonly string[]> = {
   withTable:     ["aria-colcount", "gridcell"],
   withAutoSize:  ["setMeasuredSize", "isMeasured"],
   withSortable:  ["sort-ghost", "isSorting"],
+  withTransition: ["scaleY"],
 };
 
 // ── Feature scenarios ─────────────────────────────────────────────
@@ -119,6 +121,7 @@ const scenarios: Scenario[] = [
   { name: "withTable",     imports: ["vlist", "withTable"] },
   { name: "withAutoSize",  imports: ["vlist", "withAutoSize"] },
   { name: "withSortable",  imports: ["vlist", "withSortable"] },
+  { name: "withTransition", imports: ["vlist", "withTransition"] },
 ].map((s) => ({ ...s, mustNotContain: excluded(s.imports) }));
 
 // ── Build & measure ───────────────────────────────────────────────

--- a/src/builder/api.ts
+++ b/src/builder/api.ts
@@ -205,11 +205,11 @@ export const createApi = <T extends VListItem = VListItem>(
     return true;
   };
 
-  const addItem = (item: T, index?: number): void => {
+  const insertItem = (item: T, index?: number): void => {
     const insertIndex = index ?? 0;
-    ctx.dataManager.addItem(item, insertIndex);
+    ctx.dataManager.insertItem(item, insertIndex);
     ctx.forceRender();
-    emitter.emit("data:change", { type: "add", id: item.id });
+    emitter.emit("data:change", { type: "insert", id: item.id });
   };
 
   const getItemAt = (index: number): T | undefined => {
@@ -398,9 +398,13 @@ export const createApi = <T extends VListItem = VListItem>(
     appendItems: m("appendItems", appendItems),
     prependItems: m("prependItems", prependItems),
     updateItem: m("updateItem", updateItem),
+    insertItem(item: T, index?: number) {
+      const fn = methods.get("insertItem") as ((item: T, index?: number) => void) | undefined;
+      return fn ? fn(item, index) : insertItem(item, index);
+    },
+    /** @deprecated Use `insertItem` instead. */
     addItem(item: T, index?: number) {
-      const fn = methods.get("addItem") as ((item: T, index?: number) => void) | undefined;
-      return fn ? fn(item, index) : addItem(item, index);
+      return api.insertItem(item, index);
     },
     removeItem(id: string | number) {
       const fn = methods.get("removeItem") as ((id: string | number) => boolean) | undefined;
@@ -427,6 +431,7 @@ export const createApi = <T extends VListItem = VListItem>(
       name === "appendItems" ||
       name === "prependItems" ||
       name === "updateItem" ||
+      name === "insertItem" ||
       name === "addItem" ||
       name === "removeItem" ||
       name === "reload" ||

--- a/src/builder/api.ts
+++ b/src/builder/api.ts
@@ -169,13 +169,82 @@ export const createApi = <T extends VListItem = VListItem>(
   // deletion loop completes.
   let ensureRangePending = false;
 
+  // Pending removal animation — fast-forwarded when a new removal starts
+  let removePending: (() => void) | null = null;
+
   const removeItem = (id: string | number): boolean => {
+    // Fast-forward any in-progress removal animation
+    if (removePending) {
+      removePending();
+    }
+
     // Capture focused item index before removal for focus recovery (#13d)
     const active = typeof document !== "undefined" ? document.activeElement : null;
     const focIdx = active && dom.items.contains(active)
       ? parseInt((active as HTMLElement).dataset?.index ?? "-1", 10)
       : -1;
 
+    // Resolve index and element BEFORE removal (sizeCache is still intact)
+    const index = ctx.dataManager.getIndexById(id);
+    const removedEl = index >= 0 ? rendered.get(index) : undefined;
+    const itemSize = index >= 0 ? $.hc.getSize(index) : 0;
+
+    // Fast path: item not rendered (off-screen) — immediate removal
+    // ctx.dataManager.removeItem triggers syncAfterChange (sizeCache rebuild + forceRender)
+    if (!removedEl || index < 0) {
+      const result = ctx.dataManager.removeItem(id);
+      if (!result) {
+        if (process.env.NODE_ENV !== "production") {
+          console.warn(`[vlist] removeItem() could not find item with id "${id}".`);
+        }
+        return false;
+      }
+
+      emitter.emit("data:change", { type: "remove", id });
+
+      if (!ensureRangePending) {
+        const dm = ctx.dataManager as any;
+        if (typeof dm.ensureRange === "function") {
+          ensureRangePending = true;
+          queueMicrotask(() => {
+            ensureRangePending = false;
+            const t = ctx.dataManager.getTotal();
+            const { start, end } = ctx.state.viewportState.renderRange;
+            if (t > 0 && end >= start) dm.ensureRange(start, end).catch(() => {});
+          });
+        }
+      }
+
+      if (focIdx >= 0) {
+        const t = $.vtf();
+        if (t > 0) rendered.get(Math.min(focIdx, t - 1))?.focus();
+      }
+
+      return true;
+    }
+
+    // ── Animated removal (FLIP technique) ──
+    // The data proxy's removeItem triggers syncAfterChange which rebuilds
+    // the sizeCache and calls forceRender. We capture old state, let the
+    // removal reconcile the DOM, then animate from old to new positions.
+    const horizontal = ctx.config.horizontal;
+    const prop = horizontal ? "translateX" : "translateY";
+    const duration = 200;
+    const easing = "cubic-bezier(0.2, 0, 0, 1)";
+
+    // FIRST: clone the element for the exit animation before removal destroys it
+    const exitClone = removedEl.cloneNode(true) as HTMLElement;
+    exitClone.style.pointerEvents = "none";
+    exitClone.style.overflow = "hidden";
+    exitClone.removeAttribute("data-index");
+    exitClone.removeAttribute("data-id");
+    exitClone.removeAttribute("id");
+
+    // LAST: remove item + reconcile DOM
+    // The default data proxy's removeItem calls syncAfterChange (sizeCache
+    // rebuild + forceRender). The async data manager only calls renderIfNeeded
+    // which is a no-op when the scroll position hasn't changed. Explicitly
+    // call forceRender to guarantee the DOM is reconciled before the FLIP.
     const result = ctx.dataManager.removeItem(id);
     if (!result) {
       if (process.env.NODE_ENV !== "production") {
@@ -184,10 +253,10 @@ export const createApi = <T extends VListItem = VListItem>(
       return false;
     }
 
-    emitter.emit("data:change", { type: "remove", id });
     ctx.forceRender();
+    emitter.emit("data:change", { type: "remove", id });
 
-    // Refill gaps via debounced ensureRange (coalesces consecutive deletes)
+    // Schedule async data refill immediately — don't wait for animation
     if (!ensureRangePending) {
       const dm = ctx.dataManager as any;
       if (typeof dm.ensureRange === "function") {
@@ -196,16 +265,72 @@ export const createApi = <T extends VListItem = VListItem>(
           ensureRangePending = false;
           const t = ctx.dataManager.getTotal();
           const { start, end } = ctx.state.viewportState.renderRange;
-          if (t > 0 && end >= start) dm.ensureRange(start, end).catch(() => {});
+          console.log(`[removeItem] ensureRange microtask: total=${t}, renderRange=${start}-${end}`);
+          if (t > 0 && end >= start) dm.ensureRange(start, end).catch((e: unknown) => console.error('[removeItem] ensureRange failed:', e));
         });
       }
     }
 
-    // Focus recovery (#13d)
-    if (focIdx >= 0) {
-      const t = $.vtf();
-      if (t > 0) rendered.get(Math.min(focIdx, t - 1))?.focus();
+    // Insert exit clone at the removed item's position
+    dom.items.appendChild(exitClone);
+
+    // INVERT: push shifted items back to their old positions (no transition)
+    // Items at new data-index >= removedIndex were one slot lower before removal.
+    // Their old offset = new offset + removedItemSize.
+    const children = dom.items.children;
+    for (let i = 0; i < children.length; i++) {
+      const el = children[i] as HTMLElement;
+      if (el === exitClone) continue;
+      const idx = parseInt(el.dataset?.index ?? "-1", 10);
+      if (idx < index || idx < 0) continue;
+      const newOffset = $.hc.getOffset(idx);
+      el.style.transition = "none";
+      el.style.transform = `${prop}(${Math.round(newOffset + itemSize)}px)`;
     }
+
+    // Force reflow so the browser registers the inverted positions
+    void dom.items.offsetHeight;
+
+    // PLAY: animate exit clone out + slide items to their final positions
+    exitClone.style.transition = `height ${duration}ms ${easing}, opacity ${duration}ms ${easing}`;
+    exitClone.style.opacity = "0";
+    exitClone.style.height = "0";
+
+    for (let i = 0; i < children.length; i++) {
+      const el = children[i] as HTMLElement;
+      if (el === exitClone) continue;
+      const idx = parseInt(el.dataset?.index ?? "-1", 10);
+      if (idx < index || idx < 0) continue;
+      const finalOffset = $.hc.getOffset(idx);
+      el.style.transition = `transform ${duration}ms ${easing}`;
+      el.style.transform = `${prop}(${Math.round(finalOffset)}px)`;
+    }
+
+    // Finalize after animation completes
+    let settled = false;
+    const finalize = (): void => {
+      if (settled) return;
+      settled = true;
+      removePending = null;
+
+      exitClone.remove();
+
+      // Clean up inline transition overrides
+      const allChildren = dom.items.children;
+      for (let i = 0; i < allChildren.length; i++) {
+        (allChildren[i] as HTMLElement).style.transition = "";
+      }
+
+      // Focus recovery (#13d)
+      if (focIdx >= 0) {
+        const t = $.vtf();
+        if (t > 0) rendered.get(Math.min(focIdx, t - 1))?.focus();
+      }
+    };
+
+    removePending = finalize;
+    exitClone.addEventListener("transitionend", finalize, { once: true });
+    setTimeout(finalize, duration + 50);
 
     return true;
   };

--- a/src/builder/api.ts
+++ b/src/builder/api.ts
@@ -163,88 +163,15 @@ export const createApi = <T extends VListItem = VListItem>(
   };
 
   // Debounced ensureRange — coalesces multiple synchronous removeItem calls
-  // into a single async fetch. Without this, deleting 5 items in a loop
-  // fires 5 overlapping ensureRange requests (each clearing the previous
-  // via activeLoads.clear). The microtask fires once after the synchronous
-  // deletion loop completes.
+  // into a single async fetch.
   let ensureRangePending = false;
 
-  // Pending removal animation — fast-forwarded when a new removal starts
-  let removePending: (() => void) | null = null;
-
   const removeItem = (id: string | number): boolean => {
-    // Fast-forward any in-progress removal animation
-    if (removePending) {
-      removePending();
-    }
-
-    // Capture focused item index before removal for focus recovery (#13d)
     const active = typeof document !== "undefined" ? document.activeElement : null;
     const focIdx = active && dom.items.contains(active)
       ? parseInt((active as HTMLElement).dataset?.index ?? "-1", 10)
       : -1;
 
-    // Resolve index and element BEFORE removal (sizeCache is still intact)
-    const index = ctx.dataManager.getIndexById(id);
-    const removedEl = index >= 0 ? rendered.get(index) : undefined;
-    const itemSize = index >= 0 ? $.hc.getSize(index) : 0;
-
-    // Fast path: item not rendered (off-screen) — immediate removal
-    // ctx.dataManager.removeItem triggers syncAfterChange (sizeCache rebuild + forceRender)
-    if (!removedEl || index < 0) {
-      const result = ctx.dataManager.removeItem(id);
-      if (!result) {
-        if (process.env.NODE_ENV !== "production") {
-          console.warn(`[vlist] removeItem() could not find item with id "${id}".`);
-        }
-        return false;
-      }
-
-      emitter.emit("data:change", { type: "remove", id });
-
-      if (!ensureRangePending) {
-        const dm = ctx.dataManager as any;
-        if (typeof dm.ensureRange === "function") {
-          ensureRangePending = true;
-          queueMicrotask(() => {
-            ensureRangePending = false;
-            const t = ctx.dataManager.getTotal();
-            const { start, end } = ctx.state.viewportState.renderRange;
-            if (t > 0 && end >= start) dm.ensureRange(start, end).catch(() => {});
-          });
-        }
-      }
-
-      if (focIdx >= 0) {
-        const t = $.vtf();
-        if (t > 0) rendered.get(Math.min(focIdx, t - 1))?.focus();
-      }
-
-      return true;
-    }
-
-    // ── Animated removal (FLIP technique) ──
-    // The data proxy's removeItem triggers syncAfterChange which rebuilds
-    // the sizeCache and calls forceRender. We capture old state, let the
-    // removal reconcile the DOM, then animate from old to new positions.
-    const horizontal = ctx.config.horizontal;
-    const prop = horizontal ? "translateX" : "translateY";
-    const duration = 200;
-    const easing = "cubic-bezier(0.2, 0, 0, 1)";
-
-    // FIRST: clone the element for the exit animation before removal destroys it
-    const exitClone = removedEl.cloneNode(true) as HTMLElement;
-    exitClone.style.pointerEvents = "none";
-    exitClone.style.overflow = "hidden";
-    exitClone.removeAttribute("data-index");
-    exitClone.removeAttribute("data-id");
-    exitClone.removeAttribute("id");
-
-    // LAST: remove item + reconcile DOM
-    // The default data proxy's removeItem calls syncAfterChange (sizeCache
-    // rebuild + forceRender). The async data manager only calls renderIfNeeded
-    // which is a no-op when the scroll position hasn't changed. Explicitly
-    // call forceRender to guarantee the DOM is reconciled before the FLIP.
     const result = ctx.dataManager.removeItem(id);
     if (!result) {
       if (process.env.NODE_ENV !== "production") {
@@ -256,7 +183,6 @@ export const createApi = <T extends VListItem = VListItem>(
     ctx.forceRender();
     emitter.emit("data:change", { type: "remove", id });
 
-    // Schedule async data refill immediately — don't wait for animation
     if (!ensureRangePending) {
       const dm = ctx.dataManager as any;
       if (typeof dm.ensureRange === "function") {
@@ -265,74 +191,25 @@ export const createApi = <T extends VListItem = VListItem>(
           ensureRangePending = false;
           const t = ctx.dataManager.getTotal();
           const { start, end } = ctx.state.viewportState.renderRange;
-          console.log(`[removeItem] ensureRange microtask: total=${t}, renderRange=${start}-${end}`);
-          if (t > 0 && end >= start) dm.ensureRange(start, end).catch((e: unknown) => console.error('[removeItem] ensureRange failed:', e));
+          if (t > 0 && end >= start) dm.ensureRange(start, end).catch(() => {});
         });
       }
     }
 
-    // Insert exit clone at the removed item's position
-    dom.items.appendChild(exitClone);
-
-    // INVERT: push shifted items back to their old positions (no transition)
-    // Items at new data-index >= removedIndex were one slot lower before removal.
-    // Their old offset = new offset + removedItemSize.
-    const children = dom.items.children;
-    for (let i = 0; i < children.length; i++) {
-      const el = children[i] as HTMLElement;
-      if (el === exitClone) continue;
-      const idx = parseInt(el.dataset?.index ?? "-1", 10);
-      if (idx < index || idx < 0) continue;
-      const newOffset = $.hc.getOffset(idx);
-      el.style.transition = "none";
-      el.style.transform = `${prop}(${Math.round(newOffset + itemSize)}px)`;
+    if (focIdx >= 0) {
+      const t = $.vtf();
+      if (t > 0) rendered.get(Math.min(focIdx, t - 1))?.focus();
     }
 
-    // Force reflow so the browser registers the inverted positions
-    void dom.items.offsetHeight;
-
-    // PLAY: animate exit clone out + slide items to their final positions
-    exitClone.style.transition = `height ${duration}ms ${easing}, opacity ${duration}ms ${easing}`;
-    exitClone.style.opacity = "0";
-    exitClone.style.height = "0";
-
-    for (let i = 0; i < children.length; i++) {
-      const el = children[i] as HTMLElement;
-      if (el === exitClone) continue;
-      const idx = parseInt(el.dataset?.index ?? "-1", 10);
-      if (idx < index || idx < 0) continue;
-      const finalOffset = $.hc.getOffset(idx);
-      el.style.transition = `transform ${duration}ms ${easing}`;
-      el.style.transform = `${prop}(${Math.round(finalOffset)}px)`;
-    }
-
-    // Finalize after animation completes
-    let settled = false;
-    const finalize = (): void => {
-      if (settled) return;
-      settled = true;
-      removePending = null;
-
-      exitClone.remove();
-
-      // Clean up inline transition overrides
-      const allChildren = dom.items.children;
-      for (let i = 0; i < allChildren.length; i++) {
-        (allChildren[i] as HTMLElement).style.transition = "";
-      }
-
-      // Focus recovery (#13d)
-      if (focIdx >= 0) {
-        const t = $.vtf();
-        if (t > 0) rendered.get(Math.min(focIdx, t - 1))?.focus();
-      }
-    };
-
-    removePending = finalize;
-    exitClone.addEventListener("transitionend", finalize, { once: true });
-    setTimeout(finalize, duration + 50);
-
+    emitter.emit("remove:end", { id });
     return true;
+  };
+
+  const addItem = (item: T, index?: number): void => {
+    const insertIndex = index ?? 0;
+    ctx.dataManager.addItem(item, insertIndex);
+    ctx.forceRender();
+    emitter.emit("data:change", { type: "add", id: item.id });
   };
 
   const getItemAt = (index: number): T | undefined => {
@@ -521,6 +398,10 @@ export const createApi = <T extends VListItem = VListItem>(
     appendItems: m("appendItems", appendItems),
     prependItems: m("prependItems", prependItems),
     updateItem: m("updateItem", updateItem),
+    addItem(item: T, index?: number) {
+      const fn = methods.get("addItem") as ((item: T, index?: number) => void) | undefined;
+      return fn ? fn(item, index) : addItem(item, index);
+    },
     removeItem(id: string | number) {
       const fn = methods.get("removeItem") as ((id: string | number) => boolean) | undefined;
       return fn ? fn(id) : removeItem(id);
@@ -546,6 +427,7 @@ export const createApi = <T extends VListItem = VListItem>(
       name === "appendItems" ||
       name === "prependItems" ||
       name === "updateItem" ||
+      name === "addItem" ||
       name === "removeItem" ||
       name === "reload" ||
       name === "scrollToIndex" ||

--- a/src/builder/api.ts
+++ b/src/builder/api.ts
@@ -210,6 +210,19 @@ export const createApi = <T extends VListItem = VListItem>(
     ctx.dataManager.insertItem(item, insertIndex);
     ctx.forceRender();
     emitter.emit("data:change", { type: "insert", id: item.id });
+
+    if (!ensureRangePending) {
+      const dm = ctx.dataManager as any;
+      if (typeof dm.ensureRange === "function") {
+        ensureRangePending = true;
+        queueMicrotask(() => {
+          ensureRangePending = false;
+          const t = ctx.dataManager.getTotal();
+          const { start, end } = ctx.state.viewportState.renderRange;
+          if (t > 0 && end >= start) dm.ensureRange(start, end).catch(() => {});
+        });
+      }
+    }
   };
 
   const getItemAt = (index: number): T | undefined => {

--- a/src/builder/core.ts
+++ b/src/builder/core.ts
@@ -247,15 +247,19 @@ function materialize<T extends VListItem = VListItem>(
   );
 
   const featureNames = new Set(sortedFeatures.map((p) => p.name));
-  for (const feature of sortedFeatures) {
+  for (let i = sortedFeatures.length - 1; i >= 0; i--) {
+    const feature = sortedFeatures[i]!;
     if (feature.conflicts) {
       for (const conflict of feature.conflicts) {
         if (featureNames.has(conflict)) {
-          throw new Error(
-            process.env.NODE_ENV === "production"
-              ? "[vlist] conflict"
-              : `[vlist] ${feature.name} and ${conflict} cannot be combined`,
-          );
+          if (process.env.NODE_ENV !== "production") {
+            console.warn(
+              `[vlist] ${feature.name} skipped — conflicts with ${conflict}`,
+            );
+          }
+          sortedFeatures.splice(i, 1);
+          featureNames.delete(feature.name);
+          break;
         }
       }
     }

--- a/src/builder/core.ts
+++ b/src/builder/core.ts
@@ -247,19 +247,11 @@ function materialize<T extends VListItem = VListItem>(
   );
 
   const featureNames = new Set(sortedFeatures.map((p) => p.name));
-  for (let i = sortedFeatures.length - 1; i >= 0; i--) {
-    const feature = sortedFeatures[i]!;
+  for (const feature of sortedFeatures) {
     if (feature.conflicts) {
       for (const conflict of feature.conflicts) {
         if (featureNames.has(conflict)) {
-          if (process.env.NODE_ENV !== "production") {
-            console.warn(
-              `[vlist] ${feature.name} skipped — conflicts with ${conflict}`,
-            );
-          }
-          sortedFeatures.splice(i, 1);
-          featureNames.delete(feature.name);
-          break;
+          throw new Error(`${feature.name} and ${conflict} cannot be combined`);
         }
       }
     }

--- a/src/builder/data.ts
+++ b/src/builder/data.ts
@@ -49,7 +49,7 @@ export interface SimpleDataManager<T extends VListItem = VListItem> {
   setTotal: (total: number) => void;
   setItems: (items: T[], offset?: number, total?: number) => void;
   updateItem: (index: number, updates: Partial<T>) => boolean;
-  addItem: (item: T, index: number) => void;
+  insertItem: (item: T, index: number) => void;
   removeItem: (id: string | number) => boolean;
   loadRange: (start: number, end: number) => Promise<void>;
   ensureRange: (start: number, end: number) => Promise<void>;
@@ -183,7 +183,7 @@ export const createSimpleDataManager = <T extends VListItem = VListItem>(
     return true;
   };
 
-  const addItem = (item: T, index: number): void => {
+  const insertItem = (item: T, index: number): void => {
     items.splice(index, 0, item);
     total++;
     notifyStateChange();
@@ -231,7 +231,7 @@ export const createSimpleDataManager = <T extends VListItem = VListItem>(
     setTotal,
     setItems,
     updateItem,
-    addItem,
+    insertItem,
     removeItem,
     loadRange: noop,
     ensureRange: noop,

--- a/src/builder/data.ts
+++ b/src/builder/data.ts
@@ -49,6 +49,7 @@ export interface SimpleDataManager<T extends VListItem = VListItem> {
   setTotal: (total: number) => void;
   setItems: (items: T[], offset?: number, total?: number) => void;
   updateItem: (index: number, updates: Partial<T>) => boolean;
+  addItem: (item: T, index: number) => void;
   removeItem: (id: string | number) => boolean;
   loadRange: (start: number, end: number) => Promise<void>;
   ensureRange: (start: number, end: number) => Promise<void>;
@@ -182,6 +183,12 @@ export const createSimpleDataManager = <T extends VListItem = VListItem>(
     return true;
   };
 
+  const addItem = (item: T, index: number): void => {
+    items.splice(index, 0, item);
+    total++;
+    notifyStateChange();
+  };
+
   const removeItem = (id: string | number): boolean => {
     const index = typeof id === "number" ? id : items.findIndex((item: any) => item.id === id);
     if (index < 0 || index >= items.length) return false;
@@ -224,6 +231,7 @@ export const createSimpleDataManager = <T extends VListItem = VListItem>(
     setTotal,
     setItems,
     updateItem,
+    addItem,
     removeItem,
     loadRange: noop,
     ensureRange: noop,

--- a/src/builder/materialize.ts
+++ b/src/builder/materialize.ts
@@ -683,7 +683,7 @@ export const createDefaultDataProxy = <T extends VListItem = VListItem>(
       }
       return true;
     },
-    addItem: (item: T, index: number) => {
+    insertItem: (item: T, index: number) => {
       $.it.splice(index, 0, item);
       if (idIndex) ensureIndex();
       if ($.ii) syncAfterChange();

--- a/src/builder/materialize.ts
+++ b/src/builder/materialize.ts
@@ -683,6 +683,11 @@ export const createDefaultDataProxy = <T extends VListItem = VListItem>(
       }
       return true;
     },
+    addItem: (item: T, index: number) => {
+      $.it.splice(index, 0, item);
+      if (idIndex) ensureIndex();
+      if ($.ii) syncAfterChange();
+    },
     removeItem: (id: string | number) => {
       let index: number;
       if (typeof id === "number") {

--- a/src/builder/types.ts
+++ b/src/builder/types.ts
@@ -660,6 +660,7 @@ export interface VList<T extends VListItem = VListItem> {
   appendItems: (items: T[]) => void;
   prependItems: (items: T[]) => void;
   updateItem: (id: string | number, updates: Partial<T>) => void;
+  addItem: (item: T, index?: number) => void;
   removeItem: (id: string | number) => void;
   getItemAt: (index: number) => T | undefined;
   getIndexById: (id: string | number) => number;

--- a/src/builder/types.ts
+++ b/src/builder/types.ts
@@ -660,6 +660,8 @@ export interface VList<T extends VListItem = VListItem> {
   appendItems: (items: T[]) => void;
   prependItems: (items: T[]) => void;
   updateItem: (id: string | number, updates: Partial<T>) => void;
+  insertItem: (item: T, index?: number) => void;
+  /** @deprecated Use `insertItem` instead. */
   addItem: (item: T, index?: number) => void;
   removeItem: (id: string | number) => void;
   getItemAt: (index: number) => T | undefined;

--- a/src/features/async/feature.ts
+++ b/src/features/async/feature.ts
@@ -209,7 +209,9 @@ export const withAsync = <T extends VListItem = VListItem>(
         onStateChange: () => {
           if (ctx.state.isInitialized) {
             const newTotal = ctx.getVirtualTotal();
-            if (newTotal !== ctx.sizeCache.getTotal()) {
+            const oldTotal = ctx.sizeCache.getTotal();
+            if (newTotal !== oldTotal) {
+              console.log(`[async.onStateChange] sizeCache rebuild: ${oldTotal}→${newTotal}`);
               ctx.sizeCache.rebuild(newTotal);
             }
             ctx.updateCompressionMode();

--- a/src/features/async/feature.ts
+++ b/src/features/async/feature.ts
@@ -211,7 +211,6 @@ export const withAsync = <T extends VListItem = VListItem>(
             const newTotal = ctx.getVirtualTotal();
             const oldTotal = ctx.sizeCache.getTotal();
             if (newTotal !== oldTotal) {
-              console.log(`[async.onStateChange] sizeCache rebuild: ${oldTotal}→${newTotal}`);
               ctx.sizeCache.rebuild(newTotal);
             }
             ctx.updateCompressionMode();

--- a/src/features/async/manager.ts
+++ b/src/features/async/manager.ts
@@ -132,6 +132,9 @@ export interface DataManager<T extends VListItem = VListItem> {
   /** Update item at index */
   updateItem: (index: number, updates: Partial<T>) => boolean;
 
+  /** Insert item at index */
+  addItem: (item: T, index: number) => void;
+
   /** Remove item by ID */
   removeItem: (id: string | number) => boolean;
 
@@ -457,27 +460,24 @@ export const createDataManager = <T extends VListItem = VListItem>(
     return true;
   };
 
+  const addItem = (item: T, index: number): void => {
+    storage.insert(index, item);
+    rebuildIdIndex();
+    abortAndClearLoads();
+    notifyStateChange();
+  };
+
   const removeItem = (id: string | number): boolean => {
     const index = idToIndex.get(id);
     if (index === undefined) return false;
-
-    const totalBefore = storage.getTotal();
-    const cachedBefore = storage.getCachedCount();
 
     // storage.delete now shifts all items after `index` down by 1
     // and decrements totalItems — no manual setTotal needed.
     const deleted = storage.delete(index);
     if (!deleted) return false;
 
-    // Indices changed for every item after the deleted one —
-    // rebuild the full id→index map from storage.
     rebuildIdIndex();
-
-    // Stale range keys in activeLoads may now refer to wrong offsets.
-    const abortedCount = activeLoads.size;
     abortAndClearLoads();
-
-    console.log(`[DM.removeItem] id=${id}, index=${index}, total: ${totalBefore}→${storage.getTotal()}, cached: ${cachedBefore}→${storage.getCachedCount()}, aborted ${abortedCount} loads`);
 
     notifyStateChange();
     return true;
@@ -523,15 +523,12 @@ export const createDataManager = <T extends VListItem = VListItem>(
 
       const chunkFull = storage.isChunkFullyLoaded(chunkIdx);
       if (chunkFull) {
-        console.log(`[DM.loadRange] chunk ${chunkIdx} (${chunkStart}-${chunkEnd}) SKIPPED (fully loaded)`);
         continue;
       }
       const active = activeLoads.get(key);
       if (active) {
-        console.log(`[DM.loadRange] chunk ${chunkIdx} (${chunkStart}-${chunkEnd}) already loading`);
         loadPromises.push(active[0]);
       } else {
-        console.log(`[DM.loadRange] chunk ${chunkIdx} (${chunkStart}-${chunkEnd}) WILL LOAD`);
         chunksToLoad.push({ start: chunkStart, end: chunkEnd });
       }
     }
@@ -611,7 +608,6 @@ export const createDataManager = <T extends VListItem = VListItem>(
   const ensureRange = async (start: number, end: number): Promise<void> => {
     // Check if range is already fully loaded
     const rangeLoaded = storage.isRangeLoaded(start, end);
-    console.log(`[DM.ensureRange] range=${start}-${end}, isRangeLoaded=${rangeLoaded}`);
     if (rangeLoaded) {
       return;
     }
@@ -749,6 +745,7 @@ export const createDataManager = <T extends VListItem = VListItem>(
     setTotal,
     setItems,
     updateItem,
+    addItem,
     removeItem,
 
     loadRange,

--- a/src/features/async/manager.ts
+++ b/src/features/async/manager.ts
@@ -133,7 +133,7 @@ export interface DataManager<T extends VListItem = VListItem> {
   updateItem: (index: number, updates: Partial<T>) => boolean;
 
   /** Insert item at index */
-  addItem: (item: T, index: number) => void;
+  insertItem: (item: T, index: number) => void;
 
   /** Remove item by ID */
   removeItem: (id: string | number) => boolean;
@@ -460,7 +460,7 @@ export const createDataManager = <T extends VListItem = VListItem>(
     return true;
   };
 
-  const addItem = (item: T, index: number): void => {
+  const insertItem = (item: T, index: number): void => {
     storage.insert(index, item);
     rebuildIdIndex();
     abortAndClearLoads();
@@ -745,7 +745,7 @@ export const createDataManager = <T extends VListItem = VListItem>(
     setTotal,
     setItems,
     updateItem,
-    addItem,
+    insertItem,
     removeItem,
 
     loadRange,

--- a/src/features/async/manager.ts
+++ b/src/features/async/manager.ts
@@ -461,6 +461,9 @@ export const createDataManager = <T extends VListItem = VListItem>(
     const index = idToIndex.get(id);
     if (index === undefined) return false;
 
+    const totalBefore = storage.getTotal();
+    const cachedBefore = storage.getCachedCount();
+
     // storage.delete now shifts all items after `index` down by 1
     // and decrements totalItems — no manual setTotal needed.
     const deleted = storage.delete(index);
@@ -471,7 +474,10 @@ export const createDataManager = <T extends VListItem = VListItem>(
     rebuildIdIndex();
 
     // Stale range keys in activeLoads may now refer to wrong offsets.
+    const abortedCount = activeLoads.size;
     abortAndClearLoads();
+
+    console.log(`[DM.removeItem] id=${id}, index=${index}, total: ${totalBefore}→${storage.getTotal()}, cached: ${cachedBefore}→${storage.getCachedCount()}, aborted ${abortedCount} loads`);
 
     notifyStateChange();
     return true;
@@ -515,11 +521,17 @@ export const createDataManager = <T extends VListItem = VListItem>(
       const chunkEnd = chunkStart + chunkSize - 1;
       const key = getRangeKey(chunkStart, chunkEnd);
 
-      if (storage.isChunkLoaded(chunkIdx)) continue;
+      const chunkFull = storage.isChunkFullyLoaded(chunkIdx);
+      if (chunkFull) {
+        console.log(`[DM.loadRange] chunk ${chunkIdx} (${chunkStart}-${chunkEnd}) SKIPPED (fully loaded)`);
+        continue;
+      }
       const active = activeLoads.get(key);
       if (active) {
+        console.log(`[DM.loadRange] chunk ${chunkIdx} (${chunkStart}-${chunkEnd}) already loading`);
         loadPromises.push(active[0]);
       } else {
+        console.log(`[DM.loadRange] chunk ${chunkIdx} (${chunkStart}-${chunkEnd}) WILL LOAD`);
         chunksToLoad.push({ start: chunkStart, end: chunkEnd });
       }
     }
@@ -598,7 +610,9 @@ export const createDataManager = <T extends VListItem = VListItem>(
 
   const ensureRange = async (start: number, end: number): Promise<void> => {
     // Check if range is already fully loaded
-    if (storage.isRangeLoaded(start, end)) {
+    const rangeLoaded = storage.isRangeLoaded(start, end);
+    console.log(`[DM.ensureRange] range=${start}-${end}, isRangeLoaded=${rangeLoaded}`);
+    if (rangeLoaded) {
       return;
     }
 

--- a/src/features/async/sparse.ts
+++ b/src/features/async/sparse.ts
@@ -83,6 +83,9 @@ export interface SparseStorage<T extends VListItem = VListItem> {
   /** Set multiple items starting at offset */
   setRange: (offset: number, items: T[]) => void;
 
+  /** Insert item at index, shifting subsequent items up by 1 */
+  insert: (index: number, item: T) => void;
+
   /** Delete item at index */
   delete: (index: number) => boolean;
 
@@ -281,6 +284,65 @@ export const createSparseStorage = <T extends VListItem = VListItem>(
         set(offset + i, item);
       }
     }
+  };
+
+  const insertItem = (index: number, item: T): void => {
+    if (index < 0 || index > totalItems) return;
+
+    // Collect all loaded items at indices >= insertIndex, in order.
+    const insertChunkIdx = getChunkIndex(index);
+    const sortedChunkKeys = Array.from(chunks.keys())
+      .filter(k => k >= insertChunkIdx)
+      .sort((a, b) => a - b);
+
+    const shifted: Array<{ oldIndex: number; item: T }> = [];
+
+    for (const ci of sortedChunkKeys) {
+      const c = chunks.get(ci)!;
+      const base = ci * chunkSize;
+      for (let s = 0; s < chunkSize; s++) {
+        if (c.items[s] === undefined) continue;
+        const itemIndex = base + s;
+        if (itemIndex < index) continue;
+        shifted.push({ oldIndex: itemIndex, item: c.items[s]! });
+      }
+    }
+
+    // 1. Clear items that will shift up
+    for (const { oldIndex } of shifted) {
+      const ci = getChunkIndex(oldIndex);
+      const c = chunks.get(ci);
+      if (!c) continue;
+      const slot = getIndexInChunk(oldIndex);
+      if (c.items[slot] !== undefined) {
+        c.items[slot] = undefined;
+        c.count--;
+        cachedItemCount--;
+        if (c.count === 0) chunks.delete(ci);
+      }
+    }
+
+    // 2. Increase total first (so getChunkIndex works for new positions)
+    totalItems++;
+
+    // 3. Re-insert each shifted item at (oldIndex + 1)
+    for (const { oldIndex, item: shiftedItem } of shifted) {
+      const newIndex = oldIndex + 1;
+      const ci = getChunkIndex(newIndex);
+      const dst = getOrCreateChunk(ci);
+      const slot = getIndexInChunk(newIndex);
+      dst.items[slot] = shiftedItem;
+      dst.count++;
+      cachedItemCount++;
+    }
+
+    // 4. Insert the new item
+    const ci = getChunkIndex(index);
+    const dst = getOrCreateChunk(ci);
+    const slot = getIndexInChunk(index);
+    dst.items[slot] = item;
+    dst.count++;
+    cachedItemCount++;
   };
 
   const deleteItem = (index: number): boolean => {
@@ -608,6 +670,7 @@ export const createSparseStorage = <T extends VListItem = VListItem>(
     has,
     set,
     setRange,
+    insert: insertItem,
     delete: deleteItem,
 
     getRange,

--- a/src/features/async/sparse.ts
+++ b/src/features/async/sparse.ts
@@ -103,8 +103,11 @@ export interface SparseStorage<T extends VListItem = VListItem> {
   /** Get chunk index for item index */
   getChunkIndex: (itemIndex: number) => number;
 
-  /** Check if chunk is loaded */
+  /** Check if chunk is loaded (has any items) */
   isChunkLoaded: (chunkIndex: number) => boolean;
+
+  /** Check if chunk has all expected items (count matches expected for total) */
+  isChunkFullyLoaded: (chunkIndex: number) => boolean;
 
   /** Mark chunk as accessed (for LRU) */
   touchChunk: (chunkIndex: number) => void;
@@ -448,6 +451,14 @@ export const createSparseStorage = <T extends VListItem = VListItem>(
     return chunks.has(chunkIndex);
   };
 
+  const isChunkFullyLoaded = (chunkIndex: number): boolean => {
+    const chunk = chunks.get(chunkIndex);
+    if (!chunk) return false;
+    const chunkStart = chunkIndex * chunkSize;
+    const expectedCount = Math.min(chunkSize, totalItems - chunkStart);
+    return chunk.count >= expectedCount;
+  };
+
   const touchChunk = (chunkIndex: number): void => {
     const chunk = chunks.get(chunkIndex);
     if (chunk) {
@@ -606,6 +617,7 @@ export const createSparseStorage = <T extends VListItem = VListItem>(
 
     getChunkIndex,
     isChunkLoaded,
+    isChunkFullyLoaded,
     touchChunk,
     touchChunksForRange,
 

--- a/src/features/groups/async-bridge.ts
+++ b/src/features/groups/async-bridge.ts
@@ -68,6 +68,9 @@ export interface AsyncGroupBridge {
   /** Get the group boundary at a data index */
   getGroupAtDataIndex(dataIndex: number): GroupBoundary;
 
+  /** Insert item at data index — shifts group keys up and rebuilds */
+  insertAt(dataIndex: number, item: VListItem): void;
+
   /** Remove item at data index — shifts group keys and rebuilds */
   removeAt(dataIndex: number): void;
 
@@ -268,6 +271,22 @@ export const createAsyncGroupBridge = (
     return groups[gi]!;
   };
 
+  const insertAt = (dataIndex: number, item: VListItem): void => {
+    const newMap = new Map<number, string>();
+    for (const [idx, key] of groupKeyByIndex) {
+      if (idx < dataIndex) newMap.set(idx, key);
+      else newMap.set(idx + 1, key);
+    }
+    groupKeyByIndex.clear();
+    for (const [idx, key] of newMap) groupKeyByIndex.set(idx, key);
+
+    const key = config.getGroupForIndex(dataIndex, item);
+    groupKeyByIndex.set(dataIndex, key);
+
+    dataTotal++;
+    rebuildGroups();
+  };
+
   const removeAt = (dataIndex: number): void => {
     // Remove the key at dataIndex and shift all subsequent keys down by 1
     const newMap = new Map<number, string>();
@@ -310,6 +329,7 @@ export const createAsyncGroupBridge = (
     getHeaderHeight,
     getGroupAtLayoutIndex,
     getGroupAtDataIndex,
+    insertAt,
     removeAt,
     reset,
   };

--- a/src/features/groups/feature.ts
+++ b/src/features/groups/feature.ts
@@ -696,6 +696,10 @@ function setupAsyncPath<T extends VListItem>(
       bridge.reset();
       return asyncDataManager.reload();
     },
+    insertItem: (item: T, index: number) => {
+      asyncDataManager.insertItem(item, index);
+      bridge.insertAt(index, item);
+    },
     removeItem: (id: string | number) => {
       const dataIndex = asyncDataManager.getIndexById(id);
       if (dataIndex >= 0) {

--- a/src/features/groups/feature.ts
+++ b/src/features/groups/feature.ts
@@ -566,6 +566,12 @@ function setupStaticPath<T extends VListItem>(
     rebuildGroups();
   });
 
+  ctx.methods.set("insertItem", (item: T, index?: number): void => {
+    const idx = index ?? 0;
+    originalItems.splice(idx, 0, item as T);
+    rebuildGroups();
+  });
+
   ctx.methods.set("removeItem", (id: string | number): void => {
     originalItems = originalItems.filter((item) => item.id !== id);
     rebuildGroups();

--- a/src/features/groups/feature.ts
+++ b/src/features/groups/feature.ts
@@ -697,8 +697,8 @@ function setupAsyncPath<T extends VListItem>(
       return asyncDataManager.reload();
     },
     insertItem: (item: T, index: number) => {
-      asyncDataManager.insertItem(item, index);
       bridge.insertAt(index, item);
+      asyncDataManager.insertItem(item, index);
     },
     removeItem: (id: string | number) => {
       const dataIndex = asyncDataManager.getIndexById(id);

--- a/src/features/groups/feature.ts
+++ b/src/features/groups/feature.ts
@@ -306,6 +306,8 @@ export const withGroups = <T extends VListItem = VListItem>(
             (b) => { bridge = b; indexMapper = b; },
             (s) => { stickyHeader = s; },
             stickyContainer,
+            staticOverrides.staticInsertItem,
+            staticOverrides.staticRemoveItem,
           );
         } else {
           // Static path was already set up below — nothing to do
@@ -316,7 +318,7 @@ export const withGroups = <T extends VListItem = VListItem>(
       // When items exist, set up the traditional item-array transformation.
       // If async will be detected later, the static path produces an empty
       // layout (0 items) which is harmless — the async microtask overwrites it.
-      setupStaticPath(
+      const staticOverrides = setupStaticPath(
         ctx, config, resolvedConfig, rawConfig, baseSize, stickyEnabled,
         headerTemplate, classPrefix,
         (layout) => { groupLayout = layout; indexMapper = layout; },
@@ -350,7 +352,7 @@ function setupStaticPath<T extends VListItem>(
   setGroupLayout: (layout: GroupLayout) => void,
   setStickyHeader: (s: StickyHeaderInstance) => void,
   stickyContainer?: HTMLElement | null,
-): void {
+): { staticInsertItem: Function; staticRemoveItem: Function } {
   const { dom } = ctx;
   let localStickyHeader: StickyHeaderInstance | null = null;
 
@@ -566,19 +568,21 @@ function setupStaticPath<T extends VListItem>(
     rebuildGroups();
   });
 
-  ctx.methods.set("insertItem", (item: T, index?: number): void => {
+  const staticInsertItem = (item: T, index?: number): void => {
     const idx = index ?? 0;
     originalItems.splice(idx, 0, item as T);
     rebuildGroups();
-  });
+  };
+  ctx.methods.set("insertItem", staticInsertItem);
 
-  ctx.methods.set("removeItem", (id: string | number): boolean => {
+  const staticRemoveItem = (id: string | number): boolean => {
     const before = originalItems.length;
     originalItems = originalItems.filter((item) => item.id !== id);
     if (originalItems.length === before) return false;
     rebuildGroups();
     return true;
-  });
+  };
+  ctx.methods.set("removeItem", staticRemoveItem);
 
   // ── Override items getter to return original items (without headers) ──
   ctx.methods.set("_getItems", () => originalItems as readonly T[]);
@@ -593,6 +597,8 @@ function setupStaticPath<T extends VListItem>(
   ctx.methods.set("_dataToLayoutIndex", (dataIndex: number): number =>
     groupLayout.dataToLayoutIndex(dataIndex),
   );
+
+  return { staticInsertItem, staticRemoveItem };
 }
 
 // =============================================================================
@@ -611,7 +617,9 @@ function setupAsyncPath<T extends VListItem>(
   registerOnItemsLoaded: (cb: (items: T[], offset: number, total: number) => void) => void,
   setBridge: (bridge: AsyncGroupBridge) => void,
   setStickyHeader: (s: StickyHeaderInstance) => void,
-  stickyContainer?: HTMLElement | null,
+  stickyContainer: HTMLElement | null | undefined,
+  staticInsertItem: Function,
+  staticRemoveItem: Function,
 ): void {
   const { dom } = ctx;
 
@@ -936,8 +944,10 @@ function setupAsyncPath<T extends VListItem>(
   // api.ts delegates to ctx.dataManager (= wrappedDataManager) which
   // handles the bridge correctly. The static overrides operate on the
   // empty originalItems array and would corrupt the async data.
-  ctx.methods.delete("removeItem");
-  ctx.methods.delete("insertItem");
+  // Only delete if still the static override — a later feature (e.g.
+  // withTransition) may have wrapped them.
+  if (ctx.methods.get("removeItem") === staticRemoveItem) ctx.methods.delete("removeItem");
+  if (ctx.methods.get("insertItem") === staticInsertItem) ctx.methods.delete("insertItem");
 
   // ── Stripe map for async path ──
   const stripedMode = rawConfig.item?.striped;

--- a/src/features/groups/feature.ts
+++ b/src/features/groups/feature.ts
@@ -572,9 +572,12 @@ function setupStaticPath<T extends VListItem>(
     rebuildGroups();
   });
 
-  ctx.methods.set("removeItem", (id: string | number): void => {
+  ctx.methods.set("removeItem", (id: string | number): boolean => {
+    const before = originalItems.length;
     originalItems = originalItems.filter((item) => item.id !== id);
+    if (originalItems.length === before) return false;
     rebuildGroups();
+    return true;
   });
 
   // ── Override items getter to return original items (without headers) ──
@@ -929,11 +932,12 @@ function setupAsyncPath<T extends VListItem>(
   // In async mode, _getTotal returns the data total (not layout total)
   ctx.methods.set("_getTotal", () => asyncDataManager.getTotal());
 
-  // Clear the static removeItem override — in async mode, the base api.ts
-  // removeItem delegates to ctx.dataManager (= wrappedDataManager) which
-  // handles the bridge correctly. The static override filters empty
-  // originalItems and zeros out the list.
+  // Clear the static insert/remove overrides — in async mode, the base
+  // api.ts delegates to ctx.dataManager (= wrappedDataManager) which
+  // handles the bridge correctly. The static overrides operate on the
+  // empty originalItems array and would corrupt the async data.
   ctx.methods.delete("removeItem");
+  ctx.methods.delete("insertItem");
 
   // ── Stripe map for async path ──
   const stripedMode = rawConfig.item?.striped;

--- a/src/features/transition/feature.ts
+++ b/src/features/transition/feature.ts
@@ -1,0 +1,298 @@
+/**
+ * withTransition — FLIP-based enter/exit animations for addItem and removeItem.
+ *
+ * Opt-in feature that replaces the immediate add/remove with animated versions:
+ * - removeItem: clone collapses via scaleY(0), siblings slide up
+ * - addItem: new element expands in, siblings slide down
+ *
+ * Without this feature, add/remove are instantaneous.
+ */
+
+import type { VListItem } from "../../types";
+import type { VListFeature, BuilderContext } from "../../builder/types";
+
+// =============================================================================
+// Config
+// =============================================================================
+
+export interface TransitionConfig {
+  /** Animation duration in ms (default: 150) */
+  duration?: number;
+  /** CSS easing function (default: MD3 emphasized) */
+  easing?: string;
+}
+
+// =============================================================================
+// Feature factory
+// =============================================================================
+
+export function withTransition<T extends VListItem = VListItem>(
+  config?: TransitionConfig,
+): VListFeature<T> {
+  const duration = config?.duration ?? 150;
+  const easing = config?.easing ?? "cubic-bezier(0.2, 0, 0, 1)";
+
+  // Pre-built transition strings — duration/easing are config-level constants
+  const tTransform = `transform ${duration}ms ${easing}`;
+  const tTransformOpacity = `${tTransform}, opacity ${duration}ms ${easing}`;
+
+  let ctx: BuilderContext<T>;
+  let removePending: (() => void) | null = null;
+  let addPending: (() => void) | null = null;
+  let ensureRangePending = false;
+
+  const scheduleEnsureRange = (): void => {
+    if (ensureRangePending) return;
+    const dm = ctx.dataManager as any;
+    if (typeof dm.ensureRange !== "function") return;
+    ensureRangePending = true;
+    queueMicrotask(() => {
+      ensureRangePending = false;
+      const t = ctx.dataManager.getTotal();
+      const { start, end } = ctx.state.viewportState.renderRange;
+      if (t > 0 && end >= start) dm.ensureRange(start, end).catch(() => {});
+    });
+  };
+
+  const getElement = (index: number): HTMLElement | null =>
+    (ctx.renderer as any).getElement(index);
+
+  /** Collect DOM children matching a data-index predicate in a single pass. */
+  const collectAffected = (
+    container: HTMLElement,
+    skip: HTMLElement | null,
+    predicate: (idx: number) => boolean,
+  ): Array<{ el: HTMLElement; idx: number }> => {
+    const result: Array<{ el: HTMLElement; idx: number }> = [];
+    const children = container.children;
+    for (let i = 0; i < children.length; i++) {
+      const el = children[i] as HTMLElement;
+      if (el === skip) continue;
+      const idx = parseInt(el.dataset?.index ?? "-1", 10);
+      if (idx >= 0 && predicate(idx)) result.push({ el, idx });
+    }
+    return result;
+  };
+
+  const cleanTransitions = (container: HTMLElement): void => {
+    const children = container.children;
+    for (let i = 0; i < children.length; i++) {
+      (children[i] as HTMLElement).style.transition = "";
+    }
+  };
+
+  // ── Animated removeItem ──────────────────────────────────────────
+
+  const removeItem = (id: string | number): boolean => {
+    if (removePending) removePending();
+
+    const { dom, sizeCache: sc, config: cfg, emitter } = ctx;
+    const prop = cfg.horizontal ? "translateX" : "translateY";
+
+    const active =
+      typeof document !== "undefined" ? document.activeElement : null;
+    const focIdx =
+      active && dom.items.contains(active)
+        ? parseInt((active as HTMLElement).dataset?.index ?? "-1", 10)
+        : -1;
+
+    const index = ctx.dataManager.getIndexById(id);
+    const removedEl = index >= 0 ? getElement(index) : null;
+    const itemSize = index >= 0 ? sc.getSize(index) : 0;
+    const originalOffset = index >= 0 ? sc.getOffset(index) : 0;
+
+    // Off-screen — immediate removal, no animation
+    if (!removedEl || index < 0) {
+      const result = ctx.dataManager.removeItem(id);
+      if (!result) {
+        if (process.env.NODE_ENV !== "production") {
+          console.warn(
+            `[vlist] removeItem() could not find item with id "${id}".`,
+          );
+        }
+        return false;
+      }
+      ctx.forceRender();
+      emitter.emit("data:change", { type: "remove", id });
+      scheduleEnsureRange();
+      if (focIdx >= 0) {
+        const t = ctx.getVirtualTotal();
+        if (t > 0) getElement(Math.min(focIdx, t - 1))?.focus();
+      }
+      emitter.emit("remove:end", { id });
+      return true;
+    }
+
+    // FIRST — clone element before removal destroys it
+    const exitClone = removedEl.cloneNode(true) as HTMLElement;
+    exitClone.style.pointerEvents = "none";
+    exitClone.style.overflow = "hidden";
+    exitClone.removeAttribute("data-index");
+    exitClone.removeAttribute("data-id");
+    exitClone.removeAttribute("id");
+
+    // LAST — remove data + reconcile DOM
+    const result = ctx.dataManager.removeItem(id);
+    if (!result) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(
+          `[vlist] removeItem() could not find item with id "${id}".`,
+        );
+      }
+      return false;
+    }
+    ctx.forceRender();
+    emitter.emit("data:change", { type: "remove", id });
+    scheduleEnsureRange();
+
+    // Pin clone at original position
+    exitClone.style.transition = "none";
+    exitClone.style.transformOrigin = "top center";
+    exitClone.style.transform = `${prop}(${Math.round(originalOffset)}px) scaleY(1)`;
+    exitClone.style.zIndex = "1";
+    dom.items.appendChild(exitClone);
+
+    // Collect shifted items once — avoids duplicate parseInt + filtering
+    const affected = collectAffected(dom.items, exitClone, (i) => i >= index);
+
+    // INVERT — push shifted items back to old positions
+    for (let i = 0; i < affected.length; i++) {
+      const { el, idx } = affected[i]!;
+      el.style.transition = "none";
+      el.style.transform = `${prop}(${Math.round(sc.getOffset(idx) + itemSize)}px)`;
+    }
+
+    void dom.items.offsetHeight;
+
+    // PLAY — clone collapses via scaleY, items slide to final positions
+    exitClone.style.transition = tTransformOpacity;
+    exitClone.style.transform = `${prop}(${Math.round(originalOffset)}px) scaleY(0)`;
+    exitClone.style.opacity = "0";
+
+    for (let i = 0; i < affected.length; i++) {
+      const { el, idx } = affected[i]!;
+      el.style.transition = tTransform;
+      el.style.transform = `${prop}(${Math.round(sc.getOffset(idx))}px)`;
+    }
+
+    let settled = false;
+    const finalize = (): void => {
+      if (settled) return;
+      settled = true;
+      removePending = null;
+      exitClone.remove();
+      cleanTransitions(dom.items);
+      if (focIdx >= 0) {
+        const t = ctx.getVirtualTotal();
+        if (t > 0) getElement(Math.min(focIdx, t - 1))?.focus();
+      }
+      emitter.emit("remove:end", { id });
+    };
+
+    removePending = finalize;
+    exitClone.addEventListener(
+      "transitionend",
+      (e: TransitionEvent) => { if (e.target === exitClone) finalize(); },
+      { once: true },
+    );
+    setTimeout(finalize, duration + 50);
+
+    return true;
+  };
+
+  // ── Animated addItem ─────────────────────────────────────────────
+
+  const addItem = (item: T, index?: number): void => {
+    if (addPending) addPending();
+    if (removePending) removePending();
+
+    const { dom, sizeCache: sc, config: cfg, emitter } = ctx;
+    const prop = cfg.horizontal ? "translateX" : "translateY";
+    const insertIndex = index ?? 0;
+
+    // FIRST — capture offsets before insertion (single pass)
+    const preAffected = collectAffected(dom.items, null, (i) => i >= insertIndex);
+    const oldOffsets = new Map<number, number>();
+    for (let i = 0; i < preAffected.length; i++) {
+      const { idx } = preAffected[i]!;
+      oldOffsets.set(idx, sc.getOffset(idx));
+    }
+
+    // LAST — insert data + reconcile DOM
+    ctx.dataManager.addItem(item, insertIndex);
+    ctx.forceRender();
+    emitter.emit("data:change", { type: "add", id: item.id });
+
+    const newEl = getElement(insertIndex);
+    if (!newEl) return;
+
+    const newOffset = sc.getOffset(insertIndex);
+
+    // INVERT — collapse new element via scaleY(0), push shifted items to old positions
+    newEl.style.transition = "none";
+    newEl.style.transformOrigin = "top center";
+    newEl.style.transform = `${prop}(${Math.round(newOffset)}px) scaleY(0)`;
+    newEl.style.opacity = "0";
+
+    // Collect shifted items after DOM reconciliation
+    const postAffected = collectAffected(dom.items, newEl, (i) => i > insertIndex);
+
+    for (let i = 0; i < postAffected.length; i++) {
+      const { el, idx } = postAffected[i]!;
+      const oldOffset = oldOffsets.get(idx - 1);
+      if (oldOffset !== undefined) {
+        el.style.transition = "none";
+        el.style.transform = `${prop}(${Math.round(oldOffset)}px)`;
+      }
+    }
+
+    void dom.items.offsetHeight;
+
+    // PLAY — expand new element via scaleY(1), slide shifted items to final positions
+    newEl.style.transition = tTransformOpacity;
+    newEl.style.transform = `${prop}(${Math.round(newOffset)}px) scaleY(1)`;
+    newEl.style.opacity = "1";
+
+    for (let i = 0; i < postAffected.length; i++) {
+      const { el, idx } = postAffected[i]!;
+      el.style.transition = tTransform;
+      el.style.transform = `${prop}(${Math.round(sc.getOffset(idx))}px)`;
+    }
+
+    let settled = false;
+    const finalize = (): void => {
+      if (settled) return;
+      settled = true;
+      addPending = null;
+      newEl.style.transition = "";
+      newEl.style.transformOrigin = "";
+      newEl.style.transform = `${prop}(${Math.round(newOffset)}px)`;
+      newEl.style.opacity = "";
+      cleanTransitions(dom.items);
+    };
+
+    addPending = finalize;
+    newEl.addEventListener(
+      "transitionend",
+      (e: TransitionEvent) => { if (e.target === newEl) finalize(); },
+      { once: true },
+    );
+    setTimeout(finalize, duration + 50);
+  };
+
+  // ── Feature definition ───────────────────────────────────────────
+
+  return {
+    name: "transition",
+    priority: 45,
+    setup(context: BuilderContext<T>): void {
+      ctx = context;
+      ctx.methods.set("removeItem", removeItem);
+      ctx.methods.set("addItem", addItem);
+    },
+    destroy(): void {
+      if (removePending) removePending();
+      if (addPending) addPending();
+    },
+  };
+}

--- a/src/features/transition/feature.ts
+++ b/src/features/transition/feature.ts
@@ -216,7 +216,7 @@ export function withTransition<T extends VListItem = VListItem>(
     // PLAY — clone collapses via scaleY, items slide to final positions
     const rt = removeTiming!;
     exitClone.style.transition = rt.tTransformOpacity;
-    exitClone.style.transform = `${prop}(${Math.round(originalOffset - scrollDelta)}px) scaleY(0)`;
+    exitClone.style.transform = `${prop}(${Math.round(originalOffset)}px) scaleY(0)`;
     exitClone.style.opacity = "0";
 
     for (let i = 0; i < affected.length; i++) {

--- a/src/features/transition/feature.ts
+++ b/src/features/transition/feature.ts
@@ -1,11 +1,11 @@
 /**
- * withTransition — FLIP-based enter/exit animations for addItem and removeItem.
+ * withTransition — FLIP-based enter/exit animations for insertItem and removeItem.
  *
- * Opt-in feature that replaces the immediate add/remove with animated versions:
+ * Opt-in feature that replaces the immediate insert/remove with animated versions:
  * - removeItem: clone collapses via scaleY(0), siblings slide up
- * - addItem: new element expands in, siblings slide down
+ * - insertItem: new element expands in, siblings slide down
  *
- * Without this feature, add/remove are instantaneous.
+ * Without this feature, insert/remove are instantaneous.
  */
 
 import type { VListItem } from "../../types";
@@ -15,11 +15,48 @@ import type { VListFeature, BuilderContext } from "../../builder/types";
 // Config
 // =============================================================================
 
-export interface TransitionConfig {
-  /** Animation duration in ms (default: 150) */
+/** Per-animation timing overrides. */
+export interface TransitionTiming {
+  /** Duration in ms */
   duration?: number;
-  /** CSS easing function (default: MD3 emphasized) */
+  /** CSS easing function */
   easing?: string;
+}
+
+export interface TransitionConfig {
+  /** Shared duration in ms (default: 150). Overridden by add/remove sub-configs. */
+  duration?: number;
+  /** Shared CSS easing (default: MD3 emphasized). Overridden by add/remove sub-configs. */
+  easing?: string;
+  /** Insert animation config, or `false` to disable. */
+  insert?: TransitionTiming | false;
+  /** Remove animation config, or `false` to disable. */
+  remove?: TransitionTiming | false;
+}
+
+// =============================================================================
+// Internals
+// =============================================================================
+
+interface ResolvedTiming {
+  duration: number;
+  easing: string;
+  tTransform: string;
+  tTransformOpacity: string;
+}
+
+const DEFAULT_DURATION = 150;
+const DEFAULT_EASING = "cubic-bezier(0.2, 0, 0, 1)";
+
+function resolveTiming(
+  base: { duration: number; easing: string },
+  override?: TransitionTiming | false,
+): ResolvedTiming | null {
+  if (override === false) return null;
+  const d = override?.duration ?? base.duration;
+  const e = override?.easing ?? base.easing;
+  const t = `transform ${d}ms ${e}`;
+  return { duration: d, easing: e, tTransform: t, tTransformOpacity: `${t}, opacity ${d}ms ${e}` };
 }
 
 // =============================================================================
@@ -29,12 +66,12 @@ export interface TransitionConfig {
 export function withTransition<T extends VListItem = VListItem>(
   config?: TransitionConfig,
 ): VListFeature<T> {
-  const duration = config?.duration ?? 150;
-  const easing = config?.easing ?? "cubic-bezier(0.2, 0, 0, 1)";
+  const baseDuration = config?.duration ?? DEFAULT_DURATION;
+  const baseEasing = config?.easing ?? DEFAULT_EASING;
+  const base = { duration: baseDuration, easing: baseEasing };
 
-  // Pre-built transition strings — duration/easing are config-level constants
-  const tTransform = `transform ${duration}ms ${easing}`;
-  const tTransformOpacity = `${tTransform}, opacity ${duration}ms ${easing}`;
+  const removeTiming = resolveTiming(base, config?.remove);
+  const insertTiming = resolveTiming(base, config?.insert);
 
   let ctx: BuilderContext<T>;
   let removePending: (() => void) | null = null;
@@ -131,6 +168,10 @@ export function withTransition<T extends VListItem = VListItem>(
     exitClone.removeAttribute("data-id");
     exitClone.removeAttribute("id");
 
+    // Capture scroll position before removal (for bottom-of-list compensation)
+    const scrollProp = cfg.horizontal ? "scrollLeft" : "scrollTop";
+    const oldScroll = dom.viewport[scrollProp];
+
     // LAST — remove data + reconcile DOM
     const result = ctx.dataManager.removeItem(id);
     if (!result) {
@@ -145,33 +186,42 @@ export function withTransition<T extends VListItem = VListItem>(
     emitter.emit("data:change", { type: "remove", id });
     scheduleEnsureRange();
 
-    // Pin clone at original position
+    // Detect scroll clamp (content shrank, browser clamped scroll position)
+    const scrollDelta = oldScroll - dom.viewport[scrollProp];
+
+    // Pin clone at original position (adjusted for scroll shift)
     exitClone.style.transition = "none";
     exitClone.style.transformOrigin = "top center";
-    exitClone.style.transform = `${prop}(${Math.round(originalOffset)}px) scaleY(1)`;
+    exitClone.style.transform = `${prop}(${Math.round(originalOffset - scrollDelta)}px) scaleY(1)`;
     exitClone.style.zIndex = "1";
     dom.items.appendChild(exitClone);
 
-    // Collect shifted items once — avoids duplicate parseInt + filtering
-    const affected = collectAffected(dom.items, exitClone, (i) => i >= index);
+    // When scroll clamped, also animate items above the removed index
+    const affected = collectAffected(dom.items, exitClone,
+      scrollDelta > 0 ? () => true : (i) => i >= index);
 
-    // INVERT — push shifted items back to old positions
+    // INVERT — push items back to old visual positions
     for (let i = 0; i < affected.length; i++) {
       const { el, idx } = affected[i]!;
       el.style.transition = "none";
-      el.style.transform = `${prop}(${Math.round(sc.getOffset(idx) + itemSize)}px)`;
+      if (idx >= index) {
+        el.style.transform = `${prop}(${Math.round(sc.getOffset(idx) + itemSize - scrollDelta)}px)`;
+      } else {
+        el.style.transform = `${prop}(${Math.round(sc.getOffset(idx) - scrollDelta)}px)`;
+      }
     }
 
     void dom.items.offsetHeight;
 
     // PLAY — clone collapses via scaleY, items slide to final positions
-    exitClone.style.transition = tTransformOpacity;
-    exitClone.style.transform = `${prop}(${Math.round(originalOffset)}px) scaleY(0)`;
+    const rt = removeTiming!;
+    exitClone.style.transition = rt.tTransformOpacity;
+    exitClone.style.transform = `${prop}(${Math.round(originalOffset - scrollDelta)}px) scaleY(0)`;
     exitClone.style.opacity = "0";
 
     for (let i = 0; i < affected.length; i++) {
       const { el, idx } = affected[i]!;
-      el.style.transition = tTransform;
+      el.style.transition = rt.tTransform;
       el.style.transform = `${prop}(${Math.round(sc.getOffset(idx))}px)`;
     }
 
@@ -195,14 +245,14 @@ export function withTransition<T extends VListItem = VListItem>(
       (e: TransitionEvent) => { if (e.target === exitClone) finalize(); },
       { once: true },
     );
-    setTimeout(finalize, duration + 50);
+    setTimeout(finalize, rt.duration + 50);
 
     return true;
   };
 
-  // ── Animated addItem ─────────────────────────────────────────────
+  // ── Animated insertItem ──────────────────────────────────────────
 
-  const addItem = (item: T, index?: number): void => {
+  const insertItem = (item: T, index?: number): void => {
     if (addPending) addPending();
     if (removePending) removePending();
 
@@ -219,9 +269,9 @@ export function withTransition<T extends VListItem = VListItem>(
     }
 
     // LAST — insert data + reconcile DOM
-    ctx.dataManager.addItem(item, insertIndex);
+    ctx.dataManager.insertItem(item, insertIndex);
     ctx.forceRender();
-    emitter.emit("data:change", { type: "add", id: item.id });
+    emitter.emit("data:change", { type: "insert", id: item.id });
 
     const newEl = getElement(insertIndex);
     if (!newEl) return;
@@ -249,13 +299,14 @@ export function withTransition<T extends VListItem = VListItem>(
     void dom.items.offsetHeight;
 
     // PLAY — expand new element via scaleY(1), slide shifted items to final positions
-    newEl.style.transition = tTransformOpacity;
+    const at = insertTiming!;
+    newEl.style.transition = at.tTransformOpacity;
     newEl.style.transform = `${prop}(${Math.round(newOffset)}px) scaleY(1)`;
     newEl.style.opacity = "1";
 
     for (let i = 0; i < postAffected.length; i++) {
       const { el, idx } = postAffected[i]!;
-      el.style.transition = tTransform;
+      el.style.transition = at.tTransform;
       el.style.transform = `${prop}(${Math.round(sc.getOffset(idx))}px)`;
     }
 
@@ -277,18 +328,19 @@ export function withTransition<T extends VListItem = VListItem>(
       (e: TransitionEvent) => { if (e.target === newEl) finalize(); },
       { once: true },
     );
-    setTimeout(finalize, duration + 50);
+    setTimeout(finalize, at.duration + 50);
   };
 
   // ── Feature definition ───────────────────────────────────────────
 
   return {
     name: "transition",
+    conflicts: ["withGrid", "withTable"] as const,
     priority: 45,
     setup(context: BuilderContext<T>): void {
       ctx = context;
-      ctx.methods.set("removeItem", removeItem);
-      ctx.methods.set("addItem", addItem);
+      if (removeTiming) ctx.methods.set("removeItem", removeItem);
+      if (insertTiming) ctx.methods.set("insertItem", insertItem);
     },
     destroy(): void {
       if (removePending) removePending();

--- a/src/features/transition/feature.ts
+++ b/src/features/transition/feature.ts
@@ -167,6 +167,8 @@ export function withTransition<T extends VListItem = VListItem>(
     exitClone.removeAttribute("data-index");
     exitClone.removeAttribute("data-id");
     exitClone.removeAttribute("id");
+    exitClone.removeAttribute("aria-selected");
+    exitClone.classList.remove(`${cfg.classPrefix}-item--selected`);
 
     // Capture scroll position before removal (for bottom-of-list compensation)
     const scrollProp = cfg.horizontal ? "scrollLeft" : "scrollTop";
@@ -274,19 +276,21 @@ export function withTransition<T extends VListItem = VListItem>(
     emitter.emit("data:change", { type: "insert", id: item.id });
 
     const newEl = getElement(insertIndex);
-    if (!newEl) return;
-
-    const newOffset = sc.getOffset(insertIndex);
-
-    // INVERT — collapse new element via scaleY(0), push shifted items to old positions
-    newEl.style.transition = "none";
-    newEl.style.transformOrigin = "top center";
-    newEl.style.transform = `${prop}(${Math.round(newOffset)}px) scaleY(0)`;
-    newEl.style.opacity = "0";
 
     // Collect shifted items after DOM reconciliation
     const postAffected = collectAffected(dom.items, newEl, (i) => i > insertIndex);
 
+    if (newEl) {
+      const newOffset = sc.getOffset(insertIndex);
+
+      // INVERT — collapse new element via scaleY(0)
+      newEl.style.transition = "none";
+      newEl.style.transformOrigin = "top center";
+      newEl.style.transform = `${prop}(${Math.round(newOffset)}px) scaleY(0)`;
+      newEl.style.opacity = "0";
+    }
+
+    // INVERT — push shifted items to old positions
     for (let i = 0; i < postAffected.length; i++) {
       const { el, idx } = postAffected[i]!;
       const oldOffset = oldOffsets.get(idx - 1);
@@ -296,13 +300,19 @@ export function withTransition<T extends VListItem = VListItem>(
       }
     }
 
+    if (postAffected.length === 0 && !newEl) return;
+
     void dom.items.offsetHeight;
 
     // PLAY — expand new element via scaleY(1), slide shifted items to final positions
     const at = insertTiming!;
-    newEl.style.transition = at.tTransformOpacity;
-    newEl.style.transform = `${prop}(${Math.round(newOffset)}px) scaleY(1)`;
-    newEl.style.opacity = "1";
+
+    if (newEl) {
+      const newOffset = sc.getOffset(insertIndex);
+      newEl.style.transition = at.tTransformOpacity;
+      newEl.style.transform = `${prop}(${Math.round(newOffset)}px) scaleY(1)`;
+      newEl.style.opacity = "1";
+    }
 
     for (let i = 0; i < postAffected.length; i++) {
       const { el, idx } = postAffected[i]!;
@@ -315,19 +325,24 @@ export function withTransition<T extends VListItem = VListItem>(
       if (settled) return;
       settled = true;
       addPending = null;
-      newEl.style.transition = "";
-      newEl.style.transformOrigin = "";
-      newEl.style.transform = `${prop}(${Math.round(newOffset)}px)`;
-      newEl.style.opacity = "";
+      if (newEl) {
+        newEl.style.transition = "";
+        newEl.style.transformOrigin = "";
+        newEl.style.transform = `${prop}(${Math.round(sc.getOffset(insertIndex))}px)`;
+        newEl.style.opacity = "";
+      }
       cleanTransitions(dom.items);
     };
 
+    const animEl = newEl ?? postAffected[0]?.el;
     addPending = finalize;
-    newEl.addEventListener(
-      "transitionend",
-      (e: TransitionEvent) => { if (e.target === newEl) finalize(); },
-      { once: true },
-    );
+    if (animEl) {
+      animEl.addEventListener(
+        "transitionend",
+        (e: TransitionEvent) => { if (e.target === animEl) finalize(); },
+        { once: true },
+      );
+    }
     setTimeout(finalize, at.duration + 50);
   };
 

--- a/src/features/transition/feature.ts
+++ b/src/features/transition/feature.ts
@@ -79,6 +79,7 @@ export function withTransition<T extends VListItem = VListItem>(
   let toLayout: ((dataIndex: number) => number) | null = null;
   let baseInsertItem: ((item: T, index?: number) => void) | null = null;
   let baseRemoveItem: ((id: string | number) => boolean) | null = null;
+  let setupDataManager: unknown = null;
 
   const scheduleEnsureRange = (): void => {
     if (ensureRangePending) return;
@@ -99,6 +100,8 @@ export function withTransition<T extends VListItem = VListItem>(
   /** Convert data index to layout index (accounts for group headers). */
   const dataToLayout = (dataIndex: number): number =>
     toLayout ? toLayout(dataIndex) : dataIndex;
+
+  const isBaseStale = (): boolean => ctx.dataManager !== setupDataManager;
 
   // ── Animated removeItem ──────────────────────────────────────────
 
@@ -123,7 +126,8 @@ export function withTransition<T extends VListItem = VListItem>(
 
     // Off-screen — immediate removal, no animation
     if (!removedEl || layoutIndex < 0) {
-      const result = baseRemoveItem ? baseRemoveItem(id) : ctx.dataManager.removeItem(id);
+      const stale = isBaseStale();
+      const result = (!stale && baseRemoveItem) ? baseRemoveItem(id) : ctx.dataManager.removeItem(id);
       if (!result) {
         if (process.env.NODE_ENV !== "production") {
           console.warn(
@@ -158,7 +162,8 @@ export function withTransition<T extends VListItem = VListItem>(
     const oldScroll = dom.viewport[scrollProp];
 
     // LAST — remove data + reconcile DOM
-    const result = baseRemoveItem ? baseRemoveItem(id) : ctx.dataManager.removeItem(id);
+    const stale = isBaseStale();
+    const result = (!stale && baseRemoveItem) ? baseRemoveItem(id) : ctx.dataManager.removeItem(id);
     if (!result) {
       if (process.env.NODE_ENV !== "production") {
         console.warn(
@@ -259,7 +264,7 @@ export function withTransition<T extends VListItem = VListItem>(
     const wasAtEnd = oldScroll >= oldMaxScroll - 1;
 
     // INSERT — mutate data + reconcile DOM
-    if (baseInsertItem) {
+    if (!isBaseStale() && baseInsertItem) {
       baseInsertItem(item, insertDataIndex);
     } else {
       ctx.dataManager.insertItem(item, insertDataIndex);
@@ -338,6 +343,7 @@ export function withTransition<T extends VListItem = VListItem>(
     setup(context: BuilderContext<T>): void {
       ctx = context;
       origin = ctx.config.reverse ? "bottom center" : "top center";
+      setupDataManager = ctx.dataManager;
       toLayout = (ctx.methods.get("_dataToLayoutIndex") as ((i: number) => number)) ?? null;
       baseInsertItem = (ctx.methods.get("insertItem") as ((item: T, index?: number) => void)) ?? null;
       baseRemoveItem = (ctx.methods.get("removeItem") as ((id: string | number) => boolean)) ?? null;

--- a/src/features/transition/feature.ts
+++ b/src/features/transition/feature.ts
@@ -83,12 +83,13 @@ export function withTransition<T extends VListItem = VListItem>(
 
   const scheduleEnsureRange = (): void => {
     if (ensureRangePending) return;
-    const dm = ctx.dataManager as any;
-    if (typeof dm.ensureRange !== "function") return;
+    if (typeof (ctx.dataManager as any).ensureRange !== "function") return;
     ensureRangePending = true;
     queueMicrotask(() => {
       ensureRangePending = false;
-      const t = ctx.dataManager.getTotal();
+      const dm = ctx.dataManager as any;
+      if (typeof dm.ensureRange !== "function") return;
+      const t = dm.getTotal();
       const { start, end } = ctx.state.viewportState.renderRange;
       if (t > 0 && end >= start) dm.ensureRange(start, end).catch(() => {});
     });

--- a/src/features/transition/feature.ts
+++ b/src/features/transition/feature.ts
@@ -115,8 +115,7 @@ export function withTransition<T extends VListItem = VListItem>(
         ? parseInt((active as HTMLElement).dataset?.index ?? "-1", 10)
         : -1;
 
-    const dataIndex = ctx.dataManager.getIndexById(id);
-    const layoutIndex = dataIndex >= 0 ? dataToLayout(dataIndex) : -1;
+    const layoutIndex = ctx.dataManager.getIndexById(id);
     const removedEl = layoutIndex >= 0 ? getElement(layoutIndex) : null;
     const itemSize = layoutIndex >= 0 ? sc.getSize(layoutIndex) : 0;
     const originalOffset = layoutIndex >= 0 ? sc.getOffset(layoutIndex) : 0;
@@ -333,7 +332,7 @@ export function withTransition<T extends VListItem = VListItem>(
 
   return {
     name: "transition",
-    conflicts: ["withGrid", "withTable"] as const,
+    conflicts: ["withGrid", "withTable", "withMasonry"] as const,
     priority: 45,
     setup(context: BuilderContext<T>): void {
       ctx = context;

--- a/src/features/transition/feature.ts
+++ b/src/features/transition/feature.ts
@@ -24,7 +24,7 @@ export interface TransitionTiming {
 }
 
 export interface TransitionConfig {
-  /** Shared duration in ms (default: 150). Overridden by add/remove sub-configs. */
+  /** Shared duration in ms (default: 200). Overridden by add/remove sub-configs. */
   duration?: number;
   /** Shared CSS easing (default: MD3 emphasized). Overridden by add/remove sub-configs. */
   easing?: string;
@@ -41,8 +41,6 @@ export interface TransitionConfig {
 interface ResolvedTiming {
   duration: number;
   easing: string;
-  tTransform: string;
-  tTransformOpacity: string;
 }
 
 const DEFAULT_DURATION = 200;
@@ -53,10 +51,10 @@ function resolveTiming(
   override?: TransitionTiming | false,
 ): ResolvedTiming | null {
   if (override === false) return null;
-  const d = override?.duration ?? base.duration;
-  const e = override?.easing ?? base.easing;
-  const t = `transform ${d}ms ${e}`;
-  return { duration: d, easing: e, tTransform: t, tTransformOpacity: `${t}, opacity ${d}ms ${e}` };
+  return {
+    duration: override?.duration ?? base.duration,
+    easing: override?.easing ?? base.easing,
+  };
 }
 
 // =============================================================================
@@ -101,23 +99,6 @@ export function withTransition<T extends VListItem = VListItem>(
   /** Convert data index to layout index (accounts for group headers). */
   const dataToLayout = (dataIndex: number): number =>
     toLayout ? toLayout(dataIndex) : dataIndex;
-
-  /** Collect DOM children matching a data-index predicate in a single pass. */
-  const collectAffected = (
-    container: HTMLElement,
-    skip: HTMLElement | null,
-    predicate: (idx: number) => boolean,
-  ): Array<{ el: HTMLElement; idx: number }> => {
-    const result: Array<{ el: HTMLElement; idx: number }> = [];
-    const children = container.children;
-    for (let i = 0; i < children.length; i++) {
-      const el = children[i] as HTMLElement;
-      if (el === skip) continue;
-      const idx = parseInt(el.dataset?.index ?? "-1", 10);
-      if (idx >= 0 && predicate(idx)) result.push({ el, idx });
-    }
-    return result;
-  };
 
   // ── Animated removeItem ──────────────────────────────────────────
 
@@ -193,10 +174,6 @@ export function withTransition<T extends VListItem = VListItem>(
     // Detect scroll clamp (content shrank, browser clamped scroll position)
     const scrollDelta = oldScroll - dom.viewport[scrollProp];
 
-    // Pin clone at original position (adjusted for scroll shift)
-    exitClone.style.transition = "none";
-    exitClone.style.transformOrigin = origin;
-    exitClone.style.transform = `${prop}(${Math.round(originalOffset - scrollDelta)}px) scaleY(1)`;
     exitClone.style.zIndex = "1";
     dom.items.appendChild(exitClone);
 
@@ -205,17 +182,20 @@ export function withTransition<T extends VListItem = VListItem>(
     const animations: Animation[] = [];
 
     // Animate clone: scaleY(1→0), opacity(1→0)
+    const cloneStart = Math.round(originalOffset - scrollDelta);
     animations.push(exitClone.animate([
-      { transform: `${prop}(${Math.round(originalOffset - scrollDelta)}px) scaleY(1)`, opacity: 1, transformOrigin: origin },
+      { transform: `${prop}(${cloneStart}px) scaleY(1)`, opacity: 1, transformOrigin: origin },
       { transform: `${prop}(${Math.round(originalOffset)}px) scaleY(0)`, opacity: 0, transformOrigin: origin },
     ], animOptions));
 
     // Animate siblings from old visual positions to new positions
-    const affected = collectAffected(dom.items, exitClone,
-      scrollDelta > 0 ? () => true : (i) => i >= layoutIndex);
-
-    for (let i = 0; i < affected.length; i++) {
-      const { el, idx } = affected[i]!;
+    const allOnClamp = scrollDelta > 0;
+    const itemChildren = dom.items.children;
+    for (let i = 0; i < itemChildren.length; i++) {
+      const el = itemChildren[i] as HTMLElement;
+      if (el === exitClone) continue;
+      const idx = parseInt(el.dataset?.index ?? "-1", 10);
+      if (idx < 0 || (!allOnClamp && idx < layoutIndex)) continue;
       const newOffset = sc.getOffset(idx);
       const oldVisual = idx >= layoutIndex
         ? Math.round(newOffset + itemSize - scrollDelta)
@@ -272,7 +252,11 @@ export function withTransition<T extends VListItem = VListItem>(
     }
 
     const scrollProp = cfg.horizontal ? "scrollLeft" : "scrollTop";
+    const sizeProp = cfg.horizontal ? "scrollWidth" : "scrollHeight";
+    const clientProp = cfg.horizontal ? "clientWidth" : "clientHeight";
     const oldScroll = dom.viewport[scrollProp];
+    const oldMaxScroll = dom.viewport[sizeProp] - dom.viewport[clientProp];
+    const wasAtEnd = oldScroll >= oldMaxScroll - 1;
 
     // INSERT — mutate data + reconcile DOM
     if (baseInsertItem) {
@@ -287,10 +271,9 @@ export function withTransition<T extends VListItem = VListItem>(
     let scrollDelta = dom.viewport[scrollProp] - oldScroll;
     const postInsertLayoutIndex = dataToLayout(insertDataIndex);
 
-    // Reverse mode: scroll to reveal new item
-    if (cfg.reverse && scrollDelta === 0) {
-      const maxScroll = dom.viewport[cfg.horizontal ? "scrollWidth" : "scrollHeight"]
-        - dom.viewport[cfg.horizontal ? "clientWidth" : "clientHeight"];
+    // Reverse mode: scroll to reveal new item only if already at bottom
+    if (cfg.reverse && scrollDelta === 0 && wasAtEnd) {
+      const maxScroll = dom.viewport[sizeProp] - dom.viewport[clientProp];
       dom.viewport[scrollProp] = maxScroll;
       scrollDelta = dom.viewport[scrollProp] - oldScroll;
       if (scrollDelta > 0) ctx.forceRender();

--- a/src/features/transition/feature.ts
+++ b/src/features/transition/feature.ts
@@ -45,7 +45,7 @@ interface ResolvedTiming {
   tTransformOpacity: string;
 }
 
-const DEFAULT_DURATION = 150;
+const DEFAULT_DURATION = 200;
 const DEFAULT_EASING = "cubic-bezier(0.2, 0, 0, 1)";
 
 function resolveTiming(
@@ -74,9 +74,13 @@ export function withTransition<T extends VListItem = VListItem>(
   const insertTiming = resolveTiming(base, config?.insert);
 
   let ctx: BuilderContext<T>;
+  let origin: string;
   let removePending: (() => void) | null = null;
   let addPending: (() => void) | null = null;
   let ensureRangePending = false;
+  let toLayout: ((dataIndex: number) => number) | null = null;
+  let baseInsertItem: ((item: T, index?: number) => void) | null = null;
+  let baseRemoveItem: ((id: string | number) => boolean) | null = null;
 
   const scheduleEnsureRange = (): void => {
     if (ensureRangePending) return;
@@ -93,6 +97,10 @@ export function withTransition<T extends VListItem = VListItem>(
 
   const getElement = (index: number): HTMLElement | null =>
     (ctx.renderer as any).getElement(index);
+
+  /** Convert data index to layout index (accounts for group headers). */
+  const dataToLayout = (dataIndex: number): number =>
+    toLayout ? toLayout(dataIndex) : dataIndex;
 
   /** Collect DOM children matching a data-index predicate in a single pass. */
   const collectAffected = (
@@ -111,13 +119,6 @@ export function withTransition<T extends VListItem = VListItem>(
     return result;
   };
 
-  const cleanTransitions = (container: HTMLElement): void => {
-    const children = container.children;
-    for (let i = 0; i < children.length; i++) {
-      (children[i] as HTMLElement).style.transition = "";
-    }
-  };
-
   // ── Animated removeItem ──────────────────────────────────────────
 
   const removeItem = (id: string | number): boolean => {
@@ -133,14 +134,15 @@ export function withTransition<T extends VListItem = VListItem>(
         ? parseInt((active as HTMLElement).dataset?.index ?? "-1", 10)
         : -1;
 
-    const index = ctx.dataManager.getIndexById(id);
-    const removedEl = index >= 0 ? getElement(index) : null;
-    const itemSize = index >= 0 ? sc.getSize(index) : 0;
-    const originalOffset = index >= 0 ? sc.getOffset(index) : 0;
+    const dataIndex = ctx.dataManager.getIndexById(id);
+    const layoutIndex = dataIndex >= 0 ? dataToLayout(dataIndex) : -1;
+    const removedEl = layoutIndex >= 0 ? getElement(layoutIndex) : null;
+    const itemSize = layoutIndex >= 0 ? sc.getSize(layoutIndex) : 0;
+    const originalOffset = layoutIndex >= 0 ? sc.getOffset(layoutIndex) : 0;
 
     // Off-screen — immediate removal, no animation
-    if (!removedEl || index < 0) {
-      const result = ctx.dataManager.removeItem(id);
+    if (!removedEl || layoutIndex < 0) {
+      const result = baseRemoveItem ? baseRemoveItem(id) : ctx.dataManager.removeItem(id);
       if (!result) {
         if (process.env.NODE_ENV !== "production") {
           console.warn(
@@ -175,7 +177,7 @@ export function withTransition<T extends VListItem = VListItem>(
     const oldScroll = dom.viewport[scrollProp];
 
     // LAST — remove data + reconcile DOM
-    const result = ctx.dataManager.removeItem(id);
+    const result = baseRemoveItem ? baseRemoveItem(id) : ctx.dataManager.removeItem(id);
     if (!result) {
       if (process.env.NODE_ENV !== "production") {
         console.warn(
@@ -193,38 +195,37 @@ export function withTransition<T extends VListItem = VListItem>(
 
     // Pin clone at original position (adjusted for scroll shift)
     exitClone.style.transition = "none";
-    exitClone.style.transformOrigin = "top center";
+    exitClone.style.transformOrigin = origin;
     exitClone.style.transform = `${prop}(${Math.round(originalOffset - scrollDelta)}px) scaleY(1)`;
     exitClone.style.zIndex = "1";
     dom.items.appendChild(exitClone);
 
-    // When scroll clamped, also animate items above the removed index
-    const affected = collectAffected(dom.items, exitClone,
-      scrollDelta > 0 ? () => true : (i) => i >= index);
-
-    // INVERT — push items back to old visual positions
-    for (let i = 0; i < affected.length; i++) {
-      const { el, idx } = affected[i]!;
-      el.style.transition = "none";
-      if (idx >= index) {
-        el.style.transform = `${prop}(${Math.round(sc.getOffset(idx) + itemSize - scrollDelta)}px)`;
-      } else {
-        el.style.transform = `${prop}(${Math.round(sc.getOffset(idx) - scrollDelta)}px)`;
-      }
-    }
-
-    void dom.items.offsetHeight;
-
-    // PLAY — clone collapses via scaleY, items slide to final positions
     const rt = removeTiming!;
-    exitClone.style.transition = rt.tTransformOpacity;
-    exitClone.style.transform = `${prop}(${Math.round(originalOffset)}px) scaleY(0)`;
-    exitClone.style.opacity = "0";
+    const animOptions: KeyframeAnimationOptions = { duration: rt.duration, easing: rt.easing };
+    const animations: Animation[] = [];
+
+    // Animate clone: scaleY(1→0), opacity(1→0)
+    animations.push(exitClone.animate([
+      { transform: `${prop}(${Math.round(originalOffset - scrollDelta)}px) scaleY(1)`, opacity: 1, transformOrigin: origin },
+      { transform: `${prop}(${Math.round(originalOffset)}px) scaleY(0)`, opacity: 0, transformOrigin: origin },
+    ], animOptions));
+
+    // Animate siblings from old visual positions to new positions
+    const affected = collectAffected(dom.items, exitClone,
+      scrollDelta > 0 ? () => true : (i) => i >= layoutIndex);
 
     for (let i = 0; i < affected.length; i++) {
       const { el, idx } = affected[i]!;
-      el.style.transition = rt.tTransform;
-      el.style.transform = `${prop}(${Math.round(sc.getOffset(idx))}px)`;
+      const newOffset = sc.getOffset(idx);
+      const oldVisual = idx >= layoutIndex
+        ? Math.round(newOffset + itemSize - scrollDelta)
+        : Math.round(newOffset - scrollDelta);
+      const newVisual = Math.round(newOffset);
+      if (oldVisual === newVisual) continue;
+      animations.push(el.animate([
+        { transform: `${prop}(${oldVisual}px)` },
+        { transform: `${prop}(${newVisual}px)` },
+      ], animOptions));
     }
 
     let settled = false;
@@ -233,7 +234,9 @@ export function withTransition<T extends VListItem = VListItem>(
       settled = true;
       removePending = null;
       exitClone.remove();
-      cleanTransitions(dom.items);
+      for (const a of animations) {
+        if (a.playState !== "finished") a.cancel();
+      }
       if (focIdx >= 0) {
         const t = ctx.getVirtualTotal();
         if (t > 0) getElement(Math.min(focIdx, t - 1))?.focus();
@@ -242,17 +245,13 @@ export function withTransition<T extends VListItem = VListItem>(
     };
 
     removePending = finalize;
-    exitClone.addEventListener(
-      "transitionend",
-      (e: TransitionEvent) => { if (e.target === exitClone) finalize(); },
-      { once: true },
-    );
+    Promise.all(animations.map(a => a.finished)).then(finalize, finalize);
     setTimeout(finalize, rt.duration + 50);
 
     return true;
   };
 
-  // ── Animated insertItem ──────────────────────────────────────────
+  // ── Animated insertItem (Web Animations API) ─────────────────────
 
   const insertItem = (item: T, index?: number): void => {
     if (addPending) addPending();
@@ -260,89 +259,90 @@ export function withTransition<T extends VListItem = VListItem>(
 
     const { dom, sizeCache: sc, config: cfg, emitter } = ctx;
     const prop = cfg.horizontal ? "translateX" : "translateY";
-    const insertIndex = index ?? 0;
+    const insertDataIndex = index ?? 0;
 
-    // FIRST — capture offsets before insertion (single pass)
-    const preAffected = collectAffected(dom.items, null, (i) => i >= insertIndex);
-    const oldOffsets = new Map<number, number>();
-    for (let i = 0; i < preAffected.length; i++) {
-      const { idx } = preAffected[i]!;
-      oldOffsets.set(idx, sc.getOffset(idx));
+    // FIRST — capture ALL visible elements' offsets by item ID
+    const oldOffsetById = new Map<string, number>();
+    const children = dom.items.children;
+    for (let i = 0; i < children.length; i++) {
+      const el = children[i] as HTMLElement;
+      const id = el.dataset?.id;
+      const idx = parseInt(el.dataset?.index ?? "-1", 10);
+      if (id && idx >= 0) oldOffsetById.set(id, sc.getOffset(idx));
     }
 
-    // LAST — insert data + reconcile DOM
-    ctx.dataManager.insertItem(item, insertIndex);
+    const scrollProp = cfg.horizontal ? "scrollLeft" : "scrollTop";
+    const oldScroll = dom.viewport[scrollProp];
+
+    // INSERT — mutate data + reconcile DOM
+    if (baseInsertItem) {
+      baseInsertItem(item, insertDataIndex);
+    } else {
+      ctx.dataManager.insertItem(item, insertDataIndex);
+    }
     ctx.forceRender();
     emitter.emit("data:change", { type: "insert", id: item.id });
+    scheduleEnsureRange();
 
-    const newEl = getElement(insertIndex);
+    let scrollDelta = dom.viewport[scrollProp] - oldScroll;
+    const postInsertLayoutIndex = dataToLayout(insertDataIndex);
 
-    // Collect shifted items after DOM reconciliation
-    const postAffected = collectAffected(dom.items, newEl, (i) => i > insertIndex);
-
-    if (newEl) {
-      const newOffset = sc.getOffset(insertIndex);
-
-      // INVERT — collapse new element via scaleY(0)
-      newEl.style.transition = "none";
-      newEl.style.transformOrigin = "top center";
-      newEl.style.transform = `${prop}(${Math.round(newOffset)}px) scaleY(0)`;
-      newEl.style.opacity = "0";
+    // Reverse mode: scroll to reveal new item
+    if (cfg.reverse && scrollDelta === 0) {
+      const maxScroll = dom.viewport[cfg.horizontal ? "scrollWidth" : "scrollHeight"]
+        - dom.viewport[cfg.horizontal ? "clientWidth" : "clientHeight"];
+      dom.viewport[scrollProp] = maxScroll;
+      scrollDelta = dom.viewport[scrollProp] - oldScroll;
+      if (scrollDelta > 0) ctx.forceRender();
     }
 
-    // INVERT — push shifted items to old positions
-    for (let i = 0; i < postAffected.length; i++) {
-      const { el, idx } = postAffected[i]!;
-      const oldOffset = oldOffsets.get(idx - 1);
-      if (oldOffset !== undefined) {
-        el.style.transition = "none";
-        el.style.transform = `${prop}(${Math.round(oldOffset)}px)`;
-      }
-    }
-
-    if (postAffected.length === 0 && !newEl) return;
-
-    void dom.items.offsetHeight;
-
-    // PLAY — expand new element via scaleY(1), slide shifted items to final positions
+    const newEl = getElement(postInsertLayoutIndex);
     const at = insertTiming!;
+    const animOptions: KeyframeAnimationOptions = { duration: at.duration, easing: at.easing };
+    const animations: Animation[] = [];
 
+    // Animate new element: scaleY(0→1), opacity(0→1)
     if (newEl) {
-      const newOffset = sc.getOffset(insertIndex);
-      newEl.style.transition = at.tTransformOpacity;
-      newEl.style.transform = `${prop}(${Math.round(newOffset)}px) scaleY(1)`;
-      newEl.style.opacity = "1";
+      const newOffset = sc.getOffset(postInsertLayoutIndex);
+      animations.push(newEl.animate([
+        { transform: `${prop}(${Math.round(newOffset)}px) scaleY(0)`, opacity: 0, transformOrigin: origin },
+        { transform: `${prop}(${Math.round(newOffset)}px) scaleY(1)`, opacity: 1, transformOrigin: origin },
+      ], animOptions));
     }
 
-    for (let i = 0; i < postAffected.length; i++) {
-      const { el, idx } = postAffected[i]!;
-      el.style.transition = at.tTransform;
-      el.style.transform = `${prop}(${Math.round(sc.getOffset(idx))}px)`;
+    // Animate existing items from old visual positions to new positions
+    const postChildren = dom.items.children;
+    for (let i = 0; i < postChildren.length; i++) {
+      const el = postChildren[i] as HTMLElement;
+      if (el === newEl) continue;
+      const id = el.dataset?.id;
+      const idx = parseInt(el.dataset?.index ?? "-1", 10);
+      if (!id || idx < 0) continue;
+      const oldOffset = oldOffsetById.get(id);
+      if (oldOffset === undefined) continue;
+      const newOffset = sc.getOffset(idx);
+      const visualOld = Math.round(oldOffset + scrollDelta);
+      const visualNew = Math.round(newOffset);
+      if (visualOld === visualNew) continue;
+      animations.push(el.animate([
+        { transform: `${prop}(${visualOld}px)` },
+        { transform: `${prop}(${visualNew}px)` },
+      ], animOptions));
     }
+
+    if (animations.length === 0) return;
 
     let settled = false;
     const finalize = (): void => {
       if (settled) return;
       settled = true;
       addPending = null;
-      if (newEl) {
-        newEl.style.transition = "";
-        newEl.style.transformOrigin = "";
-        newEl.style.transform = `${prop}(${Math.round(sc.getOffset(insertIndex))}px)`;
-        newEl.style.opacity = "";
+      for (const a of animations) {
+        if (a.playState !== "finished") a.cancel();
       }
-      cleanTransitions(dom.items);
     };
-
-    const animEl = newEl ?? postAffected[0]?.el;
     addPending = finalize;
-    if (animEl) {
-      animEl.addEventListener(
-        "transitionend",
-        (e: TransitionEvent) => { if (e.target === animEl) finalize(); },
-        { once: true },
-      );
-    }
+    Promise.all(animations.map(a => a.finished)).then(finalize, finalize);
     setTimeout(finalize, at.duration + 50);
   };
 
@@ -354,6 +354,10 @@ export function withTransition<T extends VListItem = VListItem>(
     priority: 45,
     setup(context: BuilderContext<T>): void {
       ctx = context;
+      origin = ctx.config.reverse ? "bottom center" : "top center";
+      toLayout = (ctx.methods.get("_dataToLayoutIndex") as ((i: number) => number)) ?? null;
+      baseInsertItem = (ctx.methods.get("insertItem") as ((item: T, index?: number) => void)) ?? null;
+      baseRemoveItem = (ctx.methods.get("removeItem") as ((id: string | number) => boolean)) ?? null;
       if (removeTiming) ctx.methods.set("removeItem", removeItem);
       if (insertTiming) ctx.methods.set("insertItem", insertItem);
     },

--- a/src/features/transition/feature.ts
+++ b/src/features/transition/feature.ts
@@ -115,7 +115,8 @@ export function withTransition<T extends VListItem = VListItem>(
         ? parseInt((active as HTMLElement).dataset?.index ?? "-1", 10)
         : -1;
 
-    const layoutIndex = ctx.dataManager.getIndexById(id);
+    let layoutIndex = ctx.dataManager.getIndexById(id);
+    if (layoutIndex < 0 && typeof id === "number") layoutIndex = id;
     const removedEl = layoutIndex >= 0 ? getElement(layoutIndex) : null;
     const itemSize = layoutIndex >= 0 ? sc.getSize(layoutIndex) : 0;
     const originalOffset = layoutIndex >= 0 ? sc.getOffset(layoutIndex) : 0;

--- a/src/features/transition/index.ts
+++ b/src/features/transition/index.ts
@@ -1,0 +1,9 @@
+/**
+ * vlist/transition — FLIP-based enter/exit animations
+ * Opt-in animated add/remove for smooth list transitions
+ *
+ * Usage: import { withTransition } from 'vlist'
+ */
+
+export { withTransition } from "./feature";
+export type { TransitionConfig } from "./feature";

--- a/src/features/transition/index.ts
+++ b/src/features/transition/index.ts
@@ -6,4 +6,4 @@
  */
 
 export { withTransition } from "./feature";
-export type { TransitionConfig } from "./feature";
+export type { TransitionConfig, TransitionTiming } from "./feature";

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export { withSortable } from "./features/sortable";
 export type { SortableConfig } from "./features/sortable";
 export { withAutoSize } from "./features/autosize";
 export { withTransition } from "./features/transition";
-export type { TransitionConfig } from "./features/transition";
+export type { TransitionConfig, TransitionTiming } from "./features/transition";
 
 // Utils
 export { createStats } from "./utils/stats";

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,8 @@ export { withTable } from "./features/table";
 export { withSortable } from "./features/sortable";
 export type { SortableConfig } from "./features/sortable";
 export { withAutoSize } from "./features/autosize";
+export { withTransition } from "./features/transition";
+export type { TransitionConfig } from "./features/transition";
 
 // Utils
 export { createStats } from "./utils/stats";

--- a/src/types.ts
+++ b/src/types.ts
@@ -623,7 +623,10 @@ export interface VListEvents<T extends VListItem = VListItem> extends EventMap {
   "scroll:idle": { scrollPosition: number };
 
   /** Data changed — fired after item removal or other data mutations */
-  "data:change": { type: "remove"; id: string | number } | { type: "update"; id: string | number };
+  "data:change": { type: "add"; id: string | number } | { type: "remove"; id: string | number } | { type: "update"; id: string | number };
+
+  /** Remove animation ended — fired after the exit transition completes */
+  "remove:end": { id: string | number };
 
   /** Sort started — fired when a drag begins */
   "sort:start": { index: number };

--- a/src/types.ts
+++ b/src/types.ts
@@ -623,7 +623,7 @@ export interface VListEvents<T extends VListItem = VListItem> extends EventMap {
   "scroll:idle": { scrollPosition: number };
 
   /** Data changed — fired after item removal or other data mutations */
-  "data:change": { type: "add"; id: string | number } | { type: "remove"; id: string | number } | { type: "update"; id: string | number };
+  "data:change": { type: "insert"; id: string | number } | { type: "add"; id: string | number } | { type: "remove"; id: string | number } | { type: "update"; id: string | number };
 
   /** Remove animation ended — fired after the exit transition completes */
   "remove:end": { id: string | number };

--- a/test/builder/index.test.ts
+++ b/test/builder/index.test.ts
@@ -6306,4 +6306,23 @@ describe("API dev warnings and edge cases", () => {
     // Total should be 7
     expect(list.total).toBe(7);
   });
+
+  // ── insertItem debounced ensureRange ───────────────────────────────
+
+  it("should coalesce multiple synchronous insertItem calls via microtask", async () => {
+    list = vlist<TestItem>({
+      container,
+      item: { height: 40, template },
+      items: createTestItems(5),
+    }).build();
+
+    list.insertItem({ id: 100, name: "Item 100" }, 0);
+    list.insertItem({ id: 101, name: "Item 101" }, 0);
+    list.insertItem({ id: 102, name: "Item 102" }, 0);
+
+    await new Promise<void>((r) => setTimeout(r, 10));
+
+    expect(list.total).toBe(8);
+  });
+
 });

--- a/test/features/async/sparse.test.ts
+++ b/test/features/async/sparse.test.ts
@@ -565,6 +565,81 @@ describe("createSparseStorage", () => {
   });
 
   // ===========================================================================
+  // insert
+  // ===========================================================================
+
+  describe("insert", () => {
+    it("should insert item at index and shift subsequent items", () => {
+      const storage = createSparseStorage({ chunkSize: 10 });
+      const items = createItems(5);
+      for (let i = 0; i < items.length; i++) storage.set(i, items[i]!);
+      storage.setTotal(5);
+
+      storage.insert(0, createItem(99));
+
+      expect(storage.getTotal()).toBe(6);
+      expect(storage.get(0)!.id).toBe(99);
+      expect(storage.get(1)!.id).toBe(1);
+      expect(storage.get(5)!.id).toBe(5);
+    });
+
+    it("should shift items across chunk boundaries", () => {
+      const storage = createSparseStorage({ chunkSize: 5 });
+      const items = createItems(10);
+      for (let i = 0; i < items.length; i++) storage.set(i, items[i]!);
+      storage.setTotal(10);
+
+      storage.insert(0, createItem(99));
+
+      expect(storage.getTotal()).toBe(11);
+      expect(storage.get(0)!.id).toBe(99);
+      expect(storage.get(5)!.id).toBe(5);
+      expect(storage.get(6)!.id).toBe(6);
+      expect(storage.get(10)!.id).toBe(10);
+    });
+
+    it("should make sparse chunks partial after cross-boundary shift", () => {
+      const storage = createSparseStorage({ chunkSize: 5 });
+      storage.setTotal(15);
+      // Load chunks 0 and 2, leave chunk 1 empty (simulates eviction)
+      for (let i = 0; i < 5; i++) storage.set(i, createItem(i));
+      for (let i = 10; i < 15; i++) storage.set(i, createItem(i));
+
+      expect(storage.isChunkFullyLoaded(0)).toBe(true);
+      expect(storage.isChunkFullyLoaded(2)).toBe(true);
+
+      storage.insert(0, createItem(99));
+
+      // Chunk 2 items shifted from 10-14 to 11-15, crossing into chunk 3
+      expect(storage.isChunkFullyLoaded(2)).toBe(false);
+    });
+
+    it("should ignore out-of-bounds index", () => {
+      const storage = createSparseStorage({ chunkSize: 10 });
+      storage.setTotal(5);
+
+      storage.insert(-1, createItem(99));
+      expect(storage.getTotal()).toBe(5);
+
+      storage.insert(6, createItem(99));
+      expect(storage.getTotal()).toBe(5);
+    });
+
+    it("should handle insert at the end", () => {
+      const storage = createSparseStorage({ chunkSize: 10 });
+      const items = createItems(3);
+      for (let i = 0; i < items.length; i++) storage.set(i, items[i]!);
+      storage.setTotal(3);
+
+      storage.insert(3, createItem(99));
+
+      expect(storage.getTotal()).toBe(4);
+      expect(storage.get(3)!.id).toBe(99);
+      expect(storage.getCachedCount()).toBe(4);
+    });
+  });
+
+  // ===========================================================================
   // getRange
   // ===========================================================================
 
@@ -965,6 +1040,73 @@ describe("createSparseStorage", () => {
 
         storage.delete(0);
         expect(storage.isChunkLoaded(0)).toBe(false);
+      });
+    });
+
+    describe("isChunkFullyLoaded", () => {
+      it("should return false for empty chunk", () => {
+        const storage = createSparseStorage({ chunkSize: 5 });
+        storage.setTotal(10);
+
+        expect(storage.isChunkFullyLoaded(0)).toBe(false);
+      });
+
+      it("should return true when chunk has all expected items", () => {
+        const storage = createSparseStorage({ chunkSize: 5 });
+        storage.setTotal(10);
+        for (let i = 0; i < 5; i++) storage.set(i, createItem(i));
+
+        expect(storage.isChunkFullyLoaded(0)).toBe(true);
+        expect(storage.isChunkFullyLoaded(1)).toBe(false);
+      });
+
+      it("should return false when chunk is partial", () => {
+        const storage = createSparseStorage({ chunkSize: 5 });
+        storage.setTotal(10);
+        for (let i = 0; i < 3; i++) storage.set(i, createItem(i));
+
+        expect(storage.isChunkFullyLoaded(0)).toBe(false);
+      });
+
+      it("should handle last chunk with fewer items than chunkSize", () => {
+        const storage = createSparseStorage({ chunkSize: 5 });
+        storage.setTotal(7);
+        for (let i = 5; i < 7; i++) storage.set(i, createItem(i));
+
+        expect(storage.isChunkFullyLoaded(1)).toBe(true);
+      });
+
+      it("should detect partial chunks after insert with sparse loading", () => {
+        const storage = createSparseStorage({ chunkSize: 5 });
+        storage.setTotal(15);
+        // Load chunks 0 and 2, leave chunk 1 empty (evicted)
+        for (let i = 0; i < 5; i++) storage.set(i, createItem(i));
+        for (let i = 10; i < 15; i++) storage.set(i, createItem(i));
+
+        expect(storage.isChunkFullyLoaded(0)).toBe(true);
+        expect(storage.isChunkFullyLoaded(2)).toBe(true);
+
+        storage.insert(0, createItem(99));
+
+        // Chunk 2 items shifted 10-14 → 11-15, last item crossed to chunk 3
+        expect(storage.isChunkFullyLoaded(0)).toBe(true);
+        expect(storage.isChunkFullyLoaded(2)).toBe(false);
+      });
+
+      it("should detect partial chunks after delete with sparse loading", () => {
+        const storage = createSparseStorage({ chunkSize: 5 });
+        storage.setTotal(15);
+        // Load chunks 0 and 2, leave chunk 1 empty
+        for (let i = 0; i < 5; i++) storage.set(i, createItem(i));
+        for (let i = 10; i < 15; i++) storage.set(i, createItem(i));
+
+        expect(storage.isChunkFullyLoaded(0)).toBe(true);
+        expect(storage.isChunkFullyLoaded(2)).toBe(true);
+
+        storage.delete(0);
+
+        // Chunk 0 lost one item (4 left, expected 5)
+        expect(storage.isChunkFullyLoaded(0)).toBe(false);
       });
     });
 

--- a/test/features/groups/async-bridge.test.ts
+++ b/test/features/groups/async-bridge.test.ts
@@ -415,6 +415,82 @@ describe("createAsyncGroupBridge", () => {
   });
 
   // ===========================================================================
+  // insertAt
+  // ===========================================================================
+
+  describe("insertAt", () => {
+    it("inserts into existing group — group count stays, item count increments", () => {
+      const { bridge, loadItems } = createBridge();
+      loadItems(ALL_TRACKS, 0, 9);
+
+      expect(bridge.groupCount).toBe(3);
+      expect(bridge.groups[0]!.count).toBe(3);
+
+      const newTrack: TestTrack = { id: "new-1", title: "Track X", day: "May 7" };
+      bridge.insertAt(1, newTrack);
+
+      expect(bridge.groupCount).toBe(3);
+      expect(bridge.groups[0]!.count).toBe(4);
+      expect(bridge.totalEntries).toBe(13); // 10 items + 3 headers
+    });
+
+    it("inserts item that creates a new group", () => {
+      const { bridge, loadItems } = createBridge();
+      loadItems(ALL_TRACKS, 0, 9);
+
+      expect(bridge.groupCount).toBe(3);
+
+      const newTrack: TestTrack = { id: "new-2", title: "Track Y", day: "May 4" };
+      bridge.insertAt(9, newTrack);
+
+      expect(bridge.groupCount).toBe(4);
+      expect(bridge.groups[3]!.key).toBe("May 4");
+      expect(bridge.groups[3]!.count).toBe(1);
+      expect(bridge.totalEntries).toBe(14); // 10 items + 4 headers
+    });
+
+    it("shifts subsequent data indices up by 1", () => {
+      const { bridge, loadItems } = createBridge();
+      loadItems(ALL_TRACKS, 0, 9);
+
+      // Track D (May 6) is at data index 3, layout index 5
+      expect(bridge.dataToLayoutIndex(3)).toBe(5);
+
+      const newTrack: TestTrack = { id: "new-3", title: "Track Z", day: "May 7" };
+      bridge.insertAt(0, newTrack);
+
+      // Track D shifted from data index 3 to 4, May 6 header shifts too
+      expect(bridge.dataToLayoutIndex(4)).toBe(6);
+    });
+
+    it("totalEntries increments correctly", () => {
+      const { bridge, loadItems } = createBridge();
+      loadItems(ALL_TRACKS, 0, 9);
+      expect(bridge.totalEntries).toBe(12);
+
+      const newTrack: TestTrack = { id: "new-4", title: "Track W", day: "May 6" };
+      bridge.insertAt(4, newTrack);
+      expect(bridge.totalEntries).toBe(13);
+    });
+
+    it("roundtrips with removeAt", () => {
+      const { bridge, loadItems } = createBridge();
+      loadItems(ALL_TRACKS, 0, 9);
+
+      const beforeGroups = bridge.groupCount;
+      const beforeTotal = bridge.totalEntries;
+
+      const newTrack: TestTrack = { id: "new-5", title: "Track V", day: "May 7" };
+      bridge.insertAt(0, newTrack);
+      expect(bridge.totalEntries).toBe(beforeTotal + 1);
+
+      bridge.removeAt(0);
+      expect(bridge.groupCount).toBe(beforeGroups);
+      expect(bridge.totalEntries).toBe(beforeTotal);
+    });
+  });
+
+  // ===========================================================================
   // Reset
   // ===========================================================================
 

--- a/test/features/transition/feature.test.ts
+++ b/test/features/transition/feature.test.ts
@@ -1161,6 +1161,77 @@ describe("withTransition — Groups integration", () => {
     allAnimations.length = 0;
   });
 
+  it("bypasses stale base methods when data manager is replaced (async groups)", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const staleRemove = mock((_id: string | number): boolean => false);
+    ctx.methods.set("removeItem", staleRemove);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    // Simulate async groups replacing the data manager after setup
+    const newDataManager = {
+      ...ctx.dataManager,
+      removeItem: (id: string | number): boolean => {
+        const index = testItems.findIndex((item) => item.id === id);
+        if (index < 0) return false;
+        testItems.splice(index, 1);
+        return true;
+      },
+      getIndexById: ctx.dataManager.getIndexById,
+      getTotal: () => testItems.length,
+    };
+    (ctx as any).dataManager = newDataManager;
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    const result = removeFn(2);
+
+    expect(result).toBe(true);
+    expect(staleRemove).not.toHaveBeenCalled();
+    expect(allAnimations.length).toBeGreaterThan(0);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("bypasses stale base insertItem when data manager is replaced", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const staleInsert = mock((_item: TestItem, _index?: number): void => {});
+    ctx.methods.set("insertItem", staleInsert);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    // Simulate async groups replacing the data manager
+    const newDataManager = {
+      ...ctx.dataManager,
+      insertItem: (item: TestItem, index: number): void => {
+        testItems.splice(index, 0, item);
+      },
+    };
+    (ctx as any).dataManager = newDataManager;
+
+    allAnimations.length = 0;
+    const insertFn = ctx.methods.get("insertItem") as (
+      item: TestItem,
+      index?: number,
+    ) => void;
+    insertFn({ id: 950, name: "Async Insert" }, 0);
+
+    expect(staleInsert).not.toHaveBeenCalled();
+    expect(testItems[0]!.id).toBe(950);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
   it("chains through baseRemoveItem from groups feature", async () => {
     const { ctx, testDom, testItems } = createMockContext();
     populateDOM(testDom, testItems, 50, 0, 5);

--- a/test/features/transition/feature.test.ts
+++ b/test/features/transition/feature.test.ts
@@ -238,8 +238,14 @@ function createMockContext(
         testItems.splice(index, 0, item);
       },
       removeItem: (id: string | number) => {
-        const index = testItems.findIndex((item) => item.id === id);
-        if (index < 0) return false;
+        let index: number;
+        if (typeof id === "number") {
+          const byId = testItems.findIndex((item) => item.id === id);
+          index = byId >= 0 ? byId : id;
+        } else {
+          index = testItems.findIndex((item) => String(item.id) === id);
+        }
+        if (index < 0 || index >= testItems.length) return false;
         testItems.splice(index, 1);
         return true;
       },
@@ -1125,6 +1131,36 @@ describe("withTransition — Groups integration", () => {
     allAnimations.length = 0;
   });
 
+  it("preserves transition wrappers when async groups deletes static overrides", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const staticInsert = (item: TestItem, index?: number): void => {
+      testItems.splice(index ?? 0, 0, item);
+    };
+    const staticRemove = (_id: string | number): boolean => true;
+    ctx.methods.set("insertItem", staticInsert);
+    ctx.methods.set("removeItem", staticRemove);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    const transitionInsert = ctx.methods.get("insertItem");
+    const transitionRemove = ctx.methods.get("removeItem");
+    expect(transitionInsert).not.toBe(staticInsert);
+    expect(transitionRemove).not.toBe(staticRemove);
+
+    // Simulate what async groups does: only delete if still the static override
+    if (ctx.methods.get("removeItem") === staticRemove) ctx.methods.delete("removeItem");
+    if (ctx.methods.get("insertItem") === staticInsert) ctx.methods.delete("insertItem");
+
+    expect(ctx.methods.get("insertItem")).toBe(transitionInsert);
+    expect(ctx.methods.get("removeItem")).toBe(transitionRemove);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
   it("chains through baseRemoveItem from groups feature", async () => {
     const { ctx, testDom, testItems } = createMockContext();
     populateDOM(testDom, testItems, 50, 0, 5);
@@ -1274,6 +1310,31 @@ describe("withTransition — Edge cases", () => {
     expect(() =>
       insertFn({ id: 1001, name: "Into Empty" }, 0),
     ).not.toThrow();
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("animates removal by numeric index when id doesn't match", async () => {
+    const items: TestItem[] = [
+      { id: 10, name: "Item 10" },
+      { id: 11, name: "Item 11" },
+      { id: 12, name: "Item 12" },
+    ];
+    const { ctx, testDom } = createMockContext({ items });
+    populateDOM(testDom, items, 50, 0, 3);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    const result = removeFn(1);
+
+    expect(result).toBe(true);
+    expect(allAnimations.length).toBeGreaterThan(0);
 
     await flushMicrotasks();
     allAnimations.length = 0;

--- a/test/features/transition/feature.test.ts
+++ b/test/features/transition/feature.test.ts
@@ -1,0 +1,1305 @@
+import { describe, it, expect, mock, beforeAll, afterAll } from "bun:test";
+import { JSDOM } from "jsdom";
+import { withTransition } from "../../../src/features/transition/feature";
+import { createSizeCache } from "../../../src/rendering/sizes";
+import type { VListItem } from "../../../src/types";
+import type { BuilderContext } from "../../../src/builder/types";
+
+// =============================================================================
+// JSDOM + Web Animations API Mock
+// =============================================================================
+
+let dom: JSDOM;
+let originalDocument: any;
+let originalWindow: any;
+
+interface MockAnimation {
+  finished: Promise<Animation>;
+  playState: AnimationPlayState;
+  cancel: () => void;
+  keyframes: Keyframe[];
+  options: KeyframeAnimationOptions;
+}
+
+const allAnimations: MockAnimation[] = [];
+
+const createMockAnimation = (
+  keyframes: Keyframe[],
+  options: KeyframeAnimationOptions,
+): MockAnimation => {
+  let resolveFn: (a: Animation) => void;
+  const anim: MockAnimation = {
+    finished: new Promise<Animation>((resolve) => {
+      resolveFn = resolve;
+    }),
+    playState: "running" as AnimationPlayState,
+    cancel: () => {
+      anim.playState = "idle" as AnimationPlayState;
+    },
+    keyframes,
+    options,
+  };
+  setTimeout(() => {
+    anim.playState = "finished" as AnimationPlayState;
+    resolveFn(anim as unknown as Animation);
+  }, 0);
+  allAnimations.push(anim);
+  return anim;
+};
+
+beforeAll(() => {
+  dom = new JSDOM("<!DOCTYPE html><html><body></body></html>", {
+    url: "http://localhost/",
+    pretendToBeVisual: true,
+  });
+
+  originalDocument = global.document;
+  originalWindow = global.window;
+
+  global.document = dom.window.document;
+  global.window = dom.window as any;
+  global.HTMLElement = dom.window.HTMLElement;
+  (global as any).Element = dom.window.Element;
+
+  dom.window.HTMLElement.prototype.animate = function (
+    this: HTMLElement,
+    keyframes: Keyframe[] | PropertyIndexedKeyframes,
+    options?: number | KeyframeAnimationOptions,
+  ): Animation {
+    const kf = Array.isArray(keyframes) ? keyframes : [];
+    const opts =
+      typeof options === "number" ? { duration: options } : options ?? {};
+    return createMockAnimation(kf, opts) as unknown as Animation;
+  };
+});
+
+afterAll(() => {
+  global.document = originalDocument;
+  global.window = originalWindow;
+});
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+interface TestItem extends VListItem {
+  id: number;
+  name: string;
+}
+
+const createTestItems = (count: number): TestItem[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: i,
+    name: `Item ${i}`,
+  }));
+
+function createTestDOM() {
+  const root = document.createElement("div");
+  const viewport = document.createElement("div");
+  const content = document.createElement("div");
+  const items = document.createElement("div");
+
+  root.className = "vlist";
+  viewport.className = "vlist-viewport";
+  content.className = "vlist-content";
+  items.className = "vlist-items";
+
+  Object.defineProperty(viewport, "clientHeight", {
+    value: 600,
+    configurable: true,
+  });
+  Object.defineProperty(viewport, "clientWidth", {
+    value: 400,
+    configurable: true,
+  });
+  Object.defineProperty(viewport, "scrollTop", {
+    value: 0,
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(viewport, "scrollLeft", {
+    value: 0,
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(viewport, "scrollHeight", {
+    value: 5000,
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(viewport, "scrollWidth", {
+    value: 400,
+    writable: true,
+    configurable: true,
+  });
+
+  content.appendChild(items);
+  viewport.appendChild(content);
+  root.appendChild(viewport);
+  document.body.appendChild(root);
+
+  return { root, viewport, content, items };
+}
+
+function createItemElement(
+  index: number,
+  id: number | string,
+  offset: number,
+): HTMLElement {
+  const el = document.createElement("div");
+  el.className = "vlist-item";
+  el.dataset.index = String(index);
+  el.dataset.id = String(id);
+  el.style.transform = `translateY(${offset}px)`;
+  el.textContent = `Item ${id}`;
+  return el;
+}
+
+function createMockContext(
+  overrides: {
+    horizontal?: boolean;
+    reverse?: boolean;
+    items?: TestItem[];
+  } = {},
+): {
+  ctx: BuilderContext<TestItem>;
+  testDom: ReturnType<typeof createTestDOM>;
+  testItems: TestItem[];
+  emitCalls: Array<{ event: string; payload: unknown }>;
+} {
+  const testDom = createTestDOM();
+  const testItems = overrides.items ?? createTestItems(20);
+  const itemHeight = 50;
+  const sizeCache = createSizeCache(itemHeight, testItems.length);
+  const emitCalls: Array<{ event: string; payload: unknown }> = [];
+
+  let virtualTotalFn = () => testItems.length;
+  const forceRenderFn = mock(() => {});
+
+  const ctx: BuilderContext<TestItem> = {
+    dom: testDom as any,
+    sizeCache: sizeCache as any,
+    emitter: {
+      on: () => {},
+      off: () => {},
+      emit: (event: string, payload: unknown) => {
+        emitCalls.push({ event, payload });
+      },
+    } as any,
+    config: {
+      overscan: 2,
+      classPrefix: "vlist",
+      reverse: overrides.reverse ?? false,
+      wrap: false,
+      horizontal: overrides.horizontal ?? false,
+      ariaIdPrefix: "vlist",
+      interactive: true,
+    },
+    rawConfig: {
+      container: document.createElement("div"),
+      items: testItems,
+      item: {
+        height: itemHeight,
+        template: (item: TestItem) => `<div>${item.name}</div>`,
+      },
+    },
+    renderer: {
+      render: () => {},
+      updateItemClasses: () => {},
+      updatePositions: () => {},
+      updateItem: () => {},
+      getElement: (index: number): HTMLElement | null => {
+        const children = testDom.items.children;
+        for (let i = 0; i < children.length; i++) {
+          const el = children[i] as HTMLElement;
+          if (el.dataset.index === String(index)) return el;
+        }
+        return null;
+      },
+      clear: () => {},
+      destroy: () => {},
+    } as any,
+    dataManager: {
+      getTotal: () => testItems.length,
+      getCached: () => testItems.length,
+      getItem: (index: number) => testItems[index],
+      getIndexById: (id: string | number) => {
+        for (let i = 0; i < testItems.length; i++) {
+          if (testItems[i]?.id === id) return i;
+        }
+        return -1;
+      },
+      getItemsInRange: (start: number, end: number) =>
+        testItems.slice(start, end + 1),
+      isItemLoaded: () => true,
+      getState: () => ({ total: testItems.length }),
+      getStorage: () => null,
+      insertItem: (item: TestItem, index: number) => {
+        testItems.splice(index, 0, item);
+      },
+      removeItem: (id: string | number) => {
+        const index = testItems.findIndex((item) => item.id === id);
+        if (index < 0) return false;
+        testItems.splice(index, 1);
+        return true;
+      },
+    } as any,
+    scrollController: {
+      getScrollTop: () => 0,
+      scrollTo: () => {},
+      isAtTop: () => true,
+      isAtBottom: () => false,
+      isCompressed: () => false,
+    } as any,
+    state: {
+      dataState: {
+        total: testItems.length,
+        cached: testItems.length,
+        isLoading: false,
+        pendingRanges: [],
+        error: undefined,
+        hasMore: false,
+        cursor: undefined,
+      },
+      viewportState: {
+        scrollPosition: 0,
+        containerSize: 600,
+        totalSize: testItems.length * itemHeight,
+        actualSize: testItems.length * itemHeight,
+        isCompressed: false,
+        compressionRatio: 1,
+        visibleRange: { start: 0, end: 11 },
+        renderRange: { start: 0, end: 15 },
+      },
+      renderState: {
+        range: { start: 0, end: 15 },
+        visibleRange: { start: 0, end: 11 },
+        renderedCount: 16,
+      },
+      lastRenderRange: { start: -1, end: -1 },
+      isDestroyed: false,
+    } as any,
+    getContainerWidth: () => 400,
+    afterScroll: [],
+    afterRenderBatch: [],
+    idleHandlers: [],
+    clickHandlers: [],
+    contextMenuHandlers: [],
+    keydownHandlers: [],
+    resizeHandlers: [],
+    contentSizeHandlers: [],
+    destroyHandlers: [],
+    methods: new Map(),
+    replaceTemplate: () => {},
+    replaceRenderer: () => {},
+    replaceDataManager: () => {},
+    replaceScrollController: () => {},
+    getItemsForRange: (range) => testItems.slice(range.start, range.end + 1),
+    getAllLoadedItems: () => testItems,
+    getVirtualTotal: () => virtualTotalFn(),
+    getCachedCompression: () => ({
+      isCompressed: false,
+      actualSize: testItems.length * itemHeight,
+      virtualSize: testItems.length * itemHeight,
+      ratio: 1,
+    }),
+    getCompressionContext: () => ({
+      scrollPosition: 0,
+      totalItems: testItems.length,
+      containerSize: 600,
+      rangeStart: 0,
+    }),
+    renderIfNeeded: () => {},
+    forceRender: forceRenderFn,
+    invalidateRendered: () => {},
+    getRenderFns: () => ({
+      renderIfNeeded: () => {},
+      forceRender: forceRenderFn,
+    }),
+    setRenderFns: () => {},
+    setVirtualTotalFn: (fn) => {
+      virtualTotalFn = fn;
+    },
+    rebuildSizeCache: () => {},
+    setSizeConfig: () => {},
+    updateContentSize: () => {},
+    updateCompressionMode: () => {},
+    setVisibleRangeFn: () => {},
+    setScrollToPosFn: () => {},
+    getScrollToPos: () => 0,
+    setPositionElementFn: () => {},
+    setUpdateItemClassesFn: () => {},
+    setScrollFns: () => {},
+    triggerScrollFrame: () => {},
+    setScrollTarget: () => {},
+    getScrollTarget: () => testDom.viewport as any,
+    setContainerDimensions: () => {},
+    disableViewportResize: () => {},
+    disableWheelHandler: () => {},
+    adjustScrollPosition: (pos: number) => pos,
+    getStripeIndexFn: () => (index: number) => index,
+    setStripeIndexFn: () => {},
+    getItemToScrollIndexFn: () => (index: number) => index,
+    getVisibleRange: mock(() => {}),
+    setItemToScrollIndexFn: () => {},
+  };
+
+  return { ctx, testDom, testItems, emitCalls };
+}
+
+function populateDOM(
+  testDom: ReturnType<typeof createTestDOM>,
+  items: TestItem[],
+  itemHeight: number,
+  start: number = 0,
+  count?: number,
+): void {
+  const n = count ?? Math.min(items.length, 12);
+  for (let i = 0; i < n; i++) {
+    const idx = start + i;
+    if (idx >= items.length) break;
+    const el = createItemElement(idx, items[idx]!.id, idx * itemHeight);
+    testDom.items.appendChild(el);
+  }
+}
+
+const flushMicrotasks = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+// =============================================================================
+// Config Resolution
+// =============================================================================
+
+describe("withTransition — Config", () => {
+  it("uses default duration and easing when no config provided", () => {
+    const feature = withTransition();
+    expect(feature.name).toBe("transition");
+    const { ctx } = createMockContext();
+    feature.setup!(ctx);
+    expect(ctx.methods.has("removeItem")).toBe(true);
+    expect(ctx.methods.has("insertItem")).toBe(true);
+  });
+
+  it("accepts custom duration and easing", () => {
+    const feature = withTransition({
+      duration: 400,
+      easing: "ease-in-out",
+    });
+    const { ctx } = createMockContext();
+    feature.setup!(ctx);
+    expect(ctx.methods.has("removeItem")).toBe(true);
+    expect(ctx.methods.has("insertItem")).toBe(true);
+  });
+
+  it("disables remove animation when remove: false", () => {
+    const feature = withTransition({ remove: false });
+    const { ctx } = createMockContext();
+    feature.setup!(ctx);
+    expect(ctx.methods.has("removeItem")).toBe(false);
+    expect(ctx.methods.has("insertItem")).toBe(true);
+  });
+
+  it("disables insert animation when insert: false", () => {
+    const feature = withTransition({ insert: false });
+    const { ctx } = createMockContext();
+    feature.setup!(ctx);
+    expect(ctx.methods.has("removeItem")).toBe(true);
+    expect(ctx.methods.has("insertItem")).toBe(false);
+  });
+
+  it("disables both when both set to false", () => {
+    const feature = withTransition({ insert: false, remove: false });
+    const { ctx } = createMockContext();
+    feature.setup!(ctx);
+    expect(ctx.methods.has("removeItem")).toBe(false);
+    expect(ctx.methods.has("insertItem")).toBe(false);
+  });
+
+  it("applies per-animation timing overrides", () => {
+    const feature = withTransition({
+      duration: 300,
+      insert: { duration: 100 },
+      remove: { easing: "linear" },
+    });
+    const { ctx } = createMockContext();
+    feature.setup!(ctx);
+    expect(ctx.methods.has("removeItem")).toBe(true);
+    expect(ctx.methods.has("insertItem")).toBe(true);
+  });
+});
+
+// =============================================================================
+// Feature Metadata
+// =============================================================================
+
+describe("withTransition — Metadata", () => {
+  it("has correct name", () => {
+    expect(withTransition().name).toBe("transition");
+  });
+
+  it("has correct priority", () => {
+    expect(withTransition().priority).toBe(45);
+  });
+
+  it("conflicts with grid, table, and masonry", () => {
+    const feature = withTransition();
+    expect(feature.conflicts).toContain("withGrid");
+    expect(feature.conflicts).toContain("withTable");
+    expect(feature.conflicts).toContain("withMasonry");
+  });
+
+  it("has a destroy method", () => {
+    expect(typeof withTransition().destroy).toBe("function");
+  });
+});
+
+// =============================================================================
+// Setup
+// =============================================================================
+
+describe("withTransition — Setup", () => {
+  it("captures baseInsertItem and baseRemoveItem from methods map", () => {
+    const baseInsert = mock((_item: TestItem, _index?: number) => {});
+    const baseRemove = mock((_id: string | number): boolean => true);
+
+    const { ctx } = createMockContext();
+    ctx.methods.set("insertItem", baseInsert);
+    ctx.methods.set("removeItem", baseRemove);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    const insertFn = ctx.methods.get("insertItem") as Function;
+    const removeFn = ctx.methods.get("removeItem") as Function;
+
+    expect(insertFn).not.toBe(baseInsert);
+    expect(removeFn).not.toBe(baseRemove);
+  });
+
+  it("captures _dataToLayoutIndex from methods map", () => {
+    const { ctx, testDom } = createMockContext();
+    const layoutMapper = (i: number): number => i + 1;
+    ctx.methods.set("_dataToLayoutIndex", layoutMapper);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    expect(ctx.methods.has("insertItem")).toBe(true);
+    expect(ctx.methods.has("removeItem")).toBe(true);
+  });
+
+  it("sets transformOrigin to 'top center' for non-reverse", () => {
+    const { ctx, testDom } = createMockContext();
+    populateDOM(testDom, createTestItems(5), 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    const insertFn = ctx.methods.get("insertItem") as Function;
+    const newItem: TestItem = { id: 999, name: "New" };
+    insertFn(newItem, 0);
+
+    const anim = allAnimations[allAnimations.length - 1];
+    if (anim) {
+      const kf = anim.keyframes;
+      const hasTopCenter = kf.some(
+        (k: any) => k.transformOrigin === "top center",
+      );
+      expect(hasTopCenter).toBe(true);
+    }
+    allAnimations.length = 0;
+  });
+
+  it("sets transformOrigin to 'bottom center' for reverse mode", () => {
+    const { ctx, testDom } = createMockContext({ reverse: true });
+    populateDOM(testDom, createTestItems(5), 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    const insertFn = ctx.methods.get("insertItem") as Function;
+    const newItem: TestItem = { id: 999, name: "New" };
+    insertFn(newItem, 0);
+
+    const anim = allAnimations[allAnimations.length - 1];
+    if (anim) {
+      const kf = anim.keyframes;
+      const hasBottomCenter = kf.some(
+        (k: any) => k.transformOrigin === "bottom center",
+      );
+      expect(hasBottomCenter).toBe(true);
+    }
+    allAnimations.length = 0;
+  });
+});
+
+// =============================================================================
+// removeItem — Off-Screen Path
+// =============================================================================
+
+describe("withTransition — removeItem (off-screen)", () => {
+  it("removes item without animation when element is not in DOM", async () => {
+    const { ctx, testDom, testItems, emitCalls } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    const result = removeFn(15);
+
+    expect(result).toBe(true);
+    expect(allAnimations.length).toBe(0);
+    expect(emitCalls.some((c) => c.event === "data:change")).toBe(true);
+    expect(emitCalls.some((c) => c.event === "remove:end")).toBe(true);
+    await flushMicrotasks();
+  });
+
+  it("returns false and warns for non-existent item", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    const result = removeFn(9999);
+
+    expect(result).toBe(false);
+    await flushMicrotasks();
+  });
+
+  it("calls forceRender after removing off-screen item", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    removeFn(15);
+
+    expect(ctx.forceRender).toHaveBeenCalled();
+    await flushMicrotasks();
+  });
+});
+
+// =============================================================================
+// removeItem — Animated Path
+// =============================================================================
+
+describe("withTransition — removeItem (animated)", () => {
+  it("creates exit clone and animations for visible item", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 10);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    const result = removeFn(3);
+
+    expect(result).toBe(true);
+    expect(allAnimations.length).toBeGreaterThan(0);
+
+    const exitClone = testDom.items.lastElementChild as HTMLElement;
+    expect(exitClone.style.pointerEvents).toBe("none");
+    expect(exitClone.style.overflow).toBe("hidden");
+    expect(exitClone.hasAttribute("data-index")).toBe(false);
+    expect(exitClone.hasAttribute("data-id")).toBe(false);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("removes clone after animations finish", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    removeFn(2);
+
+    const cloneBefore = testDom.items.querySelector(
+      "[style*='pointer-events']",
+    );
+    expect(cloneBefore).not.toBeNull();
+
+    await flushMicrotasks();
+
+    const cloneAfter = testDom.items.querySelector(
+      "[style*='pointer-events: none']",
+    );
+    expect(cloneAfter).toBeNull();
+    allAnimations.length = 0;
+  });
+
+  it("emits data:change and remove:end events", async () => {
+    const { ctx, testDom, testItems, emitCalls } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    removeFn(2);
+
+    expect(emitCalls.some((c) => c.event === "data:change")).toBe(true);
+    const dataChange = emitCalls.find((c) => c.event === "data:change");
+    expect((dataChange?.payload as any).type).toBe("remove");
+    expect((dataChange?.payload as any).id).toBe(2);
+
+    await flushMicrotasks();
+
+    expect(emitCalls.some((c) => c.event === "remove:end")).toBe(true);
+    allAnimations.length = 0;
+  });
+
+  it("returns false when baseRemoveItem returns false for visible item", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const baseRemove = mock(
+      (_id: string | number): boolean => false,
+    );
+    ctx.methods.set("removeItem", baseRemove);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    const result = removeFn(2);
+
+    expect(result).toBe(false);
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("uses baseRemoveItem when provided by a prior feature", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const baseRemove = mock((_id: string | number): boolean => {
+      const index = testItems.findIndex((item) => item.id === _id);
+      if (index < 0) return false;
+      testItems.splice(index, 1);
+      return true;
+    });
+    ctx.methods.set("removeItem", baseRemove);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    removeFn(15);
+    expect(baseRemove).toHaveBeenCalledWith(15);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("uses translateY for vertical lists", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    removeFn(2);
+
+    const cloneAnim = allAnimations[0];
+    expect(cloneAnim).toBeDefined();
+    const fromTransform = (cloneAnim!.keyframes[0] as any)?.transform ?? "";
+    expect(fromTransform).toContain("translateY");
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("strips selected-item attributes from clone", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const el = testDom.items.children[2] as HTMLElement;
+    el.setAttribute("aria-selected", "true");
+    el.setAttribute("id", "test-id");
+    el.classList.add("vlist-item--selected");
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    removeFn(2);
+
+    const exitClone = testDom.items.lastElementChild as HTMLElement;
+    expect(exitClone.hasAttribute("aria-selected")).toBe(false);
+    expect(exitClone.hasAttribute("id")).toBe(false);
+    expect(exitClone.classList.contains("vlist-item--selected")).toBe(false);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("cancels previous remove animation when a new one starts", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 10);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+
+    removeFn(3);
+    const firstBatchCount = allAnimations.length;
+    expect(firstBatchCount).toBeGreaterThan(0);
+
+    populateDOM(testDom, testItems, 50, 0, 9);
+    removeFn(5);
+
+    const firstAnims = allAnimations.slice(0, firstBatchCount);
+    const allCancelled = firstAnims.every((a) => a.playState !== "running");
+    expect(allCancelled).toBe(true);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+});
+
+// =============================================================================
+// insertItem — Animated Path
+// =============================================================================
+
+describe("withTransition — insertItem (animated)", () => {
+  it("inserts item and creates animations", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const insertFn = ctx.methods.get("insertItem") as (
+      item: TestItem,
+      index?: number,
+    ) => void;
+    const newItem: TestItem = { id: 100, name: "New Item" };
+    insertFn(newItem, 0);
+
+    expect(testItems).toContainEqual(newItem);
+    expect(ctx.forceRender).toHaveBeenCalled();
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("emits data:change event with insert type", async () => {
+    const { ctx, testDom, testItems, emitCalls } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const insertFn = ctx.methods.get("insertItem") as (
+      item: TestItem,
+      index?: number,
+    ) => void;
+    insertFn({ id: 100, name: "New" }, 2);
+
+    const dataChange = emitCalls.find((c) => c.event === "data:change");
+    expect(dataChange).toBeDefined();
+    expect((dataChange?.payload as any).type).toBe("insert");
+    expect((dataChange?.payload as any).id).toBe(100);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("uses baseInsertItem when provided by a prior feature", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const baseInsert = mock((item: TestItem, index?: number) => {
+      testItems.splice(index ?? 0, 0, item);
+    });
+    ctx.methods.set("insertItem", baseInsert);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    const insertFn = ctx.methods.get("insertItem") as (
+      item: TestItem,
+      index?: number,
+    ) => void;
+    insertFn({ id: 200, name: "Base Insert" }, 1);
+
+    expect(baseInsert).toHaveBeenCalled();
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("defaults insertion index to 0 when not provided", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const insertFn = ctx.methods.get("insertItem") as (
+      item: TestItem,
+      index?: number,
+    ) => void;
+    insertFn({ id: 300, name: "Default Index" });
+
+    expect(testItems[0]!.id).toBe(300);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("cancels pending remove animation when insert starts", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 10);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    const insertFn = ctx.methods.get("insertItem") as (
+      item: TestItem,
+      index?: number,
+    ) => void;
+
+    removeFn(3);
+    const removeAnims = [...allAnimations];
+
+    insertFn({ id: 500, name: "Interrupt" }, 0);
+
+    const allSettled = removeAnims.every((a) => a.playState !== "running");
+    expect(allSettled).toBe(true);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("cancels pending insert animation when a new insert starts", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 10);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const insertFn = ctx.methods.get("insertItem") as (
+      item: TestItem,
+      index?: number,
+    ) => void;
+
+    insertFn({ id: 600, name: "First" }, 0);
+    const firstAnims = [...allAnimations];
+
+    insertFn({ id: 601, name: "Second" }, 0);
+
+    const allSettled = firstAnims.every((a) => a.playState !== "running");
+    expect(allSettled).toBe(true);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("captures old offsets by data-id before insert", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const insertFn = ctx.methods.get("insertItem") as (
+      item: TestItem,
+      index?: number,
+    ) => void;
+    insertFn({ id: 700, name: "Middle" }, 2);
+
+    expect(ctx.forceRender).toHaveBeenCalled();
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+});
+
+// =============================================================================
+// Horizontal Mode
+// =============================================================================
+
+describe("withTransition — Horizontal mode", () => {
+  it("uses translateX instead of translateY", async () => {
+    const { ctx, testDom, testItems } = createMockContext({ horizontal: true });
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    removeFn(2);
+
+    const cloneAnim = allAnimations[0];
+    expect(cloneAnim).toBeDefined();
+    const fromTransform = (cloneAnim!.keyframes[0] as any)?.transform ?? "";
+    expect(fromTransform).toContain("translateX");
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("uses scrollLeft for scroll position in horizontal mode", async () => {
+    const { ctx, testDom, testItems } = createMockContext({ horizontal: true });
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    removeFn(2);
+
+    expect(ctx.forceRender).toHaveBeenCalled();
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+});
+
+// =============================================================================
+// Reverse Mode
+// =============================================================================
+
+describe("withTransition — Reverse mode", () => {
+  it("uses 'bottom center' transform origin in reverse mode", async () => {
+    const { ctx, testDom, testItems } = createMockContext({ reverse: true });
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    removeFn(2);
+
+    const cloneAnim = allAnimations[0];
+    expect(cloneAnim).toBeDefined();
+    const kf = cloneAnim!.keyframes;
+    const hasBottomCenter = kf.some(
+      (k: any) => k.transformOrigin === "bottom center",
+    );
+    expect(hasBottomCenter).toBe(true);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("scrolls to reveal new item when at bottom in reverse mode", async () => {
+    const { ctx, testDom, testItems } = createMockContext({ reverse: true });
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    Object.defineProperty(testDom.viewport, "scrollTop", {
+      value: 4400,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(testDom.viewport, "scrollHeight", {
+      value: 5000,
+      writable: true,
+      configurable: true,
+    });
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const insertFn = ctx.methods.get("insertItem") as (
+      item: TestItem,
+      index?: number,
+    ) => void;
+    insertFn({ id: 800, name: "Reverse Insert" }, 0);
+
+    expect(ctx.forceRender).toHaveBeenCalled();
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+});
+
+// =============================================================================
+// Groups Integration
+// =============================================================================
+
+describe("withTransition — Groups integration", () => {
+  it("uses _dataToLayoutIndex for insert position when available", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    ctx.methods.set("_dataToLayoutIndex", (i: number) => i + 1);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const insertFn = ctx.methods.get("insertItem") as (
+      item: TestItem,
+      index?: number,
+    ) => void;
+    insertFn({ id: 900, name: "Grouped Insert" }, 2);
+
+    expect(ctx.forceRender).toHaveBeenCalled();
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("chains through baseInsertItem from groups feature", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const groupInsert = mock((item: TestItem, index?: number) => {
+      testItems.splice(index ?? 0, 0, item);
+    });
+    ctx.methods.set("insertItem", groupInsert);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    const insertFn = ctx.methods.get("insertItem") as (
+      item: TestItem,
+      index?: number,
+    ) => void;
+    insertFn({ id: 901, name: "Through Groups" }, 0);
+
+    expect(groupInsert).toHaveBeenCalled();
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("chains through baseRemoveItem from groups feature", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const groupRemove = mock((_id: string | number): boolean => {
+      const index = testItems.findIndex((item) => item.id === _id);
+      if (index < 0) return false;
+      testItems.splice(index, 1);
+      return true;
+    });
+    ctx.methods.set("removeItem", groupRemove);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    removeFn(2);
+
+    expect(groupRemove).toHaveBeenCalledWith(2);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+});
+
+// =============================================================================
+// Destroy
+// =============================================================================
+
+describe("withTransition — Destroy", () => {
+  it("flushes pending remove animation on destroy", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 10);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    removeFn(3);
+
+    const removeAnims = [...allAnimations];
+    expect(removeAnims.length).toBeGreaterThan(0);
+
+    feature.destroy!();
+
+    const allSettled = removeAnims.every((a) => a.playState !== "running");
+    expect(allSettled).toBe(true);
+    allAnimations.length = 0;
+  });
+
+  it("flushes pending insert animation on destroy", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 10);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const insertFn = ctx.methods.get("insertItem") as (
+      item: TestItem,
+      index?: number,
+    ) => void;
+    insertFn({ id: 400, name: "Pending" }, 0);
+
+    const insertAnims = [...allAnimations];
+    expect(insertAnims.length).toBeGreaterThan(0);
+
+    feature.destroy!();
+
+    const allSettled = insertAnims.every((a) => a.playState !== "running");
+    expect(allSettled).toBe(true);
+    allAnimations.length = 0;
+  });
+
+  it("is safe to call destroy when no animations are pending", () => {
+    const { ctx } = createMockContext();
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    expect(() => feature.destroy!()).not.toThrow();
+  });
+});
+
+// =============================================================================
+// Edge Cases
+// =============================================================================
+
+describe("withTransition — Edge cases", () => {
+  it("handles rapid insert then remove of same item", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const insertFn = ctx.methods.get("insertItem") as (
+      item: TestItem,
+      index?: number,
+    ) => void;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+
+    insertFn({ id: 1000, name: "Quick" }, 0);
+    removeFn(1000);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("handles remove of already-removed item gracefully", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+
+    const result = removeFn(99999);
+    expect(result).toBe(false);
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("handles empty items container gracefully", async () => {
+    const { ctx } = createMockContext();
+
+    const feature = withTransition();
+    feature.setup!(ctx);
+
+    const insertFn = ctx.methods.get("insertItem") as (
+      item: TestItem,
+      index?: number,
+    ) => void;
+
+    expect(() =>
+      insertFn({ id: 1001, name: "Into Empty" }, 0),
+    ).not.toThrow();
+
+    await flushMicrotasks();
+    allAnimations.length = 0;
+  });
+
+  it("uses safety timeout to finalize animations", async () => {
+    const { ctx, testDom, testItems } = createMockContext();
+    populateDOM(testDom, testItems, 50, 0, 5);
+
+    const feature = withTransition({ duration: 50 });
+    feature.setup!(ctx);
+
+    allAnimations.length = 0;
+    const removeFn = ctx.methods.get("removeItem") as (
+      id: string | number,
+    ) => boolean;
+    removeFn(2);
+
+    expect(allAnimations.length).toBeGreaterThan(0);
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const clone = testDom.items.querySelector(
+      "[style*='pointer-events: none']",
+    );
+    expect(clone).toBeNull();
+    allAnimations.length = 0;
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "types": ["@types/bun"],
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "exactOptionalPropertyTypes": false,


### PR DESCRIPTION
## Summary

- Adds `withTransition()` feature — opt-in FLIP animations for `insertItem` (expand in + siblings slide) and `removeItem` (clone collapses + siblings slide)
- Uses Web Animations API for compositor-driven animations immune to renderer overwrites
- Supports per-animation timing overrides, horizontal mode, reverse mode, and disabling insert/remove independently
- Full compatibility with `withGroups` (sync and async), `withAsync`, and `withSelection`
- Fixes async group bridge to handle `insertItem` (new `bridge.insertAt`), not just `removeItem`
- Fixes conflict detection regression in builder core (restored `throw` for incompatible features)
- Adds `withMasonry` to transition conflicts list
- 50 transition tests, 5 async bridge `insertAt` tests, 19 builder conflict tests

## Changes

| Area | What |
|------|------|
| `src/features/transition/` | New feature: animated insert/remove with FLIP |
| `src/features/groups/` | Fix async groups to preserve transition wrappers, add `insertAt` to bridge, correct bridge ordering |
| `src/builder/core.ts` | Restore conflict detection `throw` |
| `src/builder/api.ts` | Wire `insertItem`/`removeItem` public API |
| `src/features/async/` | Sparse storage `insert`/`remove`, manager wiring |
| `test/` | 74 new tests across transition, groups, and builder |

## Test plan

- [x] `bun test` — 3468 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean
- [ ] Perf workflow triggered: https://github.com/floor/vlist.io/actions/runs/25993122819
- [ ] Manual test on staging.vlist.io messaging example after merge