### PR TITLE
fix(ci): use gemini-2.5-pro for committee responses

### DIFF
--- a/.github/workflows/ai-committee.yml
+++ b/.github/workflows/ai-committee.yml
@@ -346,7 +346,7 @@ jobs:
             }' > /tmp/request.json
 
           HTTP_STATUS=$(curl -s -o /tmp/response.json -w "%{http_code}" \
-            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$GEMINI_API_KEY" \
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key=$GEMINI_API_KEY" \
             -H "Content-Type: application/json" \
             -d @/tmp/request.json)
 


### PR DESCRIPTION
Gemini 3.1 Pro = gemini-2.5-pro in the API.