### PR TITLE
fix(build): emit TypeScript declarations in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,6 +7,7 @@
     "strict": true,
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
     "outDir": "./dist",
     "rootDir": "./src",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- Add `emitDeclarationOnly` to `tsconfig.build.json` so `.d.ts` files are included in the published package
- Bump to v2.0.1

## Test plan
- [x] `bun run build -- --types` generates 76 `.d.ts` files in `dist/`
- [x] `npm pack --dry-run` shows 87 files (was 11)