### PR TITLE
fix(ci): update Gemini model to 2.5-flash

### DIFF
--- a/.github/workflows/ai-committee.yml
+++ b/.github/workflows/ai-committee.yml
@@ -346,7 +346,7 @@ jobs:
             }' > /tmp/request.json
 
           HTTP_STATUS=$(curl -s -o /tmp/response.json -w "%{http_code}" \
-            "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent?key=$GEMINI_API_KEY" \
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$GEMINI_API_KEY" \
             -H "Content-Type: application/json" \
             -d @/tmp/request.json)
 


### PR DESCRIPTION
gemini-1.5-pro is no longer available on the v1beta API, causing HTTP 404 on every Gemini Committee response. Updates to gemini-2.5-flash.