### PR TITLE
v2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ This changelog starts at v1.5.4, the first version published under the `vlist` p
 
 ## [Unreleased]
 
+## [2.0.4] - 2026-05-28
+
+### Added
+
+- **Grid + Scale compression** — grid plugin supports scale plugin compression for 1M+ item grids with compressed range calculation, viewport-relative positioning, and virtual-space smooth scrolling
+- **Table + Scale compression** — table plugin supports scale plugin compression for 1M+ row tables with compressed range calculation and viewport-relative row positioning
+
+### Fixed
+
+- **Table item identity** — track items by reference instead of `item.id`, preventing stale renders when items share ids across updates (#91)
+- **Render pipeline ordering** — release stale elements after appending new ones, preventing transient blank frames during synchronous renders; table plugin syncs `engineState.totalSize` for correct scrollbar bounds
+
+### Performance
+
+- **Contiguous release fast path** — batch element release when items are contiguous in the release queue, reducing DOM operations during range shifts (RFC-006)
+
+### Refactored
+
+- **Table render pipeline** — align with core pipeline: release-after-create ordering, removed redundant `scrollPos === lastScrollPosition` bail-out and 4 associated state variables
+
 ## [2.0.3] - 2026-05-28
 
 ### Fixed
@@ -470,7 +490,10 @@ See [docs/migration.md](docs/migration.md) for the full v1 → v2 migration guid
 
 - **selection**: Implement ARIA multi-select keyboard model with configurable shiftArrowToggle
 
-[Unreleased]: https://github.com/floor/vlist/compare/v2.0.0-rc.3...HEAD
+[Unreleased]: https://github.com/floor/vlist/compare/v2.0.4...HEAD
+[2.0.4]: https://github.com/floor/vlist/compare/v2.0.3...v2.0.4
+[2.0.3]: https://github.com/floor/vlist/compare/v2.0.2...v2.0.3
+[2.0.2]: https://github.com/floor/vlist/compare/v2.0.0...v2.0.2
 [2.0.0-rc.3]: https://github.com/floor/vlist/compare/v2.0.0-rc.2...v2.0.0-rc.3
 [2.0.0-rc.2]: https://github.com/floor/vlist/compare/v2.0.0-rc.1...v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/floor/vlist/compare/v2.0.0...v2.0.0-rc.1

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # vlist
 
-The virtual list library for every framework. Ultra efficient, batteries-included, and accessible with composable plugins — in 7.7 KB.
+The virtual list library for every framework. Ultra efficient, batteries-included, and accessible with composable plugins — in 7.8 KB.
 
-**v2.0.3** — [Changelog](./CHANGELOG.md) · **v2 is a ground-up rewrite** with a new plugin API. Coming from v1? See [Migration Guide](https://vlist.io/docs/migration).
+**v2.0.4** — [Changelog](./CHANGELOG.md) · **v2 is a ground-up rewrite** with a new plugin API. Coming from v1? See [Migration Guide](https://vlist.io/docs/migration).
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/vlist)](https://bundlephobia.com/package/vlist)
@@ -11,7 +11,7 @@ The virtual list library for every framework. Ultra efficient, batteries-include
 
 - **Accessible** — WAI-ARIA, 2D keyboard navigation, focus recovery, screen-reader DOM ordering
 - **Zero dependencies** — framework-agnostic core with tiny adapters for Vue, Svelte, Solid, React
-- **7.7 KB gzipped** — composable plugins with perfect tree-shaking
+- **7.8 KB gzipped** — composable plugins with perfect tree-shaking
 - **Constant memory** — ~0.1 MB overhead at any scale, from 10K to 1M+ items
 - **Grid, masonry, table, groups, data, selection, sortable, transition, scale** — all opt-in
 - **Axis-neutral** — vertical and horizontal scrolling through a single code path, all plugins work in both orientations
@@ -94,16 +94,16 @@ const list = createVList({
 
 | Plugin | Size | Description |
 |--------|------|-------------|
-| **Base** | 7.7 KB | Virtualization, ARIA, keyboard nav, gap, padding |
+| **Base** | 7.8 KB | Virtualization, ARIA, keyboard nav, gap, padding |
 | `data()` | +4.7 KB | Lazy loading with velocity-aware fetching |
 | `selection()` | +2.4 KB | Single/multiple selection with 2D keyboard nav |
 | `scale()` | +3.9 KB | 1M+ items via scroll compression |
 | `groups()` | +3.7 KB | Sticky/inline headers with async group discovery |
-| `autosize()` | +0.9 KB | Auto-measure items via ResizeObserver |
+| `autosize()` | +0.8 KB | Auto-measure items via ResizeObserver |
 | `scrollbar()` | +2.0 KB | Custom scrollbar UI |
-| `grid()` | +2.1 KB | 2D grid layout |
+| `grid()` | +2.7 KB | 2D grid layout |
 | `masonry()` | +3.5 KB | Pinterest-style masonry with lane-aware keyboard nav |
-| `table()` | +5.8 KB | Data table with columns, resize, sort |
+| `table()` | +6.1 KB | Data table with columns, resize, sort |
 | `page()` | +0.8 KB | Window-level scrolling |
 | `sortable()` | +2.9 KB | Drag-and-drop reordering with auto-scroll |
 | `snapshots()` | +1.3 KB | Scroll position save/restore |

--- a/npm-readme.md
+++ b/npm-readme.md
@@ -1,8 +1,8 @@
 # vlist
 
-The virtual list library for every framework. Ultra efficient, batteries-included, and accessible with composable plugins — in 7.7 KB.
+The virtual list library for every framework. Ultra efficient, batteries-included, and accessible with composable plugins — in 7.8 KB.
 
-**v2.0.3** — [Changelog](https://github.com/floor/vlist/blob/main/CHANGELOG.md) · **v2 is a ground-up rewrite** with a new plugin API. Coming from v1? See [Migration Guide](https://vlist.io/docs/migration).
+**v2.0.4** — [Changelog](https://github.com/floor/vlist/blob/main/CHANGELOG.md) · **v2 is a ground-up rewrite** with a new plugin API. Coming from v1? See [Migration Guide](https://vlist.io/docs/migration).
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/vlist)](https://bundlephobia.com/package/vlist)
@@ -11,7 +11,7 @@ The virtual list library for every framework. Ultra efficient, batteries-include
 
 - **Accessible** — WAI-ARIA, 2D keyboard navigation, focus recovery, screen-reader DOM ordering
 - **Zero dependencies** — framework-agnostic core, tiny adapters for Vue, Svelte, Solid, React
-- **7.7 KB gzipped** — composable plugins with perfect tree-shaking
+- **7.8 KB gzipped** — composable plugins with perfect tree-shaking
 - **Constant memory** — ~0.1 MB overhead at any scale, from 10K to 1M+ items
 - **Axis-neutral** — vertical and horizontal scrolling through a single code path, all plugins work in both orientations
 
@@ -56,17 +56,17 @@ const list = createVList({ container: '#app', items, item: { height: 200, templa
 
 | Plugin | Size | Description |
 |--------|------|-------------|
-| **Base** | 7.7 KB | Virtualization, ARIA, keyboard nav, gap, padding |
+| **Base** | 7.8 KB | Virtualization, ARIA, keyboard nav, gap, padding |
 | `data()` | +4.7 KB | Lazy loading with velocity-aware fetching |
 | `selection()` | +2.4 KB | Single/multiple selection with 2D keyboard nav |
 | `scale()` | +3.9 KB | 1M+ items via scroll compression |
 | `groups()` | +3.7 KB | Sticky/inline headers with async group discovery |
-| `autosize()` | +0.7 KB | Auto-measure items via ResizeObserver |
+| `autosize()` | +0.8 KB | Auto-measure items via ResizeObserver |
 | `scrollbar()` | +2.0 KB | Custom scrollbar UI |
-| `grid()` | +2.1 KB | 2D grid layout |
+| `grid()` | +2.7 KB | 2D grid layout |
 | `masonry()` | +3.5 KB | Pinterest-style masonry with lane-aware keyboard nav |
-| `table()` | +5.8 KB | Data table with columns, resize, sort |
-| `page()` | +0.7 KB | Window-level scrolling |
+| `table()` | +6.1 KB | Data table with columns, resize, sort |
+| `page()` | +0.8 KB | Window-level scrolling |
 | `sortable()` | +2.9 KB | Drag-and-drop reordering with auto-scroll |
 | `snapshots()` | +1.3 KB | Scroll position save/restore |
 | `transition()` | +1.8 KB | FLIP-based enter/exit animations for insert & remove |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/src/core/create.ts
+++ b/src/core/create.ts
@@ -345,7 +345,7 @@ export function createVList<T extends VListItem = VListItem>(
         else dom.viewport.scrollTop = position;
       },
       smoothScrollTo(target: number | (() => number), duration: number, easing?: (t: number) => number, onComplete?: () => void): void {
-        if (smoothScrollFn) smoothScrollFn(target, duration, undefined, easing, onComplete);
+        if (smoothScrollFn) smoothScrollFn(target, duration, scrollSetFn ?? undefined, easing, onComplete);
         else ctx.scrollTo(typeof target === "function" ? target() : target);
       },
       disableDefaultScroll(): void { skipDefaultScroll = true; },

--- a/src/core/pipeline.ts
+++ b/src/core/pipeline.ts
@@ -167,6 +167,18 @@ function isInVisible(indices: Int32Array, count: number, idx: number): boolean {
   return false;
 }
 
+/** Check if visibleIndices[0..count) form a strictly consecutive sequence. */
+function isContiguousWindow(indices: Int32Array, count: number): boolean {
+  if (count <= 1) return true;
+  let prev = indices[0]!;
+  for (let i = 1; i < count; i++) {
+    const next = indices[i]!;
+    if (next !== prev + 1) return false;
+    prev = next;
+  }
+  return true;
+}
+
 
 export function phase2Commit<T extends VListItem>(
   state: EngineState,
@@ -238,7 +250,7 @@ export function phase2Commit<T extends VListItem>(
         if (typeof result === "string") {
           acquired.innerHTML = result;
         } else {
-          acquired.innerHTML = "";
+          acquired.textContent = "";
           acquired.appendChild(result);
         }
       }
@@ -308,7 +320,7 @@ export function phase2Commit<T extends VListItem>(
         if (typeof result === "string") {
           element.innerHTML = result;
         } else {
-          element.innerHTML = "";
+          element.textContent = "";
           element.appendChild(result);
         }
         element.setAttribute("data-id", newId);
@@ -359,11 +371,23 @@ export function phase2Commit<T extends VListItem>(
 
   // Release nodes no longer visible (after acquire so new elements are in the
   // DOM before stale ones are removed — no single-frame gaps).
-  for (const [idx, element] of rendered) {
-    if (!isInVisible(newIndices, count, idx)) {
-      element.remove();
-      pool.release(element);
-      rendered.delete(idx);
+  if (count > 0 && isContiguousWindow(newIndices, count)) {
+    const rangeStart = newIndices[0]!;
+    const rangeEnd = newIndices[count - 1]!;
+    for (const [idx, element] of rendered) {
+      if (idx < rangeStart || idx > rangeEnd) {
+        element.remove();
+        pool.release(element);
+        rendered.delete(idx);
+      }
+    }
+  } else {
+    for (const [idx, element] of rendered) {
+      if (!isInVisible(newIndices, count, idx)) {
+        element.remove();
+        pool.release(element);
+        rendered.delete(idx);
+      }
     }
   }
 

--- a/src/core/pool.ts
+++ b/src/core/pool.ts
@@ -33,7 +33,7 @@ export function createPool(classPrefix: string): ElementPool {
       element.removeAttribute("aria-setsize");
       element.removeAttribute("data-index");
       element.removeAttribute("data-id");
-      element.innerHTML = "";
+      element.textContent = "";
 
       if (pool.length < MAX_POOL_SIZE) {
         pool.push(element);

--- a/src/plugins/grid/plugin.ts
+++ b/src/plugins/grid/plugin.ts
@@ -18,6 +18,8 @@ import type { VListItem, ItemTemplate, ItemState } from "../../types";
 import type { VListPlugin, PluginContext, ElementPool } from "../../core/types";
 import type { SizeCache } from "../../core/sizes";
 import type { EngineState } from "../../core/state";
+import type { CompressionState } from "../../rendering/scale";
+import { calculateCompressedVisibleRange, calculateCompressedItemPosition, calculateCompressedScrollToIndex } from "../../rendering/scale";
 import { createGridLayout } from "./layout";
 import type { GridLayout } from "./types";
 type ItemStateFn = (index: number, state: ItemState) => void;
@@ -59,15 +61,25 @@ export function grid<T extends VListItem = VListItem>(
   let classPrefix: string;
   let overscan: number;
   let resolveItemState: (() => ItemStateFn | null) | null = null;
+  let getCompression: (() => CompressionState) | null = null;
+  let compressionResolved = false;
+  let ctxGetMethod: ((name: string) => unknown) | null = null;
 
   interface TrackedElement { el: HTMLElement; lastItem: unknown; }
   const rendered = new Map<number, TrackedElement>();
   let containerWidth = 0;
 
   // Mutable range objects — reused across frames
+  const compRange = { start: 0, end: -1 };
   let lastScrollPosition = -1;
   let lastContainerSize = -1;
   let forceNextRender = true;
+
+  function resolveCompression(): void {
+    if (compressionResolved || !ctxGetMethod) return;
+    compressionResolved = true;
+    getCompression = (ctxGetMethod("_scale:getCompression") as (() => CompressionState)) ?? null;
+  }
 
   function getRowCount(): number {
     return layout.getTotalRows(engineState.totalItems);
@@ -125,16 +137,26 @@ export function grid<T extends VListItem = VListItem>(
     const totalRows = getRowCount();
     if (cs <= 0 || totalRows === 0) return;
 
-    // Visible row range
-    let visStart = sizeCache.indexAtOffset(scrollPos);
-    let visEnd = sizeCache.indexAtOffset(scrollPos + cs);
-    if (visEnd < totalRows - 1) visEnd++;
-    visStart = Math.max(0, visStart);
-    visEnd = Math.min(totalRows - 1, Math.max(0, visEnd));
+    // Visible row range — compression-aware when scale plugin is active
+    resolveCompression();
+    const compression = getCompression?.() ?? null;
+    const isCompressed = compression !== null && compression.isCompressed;
+    let renderStart: number;
+    let renderEnd: number;
 
-    // Overscan in row space
-    const renderStart = Math.max(0, visStart - overscan);
-    const renderEnd = Math.min(totalRows - 1, visEnd + overscan);
+    if (isCompressed) {
+      calculateCompressedVisibleRange(scrollPos, cs, sizeCache, totalRows, compression, compRange);
+      renderStart = Math.max(0, compRange.start - overscan);
+      renderEnd = Math.min(totalRows - 1, compRange.end + overscan);
+    } else {
+      let visStart = sizeCache.indexAtOffset(scrollPos);
+      let visEnd = sizeCache.indexAtOffset(scrollPos + cs);
+      if (visEnd < totalRows - 1) visEnd++;
+      visStart = Math.max(0, visStart);
+      visEnd = Math.min(totalRows - 1, Math.max(0, visEnd));
+      renderStart = Math.max(0, visStart - overscan);
+      renderEnd = Math.min(totalRows - 1, visEnd + overscan);
+    }
 
     // Range-unchanged fast path
     if (renderStart === engineState.prevRangeStart && renderEnd === engineState.prevRangeEnd && !engineState.renderPending) {
@@ -189,12 +211,26 @@ export function grid<T extends VListItem = VListItem>(
       }
 
       applySizeStyles(tracked.el, i);
-      tracked.el.style.transform = buildTransform(i);
+
+      if (isCompressed) {
+        const row = layout.getRow(i);
+        const col = layout.getCol(i);
+        const x = layout.getColumnOffset(col, containerWidth);
+        const y = calculateCompressedItemPosition(row, scrollPos, sizeCache, totalRows, cs, compression);
+        tracked.el.style.transform = isX
+          ? `translate(${Math.round(y)}px, ${Math.round(x)}px)`
+          : `translate(${Math.round(x)}px, ${Math.round(y)}px)`;
+      } else {
+        tracked.el.style.transform = buildTransform(i);
+      }
     }
 
-    // Update content size for scrollbar
-    const totalSize = sizeCache.getTotalSize();
-    contentElement.style[isX ? "width" : "height"] = totalSize + "px";
+    // Content size — scale plugin manages it when compressed
+    if (!isCompressed) {
+      const totalSize = sizeCache.getTotalSize();
+      contentElement.style[isX ? "width" : "height"] = totalSize + "px";
+    }
+    engineState.totalSize = sizeCache.getTotalSize();
 
     // Update engine state for other hooks/plugins
     engineState.prevRangeStart = renderStart;
@@ -209,7 +245,9 @@ export function grid<T extends VListItem = VListItem>(
       const idx = itemRange.start + i;
       const row = layout.getRow(idx);
       engineState.visibleIndices[i] = idx;
-      engineState.visibleOffsets[i] = sizeCache.getOffset(row);
+      engineState.visibleOffsets[i] = isCompressed
+        ? calculateCompressedItemPosition(row, scrollPos, sizeCache, totalRows, cs, compression)
+        : sizeCache.getOffset(row);
       engineState.visibleSizes[i] = sizeCache.getSize(row);
     }
   }
@@ -243,6 +281,7 @@ export function grid<T extends VListItem = VListItem>(
       overscan = ctx.config.overscan;
       getItem = ctx.getItem.bind(ctx);
       resolveItemState = () => ctx.getItemStateFn();
+      ctxGetMethod = ctx.getMethod.bind(ctx);
 
       // Initialize container width
       containerWidth = engineState.crossSize;
@@ -361,7 +400,20 @@ export function grid<T extends VListItem = VListItem>(
         }
         pos = Math.max(0, Math.min(pos, maxScroll));
 
-        if (behavior === "smooth" && duration && duration > 0) {
+        resolveCompression();
+        const compression = getCompression?.() ?? null;
+
+        if (compression?.isCompressed && behavior === "smooth" && duration && duration > 0) {
+          const virtualTarget = calculateCompressedScrollToIndex(
+            safeRow, sizeCache, cs, totalRows, compression, align,
+          );
+          const scaleEased = ctxGetMethod?.("_scale:easedScrollTo") as ((t: number, d: number) => void) | undefined;
+          if (scaleEased) {
+            scaleEased(virtualTarget, duration);
+          } else {
+            ctx.scrollTo(pos);
+          }
+        } else if (behavior === "smooth" && duration && duration > 0) {
           ctx.smoothScrollTo(pos, duration);
         } else {
           ctx.scrollTo(pos);
@@ -394,10 +446,15 @@ export function grid<T extends VListItem = VListItem>(
         if (Math.abs(newCross - containerWidth) < 1) return;
         containerWidth = newCross;
 
-        rendered.forEach((tracked, index) => {
-          applySizeStyles(tracked.el, index);
-          tracked.el.style.transform = buildTransform(index);
-        });
+        const compression = getCompression?.() ?? null;
+        if (compression?.isCompressed) {
+          gridForceRender();
+        } else {
+          rendered.forEach((tracked, index) => {
+            applySizeStyles(tracked.el, index);
+            tracked.el.style.transform = buildTransform(index);
+          });
+        }
       },
     },
 

--- a/src/plugins/grid/renderer.ts
+++ b/src/plugins/grid/renderer.ts
@@ -485,20 +485,6 @@ export const createGridRenderer = <T extends VListItem = VListItem>(
     }
     // Once groupsActive is true, it stays true (groups don't disappear mid-scroll)
 
-    // Release items outside the new range, with grace period to prevent
-    // boundary thrashing (hover blink, CSS transition replay).
-    // Items that just left the visible range keep their DOM element for
-    // RELEASE_GRACE extra render cycles — if they re-enter, the same
-    // element is reused with :hover state intact.
-    for (const [index, tracked] of rendered) {
-      if (index >= range.start && index <= range.end) {
-        tracked.lastSeenFrame = frameCounter;
-      } else if (frameCounter - tracked.lastSeenFrame > RELEASE_GRACE) {
-        pool.release(tracked.element);
-        rendered.delete(index);
-      }
-    }
-
     // Check if aria-setsize changed (total items mutated) — update existing items only when needed
     let setSizeChanged = false;
     if (totalItemsGetter) {
@@ -611,6 +597,20 @@ export const createGridRenderer = <T extends VListItem = VListItem>(
 
     // Single DOM insertion for all new elements — minimizes reflows
     if (fragment) itemsContainer.appendChild(fragment);
+
+    // Release items outside the new range (after append so new elements are
+    // in the DOM before stale ones are removed — no single-frame gaps).
+    // Grace period prevents boundary thrashing (hover blink, CSS transition
+    // replay): items that just left the visible range keep their DOM element
+    // for RELEASE_GRACE extra render cycles.
+    for (const [index, tracked] of rendered) {
+      if (index >= range.start && index <= range.end) {
+        tracked.lastSeenFrame = frameCounter;
+      } else if (frameCounter - tracked.lastSeenFrame > RELEASE_GRACE) {
+        pool.release(tracked.element);
+        rendered.delete(index);
+      }
+    }
 
   };
 

--- a/src/plugins/masonry/renderer.ts
+++ b/src/plugins/masonry/renderer.ts
@@ -365,20 +365,6 @@ export const createMasonryRenderer = <T extends VListItem = VListItem>(
       visibleSet.add(placements[i]!.index);
     }
 
-    // Release items no longer visible, with grace period to prevent
-    // boundary thrashing (hover blink, CSS transition replay).
-    // Items that just left the visible set keep their DOM element for
-    // RELEASE_GRACE extra render cycles — if they re-enter, the same
-    // element is reused with :hover state intact.
-    for (const [index, tracked] of rendered) {
-      if (visibleSet.has(index)) {
-        tracked.lastSeenFrame = frameCounter;
-      } else if (frameCounter - tracked.lastSeenFrame > RELEASE_GRACE) {
-        pool.release(tracked.element);
-        rendered.delete(index);
-      }
-    }
-
     // DocumentFragment for batched DOM insertion of new elements
     // (matches core renderer and grid renderer patterns)
     let fragment: DocumentFragment | null = null;
@@ -465,6 +451,20 @@ export const createMasonryRenderer = <T extends VListItem = VListItem>(
 
     // Single DOM insertion for all new elements — minimizes reflows
     if (fragment) itemsContainer.appendChild(fragment);
+
+    // Release items no longer visible (after append so new elements are in
+    // the DOM before stale ones are removed — no single-frame gaps).
+    // Grace period prevents boundary thrashing (hover blink, CSS transition
+    // replay): items that just left the visible set keep their DOM element
+    // for RELEASE_GRACE extra render cycles.
+    for (const [index, tracked] of rendered) {
+      if (visibleSet.has(index)) {
+        tracked.lastSeenFrame = frameCounter;
+      } else if (frameCounter - tracked.lastSeenFrame > RELEASE_GRACE) {
+        pool.release(tracked.element);
+        rendered.delete(index);
+      }
+    }
   };
 
   /**

--- a/src/plugins/scale/plugin.ts
+++ b/src/plugins/scale/plugin.ts
@@ -473,6 +473,7 @@ export function scale<T extends VListItem = VListItem>(
 
       ctx.registerMethod("_updateCompressionMode", () => updateCompression(ctx));
       ctx.registerMethod("_scale:getCompression", () => compression);
+      ctx.registerMethod("_scale:easedScrollTo", (target: number, duration: number) => easedScrollTo(target, duration));
 
       // Register scroll get/set so scrollToIndex routes through us
       ctx.setScrollFns(

--- a/src/plugins/scale/plugin.ts
+++ b/src/plugins/scale/plugin.ts
@@ -472,6 +472,7 @@ export function scale<T extends VListItem = VListItem>(
       storedCtx = ctx;
 
       ctx.registerMethod("_updateCompressionMode", () => updateCompression(ctx));
+      ctx.registerMethod("_scale:getCompression", () => compression);
 
       // Register scroll get/set so scrollToIndex routes through us
       ctx.setScrollFns(

--- a/src/plugins/table/plugin.ts
+++ b/src/plugins/table/plugin.ts
@@ -16,6 +16,9 @@ import type { VListItem } from "../../types";
 import type { VListPlugin, PluginContext } from "../../core/types";
 import type { EngineState } from "../../core/state";
 import type { SizeCache } from "../../core/sizes";
+import type { CompressionContext } from "../../rendering/renderer";
+import type { CompressionState } from "../../rendering/scale";
+import { calculateCompressedVisibleRange } from "../../rendering/scale";
 
 import { createTableLayout } from "./layout";
 import { createTableHeader } from "./header";
@@ -64,12 +67,20 @@ export function table<T extends VListItem = VListItem>(
   let selectionResolved = false;
 
   let lastAriaRowCount = -1;
+  let getCompression: (() => CompressionState) | null = null;
+  let compressionResolved = false;
 
   function resolveSelectionMethods(): void {
     if (selectionResolved || !storedCtx) return;
     selectionResolved = true;
     selectedIdsGetter = (storedCtx.getMethod("_getSelectedIds") as (() => Set<string | number>)) ?? null;
     focusedIndexGetter = (storedCtx.getMethod("_getFocusedIndex") as (() => number)) ?? null;
+  }
+
+  function resolveCompression(): void {
+    if (compressionResolved || !storedCtx) return;
+    compressionResolved = true;
+    getCompression = (storedCtx.getMethod("_scale:getCompression") as (() => CompressionState)) ?? null;
   }
 
   // =========================================================================
@@ -79,6 +90,7 @@ export function table<T extends VListItem = VListItem>(
   // Persistent per-render buffers — hoisted to avoid per-frame allocation
   const rangeItems: T[] = [];
   const range = { start: 0, end: 0 };
+  const compRange = { start: 0, end: -1 };
 
   function tableRenderIfNeeded(): void {
     if (engineState.destroyed || !storedCtx || !tableRenderer || !tableLayout) {
@@ -98,17 +110,30 @@ export function table<T extends VListItem = VListItem>(
       storedCtx.dom.root.setAttribute("aria-rowcount", `${ariaRowCount}`);
     }
 
-    // Calculate visible range
+    // Calculate visible range — compression-aware when scale plugin is active
+    resolveCompression();
     const scrollPos = engineState.scrollPosition;
-    let visStart = sizeCache.indexAtOffset(scrollPos);
-    let visEnd = sizeCache.indexAtOffset(scrollPos + containerSize);
-    if (visEnd < totalItems - 1) visEnd++;
-    visStart = Math.max(0, visStart);
-    visEnd = Math.min(totalItems - 1, visEnd);
-
+    const compression = getCompression?.() ?? null;
+    const isCompressed = compression !== null && compression.isCompressed;
     const overscan = storedCtx.config.overscan;
-    const renderStart = Math.max(0, visStart - overscan);
-    const renderEnd = Math.min(totalItems - 1, visEnd + overscan);
+    let renderStart: number;
+    let renderEnd: number;
+
+    if (isCompressed) {
+      calculateCompressedVisibleRange(
+        scrollPos, containerSize, sizeCache, totalItems, compression, compRange,
+      );
+      renderStart = Math.max(0, compRange.start - overscan);
+      renderEnd = Math.min(totalItems - 1, compRange.end + overscan);
+    } else {
+      let visStart = sizeCache.indexAtOffset(scrollPos);
+      let visEnd = sizeCache.indexAtOffset(scrollPos + containerSize);
+      if (visEnd < totalItems - 1) visEnd++;
+      visStart = Math.max(0, visStart);
+      visEnd = Math.min(totalItems - 1, visEnd);
+      renderStart = Math.max(0, visStart - overscan);
+      renderEnd = Math.min(totalItems - 1, visEnd + overscan);
+    }
 
     if (
       renderStart === engineState.prevRangeStart &&
@@ -130,7 +155,19 @@ export function table<T extends VListItem = VListItem>(
 
     range.start = renderStart;
     range.end = renderEnd;
-    tableRenderer.render(rangeItems, range, selectedIds, focusedIndex);
+
+    let compressionCtx: CompressionContext | undefined;
+    if (isCompressed) {
+      compressionCtx = {
+        scrollPosition: scrollPos,
+        totalItems,
+        containerSize,
+        rangeStart: renderStart,
+        compression,
+      };
+    }
+
+    tableRenderer.render(rangeItems, range, selectedIds, focusedIndex, compressionCtx);
 
     // Update engine state
     engineState.prevRangeStart = renderStart;

--- a/src/plugins/table/plugin.ts
+++ b/src/plugins/table/plugin.ts
@@ -161,8 +161,10 @@ export function table<T extends VListItem = VListItem>(
       engineState.visibleSizes[i] = sizeCache.getSize(idx);
     }
 
-    // Update content size
-    storedCtx.dom.content.style.height = sizeCache.getTotalSize() + "px";
+    // Update content size (also sync engineState for scrollbar plugin)
+    const totalSize = sizeCache.getTotalSize();
+    engineState.totalSize = totalSize;
+    storedCtx.dom.content.style.height = totalSize + "px";
   }
 
   function tableForceRender(): void {

--- a/src/plugins/table/plugin.ts
+++ b/src/plugins/table/plugin.ts
@@ -63,10 +63,6 @@ export function table<T extends VListItem = VListItem>(
   let focusedIndexGetter: (() => number) | null = null;
   let selectionResolved = false;
 
-  let lastScrollPosition = -1;
-  let lastContainerSize = -1;
-  let lastTotalItems = -1;
-  let forceNextRender = true;
   let lastAriaRowCount = -1;
 
   function resolveSelectionMethods(): void {
@@ -85,26 +81,15 @@ export function table<T extends VListItem = VListItem>(
   const range = { start: 0, end: 0 };
 
   function tableRenderIfNeeded(): void {
-    if (engineState.destroyed || !storedCtx || !tableRenderer || !tableLayout) return;
-
-    const scrollPos = engineState.scrollPosition;
-    const containerSize = engineState.containerSize;
-    const totalItems = engineState.totalItems;
-
-    if (
-      !forceNextRender &&
-      scrollPos === lastScrollPosition &&
-      containerSize === lastContainerSize &&
-      totalItems === lastTotalItems
-    ) {
+    if (engineState.destroyed || !storedCtx || !tableRenderer || !tableLayout) {
       return;
     }
-    lastScrollPosition = scrollPos;
-    lastContainerSize = containerSize;
-    lastTotalItems = totalItems;
-    forceNextRender = false;
 
-    if (containerSize <= 0 || totalItems === 0) return;
+    const containerSize = engineState.containerSize;
+    const totalItems = engineState.totalItems;
+    if (containerSize <= 0 || totalItems === 0) {
+      return;
+    }
 
     // Update aria-rowcount when item count changes (+1 for header row)
     const ariaRowCount = totalItems + 1;
@@ -114,6 +99,7 @@ export function table<T extends VListItem = VListItem>(
     }
 
     // Calculate visible range
+    const scrollPos = engineState.scrollPosition;
     let visStart = sizeCache.indexAtOffset(scrollPos);
     let visEnd = sizeCache.indexAtOffset(scrollPos + containerSize);
     if (visEnd < totalItems - 1) visEnd++;
@@ -172,7 +158,6 @@ export function table<T extends VListItem = VListItem>(
     engineState.prevRangeStart = -1;
     engineState.prevRangeEnd = -1;
     engineState.renderPending = true;
-    forceNextRender = true;
     tableRenderIfNeeded();
   }
 

--- a/src/plugins/table/renderer.ts
+++ b/src/plugins/table/renderer.ts
@@ -21,7 +21,7 @@
  * - Template re-evaluation skipped when item id + selection/focus state unchanged
  * - Position update skipped when coordinates unchanged (position tracking)
  * - Cell widths are only updated when column layout changes (not every scroll frame)
- * - Released elements removed from DOM immediately, pooled for reuse
+ * - Stale elements released after new ones are in the DOM (no single-frame gaps)
  *
  * DOM structure per row:
  *   .vlist-item.vlist-table-row (position: absolute, translateY)
@@ -516,7 +516,7 @@ export const createTableRenderer = <T extends VListItem = VListItem>(
    * - New rows: created and positioned
    * - Existing rows with same item: state/position update only
    * - Existing rows with different item: full template re-evaluation
-   * - Rows outside range: released after grace period
+   * - Rows outside range: released after new rows are in the DOM
    */
   const render = (
     items: T[],
@@ -525,17 +525,6 @@ export const createTableRenderer = <T extends VListItem = VListItem>(
     focusedIndex: number,
     compressionCtx?: CompressionContext,
   ): void => {
-    // Release items outside the new range immediately.
-    // Tables don't need a grace period — row hover is a simple background
-    // change with no CSS transitions to preserve, and each graced row
-    // carries N cell elements so the DOM cost is high.
-    for (const [index, tracked] of rendered) {
-      if (index < range.start || index > range.end) {
-        pool.release(tracked.element);
-        rendered.delete(index);
-      }
-    }
-
     // Check if aria-setsize changed
     let setSizeChanged = false;
     const total = getTotalItems();
@@ -699,6 +688,17 @@ export const createTableRenderer = <T extends VListItem = VListItem>(
     // Single DOM insertion for all new elements — minimizes reflows
     if (fragment) {
       container.appendChild(fragment);
+    }
+
+    // Release rows outside the new range AFTER new elements are in the DOM.
+    // This matches the core pipeline's approach: new elements are visible
+    // before stale ones are removed, preventing single-frame gaps during
+    // native scrollbar drag (compositor scrolls ahead of main-thread JS).
+    for (const [index, tracked] of rendered) {
+      if (index < range.start || index > range.end) {
+        pool.release(tracked.element);
+        rendered.delete(index);
+      }
     }
   };
 

--- a/src/plugins/table/renderer.ts
+++ b/src/plugins/table/renderer.ts
@@ -138,7 +138,10 @@ interface TrackedRow {
   /** Whether this row is a group header (fast flag — avoids DOM queries) */
   isGroupHeader: boolean;
 
-  /** Last rendered item ID (for change detection) */
+  /** Last rendered item reference (for change detection) */
+  _lastItem: unknown;
+
+  /** Last rendered item ID (for data-id attribute and placeholder transitions) */
   lastItemId: string | number;
 
   /** Last selected state */
@@ -432,6 +435,7 @@ export const createTableRenderer = <T extends VListItem = VListItem>(
       cells: [],  // No cells for group headers
       index,
       isGroupHeader: true,
+      _lastItem: item,
       lastItemId: item.id,
       lastSelected: false,
       lastFocused: false,
@@ -490,6 +494,7 @@ export const createTableRenderer = <T extends VListItem = VListItem>(
       cells,
       index,
       isGroupHeader: false,
+      _lastItem: item,
       lastItemId: item.id,
       lastSelected: isSelected,
       lastFocused: isFocused,
@@ -578,8 +583,8 @@ export const createTableRenderer = <T extends VListItem = VListItem>(
 
         if (isHeader) {
           // ── Group header fast path ──
-          const idChanged = existing.lastItemId !== item.id;
-          if (idChanged) {
+          const itemChanged = existing._lastItem !== item;
+          if (itemChanged) {
             // Different group header — re-render content
             const headerItem = item as unknown as GroupHeaderItem;
             const content = existing.element.firstElementChild as HTMLElement;
@@ -592,6 +597,7 @@ export const createTableRenderer = <T extends VListItem = VListItem>(
               }
             }
             existing.element.setAttribute("data-id", String(item.id));
+            existing._lastItem = item;
             existing.lastItemId = item.id;
           }
 
@@ -610,12 +616,12 @@ export const createTableRenderer = <T extends VListItem = VListItem>(
           }
 
         } else {
-          // ── Data row path (existing logic) ──
-          const idChanged = existing.lastItemId !== item.id;
+          // ── Data row path ──
+          const itemChanged = existing._lastItem !== item;
           const selectedChanged = existing.lastSelected !== isSelected;
           const focusedChanged = existing.lastFocused !== isFocused;
 
-          if (idChanged) {
+          if (itemChanged) {
             // Different item at this index — full re-render of cells
             const wasPlaceholder = existing.lastItemId != null && isPH(existing.lastItemId);
             const isPlaceholder = isPH(item.id);
@@ -639,10 +645,9 @@ export const createTableRenderer = <T extends VListItem = VListItem>(
               setTimeout(() => {
                 existing.element.classList.remove(replacedClass);
               }, 300);
-
-
             }
 
+            existing._lastItem = item;
             existing.lastItemId = item.id;
             existing.lastSelected = isSelected;
             existing.lastFocused = isFocused;
@@ -745,6 +750,7 @@ export const createTableRenderer = <T extends VListItem = VListItem>(
       applyCellTemplate(existing.cells[c]!, item, cols[c]!, index);
     }
     existing.element.setAttribute("data-id", String(item.id));
+    existing._lastItem = item;
     existing.lastItemId = item.id;
 
     applyRowClasses(existing.element, index, isSelected, isFocused);

--- a/test/core/pipeline.test.ts
+++ b/test/core/pipeline.test.ts
@@ -525,3 +525,88 @@ describe("phase2Commit — multiple instances do not interfere", () => {
     }
   });
 });
+
+// =============================================================================
+// phase2Commit — Contiguous release fast path
+// =============================================================================
+
+describe("phase2Commit — contiguous release fast path", () => {
+  function setupCommitTest(totalItems: number) {
+    const items = createTestItems(totalItems);
+    const hooks = emptyHooks();
+    const rc = createRenderConfig("vlist", false, false, 0, 0, 0, "", 0);
+    const state = createEngineState(totalItems + 20);
+    state.totalItems = totalItems;
+    const pool = createPool("vlist");
+    const content = document.createElement("div");
+    const rendered = new Map<number, HTMLElement>();
+    return { items, hooks, rc, state, pool, content, rendered };
+  }
+
+  function fillState(state: EngineState, start: number, count: number, itemSize: number): void {
+    state.visibleCount = count;
+    for (let i = 0; i < count; i++) {
+      state.visibleIndices[i] = start + i;
+      state.visibleOffsets[i] = (start + i) * itemSize;
+      state.visibleSizes[i] = itemSize;
+    }
+  }
+
+  it("releases out-of-range items via range check for contiguous indices", () => {
+    const { items, hooks, rc, state, pool, content, rendered } = setupCommitTest(30);
+
+    fillState(state, 0, 10, 50);
+    phase2Commit(state, pool, content, simpleTemplate as any, () => items, rendered, rc, hooks);
+    expect(rendered.size).toBe(10);
+
+    fillState(state, 5, 10, 50);
+    phase2Commit(state, pool, content, simpleTemplate as any, () => items, rendered, rc, hooks);
+
+    expect(rendered.size).toBe(10);
+    for (let i = 0; i < 5; i++) expect(rendered.has(i)).toBe(false);
+    for (let i = 5; i <= 14; i++) expect(rendered.has(i)).toBe(true);
+  });
+
+  it("releases correctly when scrolling backward", () => {
+    const { items, hooks, rc, state, pool, content, rendered } = setupCommitTest(30);
+
+    fillState(state, 10, 10, 50);
+    phase2Commit(state, pool, content, simpleTemplate as any, () => items, rendered, rc, hooks);
+    expect(rendered.size).toBe(10);
+
+    fillState(state, 5, 10, 50);
+    phase2Commit(state, pool, content, simpleTemplate as any, () => items, rendered, rc, hooks);
+
+    expect(rendered.size).toBe(10);
+    for (let i = 15; i <= 19; i++) expect(rendered.has(i)).toBe(false);
+    for (let i = 5; i <= 14; i++) expect(rendered.has(i)).toBe(true);
+  });
+
+  it("returns released elements to the pool", () => {
+    const { items, hooks, rc, state, pool, content, rendered } = setupCommitTest(30);
+
+    fillState(state, 0, 10, 50);
+    phase2Commit(state, pool, content, simpleTemplate as any, () => items, rendered, rc, hooks);
+    expect(pool.size).toBe(0);
+
+    fillState(state, 10, 10, 50);
+    phase2Commit(state, pool, content, simpleTemplate as any, () => items, rendered, rc, hooks);
+
+    expect(pool.size).toBe(10);
+    expect(rendered.size).toBe(10);
+  });
+
+  it("handles visibleCount = 0 without errors", () => {
+    const { items, hooks, rc, state, pool, content, rendered } = setupCommitTest(20);
+
+    fillState(state, 0, 5, 50);
+    phase2Commit(state, pool, content, simpleTemplate as any, () => items, rendered, rc, hooks);
+    expect(rendered.size).toBe(5);
+
+    state.visibleCount = 0;
+    phase2Commit(state, pool, content, simpleTemplate as any, () => items, rendered, rc, hooks);
+
+    expect(rendered.size).toBe(0);
+    expect(pool.size).toBe(5);
+  });
+});

--- a/test/integration/grid-scale.test.ts
+++ b/test/integration/grid-scale.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Grid + Scale integration tests
+ *
+ * Verifies that the grid plugin correctly handles compressed scroll space
+ * when combined with the scale plugin for large datasets (1M+ items).
+ * The grid operates in ROW space, so compression maps virtual scroll
+ * positions to row indices via the size cache.
+ *
+ * Note: grid's setVirtualTotalFn makes list.total return the row count,
+ * not the item count. Tests use getRenderedIndices() for item-level checks.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { createVList } from "../../src/core/create";
+import type { VList } from "../../src/core/types";
+import {
+  createTestItems,
+  createContainer,
+  simpleTemplate,
+  type TestItem,
+} from "../helpers/factory";
+import { grid } from "../../src/plugins/grid/plugin";
+import { scale } from "../../src/plugins/scale/plugin";
+import { scrollbar } from "../../src/plugins/scrollbar/plugin";
+import { MAX_VIRTUAL_SIZE } from "../../src/rendering/scale";
+
+// =============================================================================
+// DOM Setup
+// =============================================================================
+
+let origClientHeight: PropertyDescriptor | undefined;
+let origClientWidth: PropertyDescriptor | undefined;
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  origClientHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "clientHeight",
+  );
+  origClientWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "clientWidth",
+  );
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    get() { return 500; },
+    configurable: true,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    get() { return 800; },
+    configurable: true,
+  });
+});
+
+afterAll(() => {
+  if (origClientHeight)
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", origClientHeight);
+  if (origClientWidth)
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", origClientWidth);
+  GlobalRegistrator.unregister();
+});
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const ITEM_HEIGHT = 120;
+const COLUMNS = 4;
+const GAP = 8;
+const ROW_SIZE = ITEM_HEIGHT + GAP; // 128px per row in size cache
+
+let container: HTMLElement;
+let list: VList<TestItem> | null = null;
+
+beforeEach(() => {
+  container = createContainer({ width: 800, height: 500 });
+});
+
+afterEach(() => {
+  if (list) {
+    list.destroy();
+    list = null;
+  }
+  container.remove();
+});
+
+function getRenderedIndices(): number[] {
+  if (!list) return [];
+  return Array.from(list.element.querySelectorAll("[data-index]"))
+    .map((el) => parseInt(el.getAttribute("data-index")!, 10))
+    .sort((a, b) => a - b);
+}
+
+function getItemTransformY(el: Element): number {
+  const match = (el as HTMLElement).style.transform.match(/translate\([-\d.]+px,\s*([-\d.]+)px\)/);
+  return match ? parseFloat(match[1]!) : NaN;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("grid + scale integration", () => {
+  describe("creation and initialization", () => {
+    it("creates a list with grid + scale without errors", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(1000),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [grid({ columns: COLUMNS, gap: GAP }), scale()],
+      );
+
+      // grid virtualizes total to row count
+      expect(list.total).toBe(Math.ceil(1000 / COLUMNS));
+    });
+
+    it("renders grid items with scale plugin present (non-compressed)", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(1000),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [grid({ columns: COLUMNS, gap: GAP }), scale()],
+      );
+
+      const items = list.element.querySelectorAll(".vlist-grid-item");
+      expect(items.length).toBeGreaterThan(0);
+    });
+
+    it("creates with grid + scale + scrollbar", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(1000),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [
+          grid({ columns: COLUMNS, gap: GAP }),
+          scale(),
+          scrollbar(),
+        ],
+      );
+
+      expect(list.total).toBe(Math.ceil(1000 / COLUMNS));
+      expect(list.element.querySelector("[class*='scrollbar']")).not.toBeNull();
+    });
+  });
+
+  describe("compressed mode", () => {
+    // 600K items → 150K rows → 150K × 128 = 19.2M px > 16M limit
+    const LARGE_COUNT = 600_000;
+
+    it("activates compression for datasets exceeding browser limit", () => {
+      const totalRows = Math.ceil(LARGE_COUNT / COLUMNS);
+      const totalHeight = totalRows * ROW_SIZE;
+      expect(totalHeight).toBeGreaterThan(MAX_VIRTUAL_SIZE);
+
+      list = createVList(
+        {
+          container,
+          items: createTestItems(LARGE_COUNT),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [grid({ columns: COLUMNS, gap: GAP }), scale()],
+      );
+
+      expect(list.total).toBe(Math.ceil(LARGE_COUNT / COLUMNS));
+    });
+
+    it("renders items at initial position in compressed mode", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(LARGE_COUNT),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [grid({ columns: COLUMNS, gap: GAP }), scale()],
+      );
+
+      const indices = getRenderedIndices();
+      expect(indices.length).toBeGreaterThan(0);
+      expect(indices[0]).toBe(0);
+    });
+
+    it("renders multiple columns per row", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(LARGE_COUNT),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [grid({ columns: COLUMNS, gap: GAP }), scale()],
+      );
+
+      const indices = getRenderedIndices();
+      expect(indices).toContain(0);
+      expect(indices).toContain(1);
+      expect(indices).toContain(2);
+      expect(indices).toContain(3);
+    });
+
+    it("positions items relative to viewport in compressed mode", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(LARGE_COUNT),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [grid({ columns: COLUMNS, gap: GAP }), scale()],
+      );
+
+      const items = list.element.querySelectorAll(".vlist-grid-item");
+      expect(items.length).toBeGreaterThan(0);
+
+      const firstY = getItemTransformY(items[0]!);
+      expect(firstY).not.toBeNaN();
+      expect(Math.abs(firstY)).toBeLessThan(ITEM_HEIGHT + GAP);
+    });
+
+    it("renders correct items after scrollToIndex in compressed mode", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(LARGE_COUNT),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [grid({ columns: COLUMNS, gap: GAP }), scale()],
+      );
+
+      list.scrollToIndex(300_000, "start");
+
+      const indices = getRenderedIndices();
+      expect(indices.length).toBeGreaterThan(0);
+      const minIdx = Math.min(...indices);
+      const maxIdx = Math.max(...indices);
+      expect(minIdx).toBeLessThanOrEqual(300_000);
+      expect(maxIdx).toBeGreaterThanOrEqual(300_000);
+    });
+
+    it("renders correct items near the end of the list", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(LARGE_COUNT),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [grid({ columns: COLUMNS, gap: GAP }), scale()],
+      );
+
+      list.scrollToIndex(LARGE_COUNT - 1, "end");
+
+      const indices = getRenderedIndices();
+      expect(indices.length).toBeGreaterThan(0);
+      expect(Math.max(...indices)).toBe(LARGE_COUNT - 1);
+    });
+
+    it("items have viewport-relative positions (not absolute multi-million px)", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(LARGE_COUNT),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [grid({ columns: COLUMNS, gap: GAP }), scale()],
+      );
+
+      list.scrollToIndex(300_000, "start");
+
+      const items = list.element.querySelectorAll(".vlist-grid-item");
+      for (const item of items) {
+        const y = getItemTransformY(item);
+        expect(y).not.toBeNaN();
+        expect(Math.abs(y)).toBeLessThan(5000);
+      }
+    });
+  });
+
+  describe("force compression", () => {
+    it("works with scale({ force: true }) on small datasets", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(100),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [grid({ columns: COLUMNS, gap: GAP }), scale({ force: true })],
+      );
+
+      expect(list.total).toBe(Math.ceil(100 / COLUMNS));
+
+      const indices = getRenderedIndices();
+      expect(indices.length).toBeGreaterThan(0);
+      expect(indices[0]).toBe(0);
+    });
+
+    it("scrollToIndex works with forced compression", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(500),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [grid({ columns: COLUMNS, gap: GAP }), scale({ force: true })],
+      );
+
+      list.scrollToIndex(250, "center");
+
+      const indices = getRenderedIndices();
+      expect(indices).toContain(250);
+    });
+  });
+
+  describe("non-compressed (scale present but below threshold)", () => {
+    it("uses standard positioning when below compression threshold", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(1000),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [grid({ columns: COLUMNS, gap: GAP }), scale()],
+      );
+
+      const totalRows = Math.ceil(1000 / COLUMNS);
+      const totalHeight = totalRows * ROW_SIZE;
+      expect(totalHeight).toBeLessThan(MAX_VIRTUAL_SIZE);
+
+      // First item at position (x, 0)
+      const firstItem = list.element.querySelector("[data-index='0']") as HTMLElement;
+      expect(firstItem).not.toBeNull();
+      expect(getItemTransformY(firstItem)).toBe(0);
+    });
+
+    it("scrollToIndex does not throw without compression", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(1000),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [grid({ columns: COLUMNS, gap: GAP }), scale()],
+      );
+
+      expect(() => list!.scrollToIndex(500, "start")).not.toThrow();
+    });
+  });
+
+  describe("destroy", () => {
+    it("destroys cleanly with grid + scale", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(600_000),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [grid({ columns: COLUMNS, gap: GAP }), scale()],
+      );
+
+      expect(() => {
+        list!.destroy();
+        list = null;
+      }).not.toThrow();
+    });
+
+    it("destroys cleanly with grid + scale + scrollbar", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(1000),
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [
+          grid({ columns: COLUMNS, gap: GAP }),
+          scale(),
+          scrollbar(),
+        ],
+      );
+
+      expect(() => {
+        list!.destroy();
+        list = null;
+      }).not.toThrow();
+    });
+  });
+});

--- a/test/integration/table-scale.test.ts
+++ b/test/integration/table-scale.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Table + Scale integration tests
+ *
+ * Verifies that the table plugin correctly handles compressed scroll space
+ * when combined with the scale plugin for large datasets (1M+ items).
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { createVList } from "../../src/core/create";
+import type { VList } from "../../src/core/types";
+import {
+  createTestItems,
+  createContainer,
+  simpleTemplate,
+  type TestItem,
+} from "../helpers/factory";
+import type { TableColumn } from "../../src/plugins/table/types";
+import { table } from "../../src/plugins/table/plugin";
+import { scale } from "../../src/plugins/scale/plugin";
+import { scrollbar } from "../../src/plugins/scrollbar/plugin";
+import { MAX_VIRTUAL_SIZE } from "../../src/rendering/scale";
+
+// =============================================================================
+// DOM Setup
+// =============================================================================
+
+let origClientHeight: PropertyDescriptor | undefined;
+let origClientWidth: PropertyDescriptor | undefined;
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  origClientHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "clientHeight",
+  );
+  origClientWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "clientWidth",
+  );
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    get() { return 500; },
+    configurable: true,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    get() { return 800; },
+    configurable: true,
+  });
+});
+
+afterAll(() => {
+  if (origClientHeight)
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", origClientHeight);
+  if (origClientWidth)
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", origClientWidth);
+  GlobalRegistrator.unregister();
+});
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const ROW_HEIGHT = 36;
+
+const columns: TableColumn<TestItem>[] = [
+  { key: "name", label: "Name", width: 200 },
+  { key: "value", label: "Value", width: 100 },
+];
+
+let container: HTMLElement;
+let list: VList<TestItem> | null = null;
+
+beforeEach(() => {
+  container = createContainer({ width: 800, height: 500 });
+});
+
+afterEach(() => {
+  if (list) {
+    list.destroy();
+    list = null;
+  }
+  container.remove();
+});
+
+function getRenderedIndices(): number[] {
+  if (!list) return [];
+  return Array.from(list.element.querySelectorAll("[data-index]"))
+    .map((el) => parseInt(el.getAttribute("data-index")!, 10))
+    .sort((a, b) => a - b);
+}
+
+function getRowTransformY(el: Element): number {
+  const match = (el as HTMLElement).style.transform.match(/translateY\(([-\d.]+)px\)/);
+  return match ? parseFloat(match[1]!) : NaN;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("table + scale integration", () => {
+  describe("creation and initialization", () => {
+    it("creates a list with table + scale without errors", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(1000),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [table({ columns, rowHeight: ROW_HEIGHT }), scale()],
+      );
+
+      expect(list.total).toBe(1000);
+    });
+
+    it("renders table rows with scale plugin present (non-compressed)", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(1000),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [table({ columns, rowHeight: ROW_HEIGHT }), scale()],
+      );
+
+      const rows = list.element.querySelectorAll(".vlist-table-row");
+      expect(rows.length).toBeGreaterThan(0);
+    });
+
+    it("creates with table + scale + scrollbar", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(1000),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [
+          table({ columns, rowHeight: ROW_HEIGHT }),
+          scale(),
+          scrollbar(),
+        ],
+      );
+
+      expect(list.total).toBe(1000);
+      expect(list.element.querySelector("[class*='scrollbar']")).not.toBeNull();
+    });
+  });
+
+  describe("compressed mode", () => {
+    const LARGE_COUNT = 500_000;
+
+    it("activates compression for datasets exceeding browser limit", () => {
+      const totalHeight = LARGE_COUNT * ROW_HEIGHT;
+      expect(totalHeight).toBeGreaterThan(MAX_VIRTUAL_SIZE);
+
+      list = createVList(
+        {
+          container,
+          items: createTestItems(LARGE_COUNT),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [table({ columns, rowHeight: ROW_HEIGHT }), scale()],
+      );
+
+      expect(list.total).toBe(LARGE_COUNT);
+    });
+
+    it("renders rows at initial position in compressed mode", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(LARGE_COUNT),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [table({ columns, rowHeight: ROW_HEIGHT }), scale()],
+      );
+
+      const indices = getRenderedIndices();
+      expect(indices.length).toBeGreaterThan(0);
+      expect(indices[0]).toBe(0);
+    });
+
+    it("positions rows relative to viewport in compressed mode", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(LARGE_COUNT),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [table({ columns, rowHeight: ROW_HEIGHT }), scale()],
+      );
+
+      const rows = list.element.querySelectorAll(".vlist-table-row");
+      expect(rows.length).toBeGreaterThan(0);
+
+      const firstY = getRowTransformY(rows[0]!);
+      expect(firstY).not.toBeNaN();
+      // At scroll position 0, first row should be near top of viewport
+      expect(Math.abs(firstY)).toBeLessThan(ROW_HEIGHT);
+    });
+
+    it("renders correct rows after scrollToIndex in compressed mode", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(LARGE_COUNT),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [table({ columns, rowHeight: ROW_HEIGHT }), scale()],
+      );
+
+      list.scrollToIndex(250_000, "start");
+
+      const indices = getRenderedIndices();
+      expect(indices.length).toBeGreaterThan(0);
+      // Rendered range should be near the target index
+      const minIdx = Math.min(...indices);
+      const maxIdx = Math.max(...indices);
+      expect(minIdx).toBeLessThanOrEqual(250_000);
+      expect(maxIdx).toBeGreaterThanOrEqual(250_000);
+    });
+
+    it("renders correct rows near the end of the list", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(LARGE_COUNT),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [table({ columns, rowHeight: ROW_HEIGHT }), scale()],
+      );
+
+      list.scrollToIndex(LARGE_COUNT - 1, "end");
+
+      const indices = getRenderedIndices();
+      expect(indices.length).toBeGreaterThan(0);
+      expect(Math.max(...indices)).toBe(LARGE_COUNT - 1);
+    });
+
+    it("rows have viewport-relative positions (not absolute multi-million px)", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(LARGE_COUNT),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [table({ columns, rowHeight: ROW_HEIGHT }), scale()],
+      );
+
+      list.scrollToIndex(250_000, "start");
+
+      const rows = list.element.querySelectorAll(".vlist-table-row");
+      for (const row of rows) {
+        const y = getRowTransformY(row);
+        expect(y).not.toBeNaN();
+        // In compressed mode, positions are viewport-relative (small values),
+        // not absolute offsets (which would be ~9M px at index 250K)
+        expect(Math.abs(y)).toBeLessThan(5000);
+      }
+    });
+  });
+
+  describe("force compression", () => {
+    it("works with scale({ force: true }) on small datasets", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(100),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [table({ columns, rowHeight: ROW_HEIGHT }), scale({ force: true })],
+      );
+
+      expect(list.total).toBe(100);
+
+      const indices = getRenderedIndices();
+      expect(indices.length).toBeGreaterThan(0);
+      expect(indices[0]).toBe(0);
+    });
+
+    it("scrollToIndex works with forced compression", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(500),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [table({ columns, rowHeight: ROW_HEIGHT }), scale({ force: true })],
+      );
+
+      list.scrollToIndex(250, "center");
+
+      const indices = getRenderedIndices();
+      expect(indices).toContain(250);
+    });
+  });
+
+  describe("non-compressed (scale present but below threshold)", () => {
+    it("uses standard positioning when below compression threshold", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(1000),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [table({ columns, rowHeight: ROW_HEIGHT }), scale()],
+      );
+
+      const totalHeight = 1000 * ROW_HEIGHT;
+      expect(totalHeight).toBeLessThan(MAX_VIRTUAL_SIZE);
+
+      // First row should be at absolute offset 0
+      const firstRow = list.element.querySelector("[data-index='0']") as HTMLElement;
+      expect(firstRow).not.toBeNull();
+      expect(getRowTransformY(firstRow)).toBe(0);
+
+      // Second row at absolute offset = ROW_HEIGHT
+      const secondRow = list.element.querySelector("[data-index='1']") as HTMLElement;
+      expect(secondRow).not.toBeNull();
+      expect(getRowTransformY(secondRow)).toBe(ROW_HEIGHT);
+    });
+
+    it("scrollToIndex does not throw without compression", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(1000),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [table({ columns, rowHeight: ROW_HEIGHT }), scale()],
+      );
+
+      expect(() => list!.scrollToIndex(500, "start")).not.toThrow();
+    });
+  });
+
+  describe("destroy", () => {
+    it("destroys cleanly with table + scale", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(500_000),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [table({ columns, rowHeight: ROW_HEIGHT }), scale()],
+      );
+
+      expect(() => {
+        list!.destroy();
+        list = null;
+      }).not.toThrow();
+    });
+
+    it("destroys cleanly with table + scale + scrollbar", () => {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(1000),
+          item: { height: ROW_HEIGHT, template: simpleTemplate },
+        },
+        [
+          table({ columns, rowHeight: ROW_HEIGHT }),
+          scale(),
+          scrollbar(),
+        ],
+      );
+
+      expect(() => {
+        list!.destroy();
+        list = null;
+      }).not.toThrow();
+    });
+  });
+});

--- a/test/plugins/table/renderer.test.ts
+++ b/test/plugins/table/renderer.test.ts
@@ -399,7 +399,7 @@ describe("selection and focus", () => {
 // =============================================================================
 
 describe("change tracking", () => {
-  it("should skip template re-evaluation when item ID unchanged", () => {
+  it("should skip template re-evaluation when item reference is unchanged", () => {
     const columns: TableColumn<TestItem>[] = [
       col("name", {
         width: 200,
@@ -415,11 +415,30 @@ describe("change tracking", () => {
     const cell = container.querySelector(".vlist-table-cell")!;
     const originalHTML = cell.innerHTML;
 
-    // Re-render with same item — template should not be re-evaluated
-    // (we can verify by checking the same element is reused)
+    // Re-render with same item reference — template should not be re-evaluated
     renderer.render(items, { start: 0, end: 0 }, EMPTY_SET, -1);
 
     expect(cell.innerHTML).toBe(originalHTML);
+
+    container.remove();
+  });
+
+  it("should re-render cells when item reference changes even with same id", () => {
+    const { renderer, container } = createTestRenderer();
+    const items1: TestItem[] = [{ id: 1, name: "Alice", email: "alice@test.com", role: "admin" }];
+    const items2: TestItem[] = [{ id: 1, name: "Alice Updated", email: "alice2@test.com", role: "admin" }];
+
+    renderer.render(items1, { start: 0, end: 0 }, EMPTY_SET, -1);
+
+    let cells = container.querySelectorAll(".vlist-table-cell");
+    expect(cells[0]!.textContent).toBe("Alice");
+
+    // Different object with same id — must re-render
+    renderer.render(items2, { start: 0, end: 0 }, EMPTY_SET, -1);
+
+    cells = container.querySelectorAll(".vlist-table-cell");
+    expect(cells[0]!.textContent).toBe("Alice Updated");
+    expect(cells[1]!.textContent).toBe("alice2@test.com");
 
     container.remove();
   });


### PR DESCRIPTION
## Summary

- **Grid + Scale compression** — grid plugin supports scale plugin compression for 1M+ item grids
- **Table + Scale compression** — table plugin supports scale plugin compression for 1M+ row tables
- **Table item identity fix** — track by reference instead of `item.id` (#91)
- **Render pipeline ordering** — release-after-create, table totalSize sync
- **Contiguous release fast path** — batch element release for range shifts (RFC-006)
- **Table render pipeline cleanup** — removed redundant bail-out and state variables

## Test plan

- [ ] `bun test` passes
- [ ] `bun run size` matches README/npm-readme sizes
- [ ] Grid + scale works at 1M+ items on staging.vlist.io
- [ ] Table + scale works at 1M+ items on staging.vlist.io