### PR TITLE
ci: add GPT 5.5 as third committee member

### DIFF
--- a/.github/workflows/ai-committee.yml
+++ b/.github/workflows/ai-committee.yml
@@ -196,7 +196,7 @@ jobs:
             -f id="$DISC_ID" \
             -f body="$RESPONSE_TEXT"
 
-          echo "Response posted successfully."
+          echo "Claude response posted successfully."
 
   gemini-respond:
     name: Gemini Committee Response
@@ -373,4 +373,174 @@ jobs:
             -f id="$DISC_ID" \
             -f body="$RESPONSE_TEXT"
 
-          echo "Response posted successfully."
+          echo "Gemini response posted successfully."
+
+  gpt-respond:
+    name: GPT Committee Response
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    if: >-
+      github.event.comment.user.login != 'github-actions[bot]' &&
+      !contains(github.event.comment.body, '**Committee Member:** GPT') &&
+      (contains(github.event.comment.body, '@gpt') || contains(github.event.comment.body, '@committee'))
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check discussion is an RFC
+        id: check
+        env:
+          TITLE: ${{ github.event.discussion.title }}
+        run: |
+          if echo "$TITLE" | grep -qi 'RFC-'; then
+            echo "is_rfc=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_rfc=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch discussion thread
+        if: steps.check.outputs.is_rfc == 'true'
+        id: thread
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DISC_NUMBER=${{ github.event.discussion.number }}
+
+          gh api graphql -f query='
+            query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                discussion(number: $number) {
+                  id
+                  title
+                  body
+                  comments(first: 100) {
+                    nodes {
+                      author { login }
+                      body
+                      createdAt
+                    }
+                  }
+                }
+              }
+            }
+          ' -f owner=floor -f name=vlist -F number="$DISC_NUMBER" > /tmp/discussion.json
+
+          DISC_ID=$(jq -r '.data.repository.discussion.id' /tmp/discussion.json)
+          echo "disc_id=$DISC_ID" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "# Discussion Thread"
+            echo ""
+            echo "## RFC: $(jq -r '.data.repository.discussion.title' /tmp/discussion.json)"
+            echo ""
+            echo "### Original Post"
+            echo ""
+            jq -r '.data.repository.discussion.body' /tmp/discussion.json
+            echo ""
+            echo "---"
+            echo ""
+            echo "### Comments"
+            echo ""
+            jq -r '.data.repository.discussion.comments.nodes[] |
+              "#### \(.author.login) (\(.createdAt))\n\n\(.body)\n\n---\n"
+            ' /tmp/discussion.json
+          } > /tmp/thread.md
+
+      - name: Build source context
+        if: steps.check.outputs.is_rfc == 'true'
+        run: |
+          {
+            echo "# v1 Source Reference"
+            echo ""
+            echo "## .claude/CLAUDE.md (project rules)"
+            echo '```'
+            head -120 .claude/CLAUDE.md
+            echo '```'
+            echo ""
+            echo "## src/builder/types.ts (key interfaces — first 200 lines)"
+            echo '```typescript'
+            head -200 src/builder/types.ts
+            echo '```'
+            echo ""
+            echo "## src/builder/core.ts — hot path: coreRenderIfNeeded (lines 731-943)"
+            echo '```typescript'
+            sed -n '731,943p' src/builder/core.ts
+            echo '```'
+            echo ""
+            echo "## src/builder/core.ts — scroll handling (lines 960-1085)"
+            echo '```typescript'
+            sed -n '960,1085p' src/builder/core.ts
+            echo '```'
+            echo ""
+            echo "## src/builder/range.ts (range calculations)"
+            echo '```typescript'
+            cat src/builder/range.ts
+            echo '```'
+            echo ""
+            echo "## src/builder/materialize.ts — MRefs interface (lines 40-162)"
+            echo '```typescript'
+            sed -n '40,162p' src/builder/materialize.ts
+            echo '```'
+          } > /tmp/source_context.md
+
+      - name: Generate and post response
+        if: steps.check.outputs.is_rfc == 'true'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISC_ID: ${{ steps.thread.outputs.disc_id }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+        run: |
+          THREAD=$(cat /tmp/thread.md)
+          SOURCE=$(cat /tmp/source_context.md)
+
+          jq -n \
+            --arg thread "$THREAD" \
+            --arg source "$SOURCE" \
+            --arg author "$COMMENT_AUTHOR" \
+            '{
+              model: "gpt-5.5",
+              max_tokens: 4096,
+              messages: [
+                {
+                  role: "system",
+                  content: "You are GPT, a member of the vlist v2 Technical Committee. Your role is to provide rigorous architectural critique grounded in the v1 source code.\n\nRules (from RFC-000 and RFC-001):\n- v1 is the absolute source of truth for behavior, math, and test assertions. v2 is strictly an architectural rewrite.\n- No pleasantries. Responses must be strictly technical.\n- When critiquing code, provide exact file paths and line numbers from v1.\n- When verifying behavior, cite the exact v1 file and line.\n- Actively look for edge cases, memory leaks, performance bottlenecks, and bundle-size bloat.\n- Zero allocations on the hot path is non-negotiable.\n- Zero runtime dependencies.\n\nYour responses will be posted directly as GitHub Discussion comments. Format them as clean markdown. Start every response with:\n**Committee Member:** GPT (5.5)\n\nKeep responses focused and under 2000 words. If you agree with a proposal, say so concisely and add what the author might have missed. If you disagree, explain exactly why with v1 code citations.\n\nDo NOT repeat the full RFC or prior comments. Respond only to what is new."
+                },
+                {
+                  role: "user",
+                  content: ("The following is the v1 source code for reference. Use it to ground your critique with exact file paths and line numbers.\n\n" + $source + "\n\n---\n\n" + $thread + "\n\n---\n\nA new comment was just posted by **" + $author + "**. Read the full thread and provide your technical response. Focus on the latest comment but consider the full discussion context. If the comment asks a question, answer it. If it proposes something, critique it. If it addresses your prior feedback, acknowledge what was resolved and push on what remains open.")
+                }
+              ]
+            }' > /tmp/request.json
+
+          HTTP_STATUS=$(curl -s -o /tmp/response.json -w "%{http_code}" \
+            "https://api.openai.com/v1/chat/completions" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $OPENAI_API_KEY" \
+            -d @/tmp/request.json)
+
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "::error::OpenAI API returned HTTP $HTTP_STATUS"
+            cat /tmp/response.json
+            exit 1
+          fi
+
+          RESPONSE_TEXT=$(jq -r '.choices[0].message.content // empty' /tmp/response.json)
+
+          if [ -z "$RESPONSE_TEXT" ]; then
+            echo "::error::Empty response from OpenAI API"
+            cat /tmp/response.json
+            exit 1
+          fi
+
+          gh api graphql \
+            -f query='mutation($id: ID!, $body: String!) {
+              addDiscussionComment(input: {discussionId: $id, body: $body}) {
+                comment { url }
+              }
+            }' \
+            -f id="$DISC_ID" \
+            -f body="$RESPONSE_TEXT"
+
+          echo "GPT response posted successfully."


### PR DESCRIPTION
Adds gpt-respond job to ai-committee.yml. Triggers on @gpt or @committee. Uses OpenAI chat completions API with gpt-5.5 model. Requires OPENAI_API_KEY secret.