### PR TITLE
v2.1.1 — Groups cross-plugin integration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -154,6 +154,8 @@ Use orientation-neutral terminology. The library supports both vertical and hori
 
 Bun test runner with happy-dom (`@happy-dom/global-registrator`). Tests mirror `src/` structure.
 
+**Every code change MUST include its tests in the same step.** Never split a fix and its tests into separate commits. Write the tests before reporting the work as done.
+
 - DOM environment: `GlobalRegistrator.register()` in `beforeAll`, `unregister()` in `afterAll` — sets all browser globals
 - Shared helpers in `test/helpers/`: `setupDOM`, `teardownDOM`, `createTestItems`, `createContainer`, `simpleTemplate`, `useFakeTimers`
 - `useFakeTimers()`: custom utility (Bun lacks `mock.timers`) — intercepts setTimeout/setInterval, use `fakeTimers.tick(ms)` to advance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ This changelog starts at v1.5.4, the first version published under the `vlist` p
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-06-01
+
+### Added
+
+- **Groups + Table + Data integration** — groups plugin works natively with table and async data plugins
+  - `setGetItemFn` deferred via microtask for correct plugin ordering
+  - `sizeCache.rebuild` interceptor with loaded-count guard for snapshots restore race
+  - Sticky headers in table mode
+- **Groups + Grid integration** — groups plugin renders grid items with correct column layout
+  - Binary search on sorted position array for O(log n) visible range lookup
+  - Grid-aware header positioning (full width, correct Y offsets)
+  - Sticky header uses grid-aware offsets for correct group transitions
+  - Padding support (crossAxisPadding, mainAxisPadding, startPadding)
+  - Resize handling: rebuilds grid positions on container width change
+- **Data plugin `_getItem` method** — returns placeholder objects for unloaded items (vs `_getLoadedItem` which returns undefined)
+
+### Fixed
+
+- **Selection with groups** — all item lookups use `getDataItemAtLayout` which resolves by data index via `getItems()[di]` or `_getLoadedItem(di)`, consistent across table, grid, and list modes
+- **Keyboard navigation in table mode** — keydown listener moved from `dom.content` to `dom.root`; selection click handler focuses correct element when content has no tabindex
+- **Smooth scroll idle** — `scheduleIdle()` called on final animation frame so data plugin loads visible range after scrollToIndex with smooth behavior
+- **Snapshots `_suppressSave`** — removed permanently-blocking flag that prevented all saves after restore with `dataIndex`; pixel-perfect scroll restore via raw `scrollTop` when data total matches
+- **Placeholders in table+groups+data** — groups' table-mode `getItemFn` uses `_getItem` (includes placeholders) instead of `_getLoadedItem` (returns undefined)
+- **Groups grid content size** — includes `mainAxisPadding` for correct bottom padding
+- **Groups scroll-into-view** — uses grid-aware Y positions with padding for keyboard navigation
+
 ## [2.1.0] - 2026-05-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The virtual list library for every framework. Ultra efficient, batteries-included, and accessible with composable plugins — in 8.0 KB.
 
-**v2.1.0** — [Changelog](./CHANGELOG.md) · **New:** [`tree()`](https://vlist.io/docs/plugins/tree) plugin — virtualized collapsible trees with async loading, indent guides, and WAI-ARIA treeview keyboard nav.
+**v2.1.1** — [Changelog](./CHANGELOG.md) · Native groups + table + data + grid cross-plugin integration, pixel-perfect snapshot restore, keyboard nav fixes.
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/vlist)](https://bundlephobia.com/package/vlist)
@@ -95,14 +95,14 @@ const list = createVList({
 | Plugin | Size | Description |
 |--------|------|-------------|
 | **Base** | 8.0 KB | Virtualization, ARIA, keyboard nav, gap, padding |
-| `data()` | +4.6 KB | Lazy loading with velocity-aware fetching |
-| `selection()` | +2.4 KB | Single/multiple selection with 2D keyboard nav |
+| `data()` | +4.7 KB | Lazy loading with velocity-aware fetching |
+| `selection()` | +2.5 KB | Single/multiple selection with 2D keyboard nav |
 | `scale()` | +3.9 KB | 1M+ items via scroll compression |
-| `groups()` | +3.7 KB | Sticky/inline headers with async group discovery |
+| `groups()` | +4.8 KB | Sticky/inline headers with grid + table + data integration |
 | `autosize()` | +0.8 KB | Auto-measure items via ResizeObserver |
 | `scrollbar()` | +2.0 KB | Custom scrollbar UI |
-| `grid()` | +2.7 KB | 2D grid layout |
-| `masonry()` | +3.6 KB | Pinterest-style masonry with lane-aware keyboard nav |
+| `grid()` | +2.8 KB | 2D grid layout |
+| `masonry()` | +3.7 KB | Pinterest-style masonry with lane-aware keyboard nav |
 | `table()` | +6.1 KB | Data table with columns, resize, sort |
 | `tree()` | +5.3 KB | Collapsible tree with async loading and indent guides |
 | `page()` | +0.8 KB | Window-level scrolling |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/scripts/size.ts
+++ b/scripts/size.ts
@@ -34,6 +34,8 @@ const KNOWN_DEPS: Partial<Record<PluginName, readonly PluginName[]>> = {
   scale: ["scrollbar"],
   // selection does a dynamic getMethod("getGroupLayout") lookup — string only, no import
   selection: ["groups"],
+  // groups does a dynamic getMethod("getGridLayout") lookup — string only, no import
+  groups: ["grid"],
 };
 
 // ── Unique string markers per plugin ─────────────────────────────

--- a/src/core/create.ts
+++ b/src/core/create.ts
@@ -575,7 +575,7 @@ export function createVList<T extends VListItem = VListItem>(
   dom.content.addEventListener("click", onContentClick);
   dom.content.addEventListener("dblclick", onContentDblClick);
   dom.content.addEventListener("contextmenu", onContentContextMenu);
-  if (keydownHandlers.length > 0) dom.content.addEventListener("keydown", onContentKeydown);
+  if (keydownHandlers.length > 0) dom.root.addEventListener("keydown", onContentKeydown);
 
   // ── ResizeObserver ──────────────────────────────────────────────
 
@@ -800,7 +800,7 @@ export function createVList<T extends VListItem = VListItem>(
       dom.content.removeEventListener("click", onContentClick);
       dom.content.removeEventListener("dblclick", onContentDblClick);
       dom.content.removeEventListener("contextmenu", onContentContextMenu);
-      dom.content.removeEventListener("keydown", onContentKeydown);
+      dom.root.removeEventListener("keydown", onContentKeydown);
 
       const destroyErrors: Error[] = [];
       for (const handler of destroyHandlers) {

--- a/src/core/scroll.ts
+++ b/src/core/scroll.ts
@@ -157,6 +157,7 @@ export function createScrollHandler(config: ScrollHandlerConfig): ScrollHandler 
         animationId = requestAnimationFrame(tick);
       } else {
         animationId = null;
+        scheduleIdle();
         onComplete?.();
       }
     }

--- a/src/plugins/data/plugin.ts
+++ b/src/plugins/data/plugin.ts
@@ -192,6 +192,10 @@ export function data<T extends VListItem = VListItem>(
         },
         onItemsLoaded: (loadedItems) => {
           if (engineState.initialized) {
+            // Always rebuild sizeCache so layout interceptors (groups plugin)
+            // can detect newly loaded items and rebuild their layout.
+            sizeCache.rebuild(dataManager.getTotal());
+            ctx.updateContentSize(sizeCache.getTotalSize());
             forceRender();
             emitter.emit("load:end", { items: loadedItems, total: dataManager.getTotal() });
           }

--- a/src/plugins/data/plugin.ts
+++ b/src/plugins/data/plugin.ts
@@ -279,6 +279,10 @@ export function data<T extends VListItem = VListItem>(
         return dataManager.getStorage().get(index) as T | undefined;
       });
 
+      ctx.registerMethod("_getItem", (index: number): T | undefined => {
+        return dataManager.getItem(index) as T | undefined;
+      });
+
       ctx.registerMethod("_getLoadedCount", (): number => dataManager.getCached());
 
       // ARIA: aria-busy for loading state

--- a/src/plugins/groups/plugin.ts
+++ b/src/plugins/groups/plugin.ts
@@ -822,6 +822,22 @@ export function groups<T extends VListItem = VListItem>(
         return entry.type === "header";
       });
 
+      const mainPadEnd = mainAxisPadding - ctx.config.startPadding;
+      ctx.registerMethod("_scrollItemIntoView", (layoutIndex: number): void => {
+        if (layoutIndex < 0) return;
+        const pos = gridItemPositions?.get(layoutIndex);
+        const offset = pos ? pos.rowY : sizeCache.getOffset(layoutIndex);
+        const size = sizeCache.getSize(layoutIndex);
+        const cs = engineState.containerSize;
+        const sp = engineState.scrollPosition;
+
+        if (offset < sp) {
+          ctx.scrollTo(offset);
+        } else if (offset + size + mainPadEnd > sp + cs) {
+          ctx.scrollTo(offset + size + mainPadEnd - cs);
+        }
+      });
+
       ctx.registerMethod("scrollToIndex", (
         index: number,
         alignOrOptions: "start" | "center" | "end" | { align?: "start" | "center" | "end"; behavior?: "auto" | "smooth"; duration?: number } = "start",

--- a/src/plugins/groups/plugin.ts
+++ b/src/plugins/groups/plugin.ts
@@ -346,10 +346,28 @@ export function groups<T extends VListItem = VListItem>(
     return !isPlaceholder;
   }
 
+  let lastCrossSize = 0;
+
+  function syncGridIfResized(): void {
+    if (gridColumns <= 0) return;
+    const cross = engineState.crossSize;
+    if (cross === lastCrossSize) return;
+    lastCrossSize = cross;
+    rebuildGridPositions();
+    const totalSize = getGridContentSize();
+    contentElement.style[isX ? "width" : "height"] = (totalSize + mainAxisPadding) + "px";
+    if (stickyHeader) {
+      stickyHeader.refresh();
+      stickyHeader.update(engineState.scrollPosition);
+    }
+    forceNextRender = true;
+  }
+
   function groupsRenderIfNeeded(): void {
     if (engineState.destroyed) return;
 
     syncLayoutIfNeeded();
+    syncGridIfResized();
 
     const scrollPos = engineState.scrollPosition;
     const cs = engineState.containerSize;
@@ -491,6 +509,10 @@ export function groups<T extends VListItem = VListItem>(
       } else {
         // ── Existing unchanged element — fast path ──
         isHeader = element.classList.contains(groupHeaderClass);
+        if (isForced) {
+          applySizeStyles(element, i);
+          element.style.transform = buildTransform(i);
+        }
       }
 
       if (!isHeader && isf) {
@@ -536,6 +558,7 @@ export function groups<T extends VListItem = VListItem>(
 
   function groupsForceRender(): void {
     if (engineState.destroyed) return;
+    syncGridIfResized();
 
     if (DEBUG) {
       console.log(`[groups] forceRender, placeholders: ${placeholderIndices.size}, rendered: ${rendered.size}`);
@@ -895,6 +918,23 @@ export function groups<T extends VListItem = VListItem>(
         if (stickyHeader) {
           stickyHeader.update(scrollPosition);
         }
+      },
+      onResize(_w: number, _h: number): void {
+        if (gridColumns <= 0) return;
+        // Grid plugin's onResize runs first (same priority, earlier in array)
+        // and updates its internal columnWidth. Now sizeCache sizes will
+        // reflect the new column width. Rebuild positions and re-render.
+        origSizeCacheRebuild(layout.totalEntries);
+        lastCrossSize = engineState.crossSize;
+        rebuildGridPositions();
+        const totalSize = getGridContentSize();
+        contentElement.style[isX ? "width" : "height"] = (totalSize + mainAxisPadding) + "px";
+        if (stickyHeader) {
+          stickyHeader.refresh();
+          stickyHeader.update(engineState.scrollPosition);
+        }
+        forceNextRender = true;
+        groupsRenderIfNeeded();
       },
     },
 

--- a/src/plugins/groups/plugin.ts
+++ b/src/plugins/groups/plugin.ts
@@ -673,6 +673,21 @@ export function groups<T extends VListItem = VListItem>(
 
       ctx.setRenderFn(groupsRenderIfNeeded, groupsForceRender);
 
+      // If table plugin is active, tell its renderer about group headers.
+      // Table's setRenderFn (called in table's setup) overrides ours above.
+      queueMicrotask(() => {
+        const tableGroupsFn = getMethod?.("_updateTableForGroups") as ((
+          isHeaderFn: (item: T) => boolean,
+          ht: (key: string, groupIndex: number) => HTMLElement | string,
+        ) => void) | undefined;
+        if (tableGroupsFn) {
+          tableGroupsFn(
+            (item: T) => !!(item as Record<string, unknown>).__groupHeader,
+            headerTemplate,
+          );
+        }
+      });
+
       ctx.registerMethod("getGroupLayout", () => layout);
 
       ctx.registerMethod("_dataToLayoutIndex", (dataIndex: number): number =>

--- a/src/plugins/groups/plugin.ts
+++ b/src/plugins/groups/plugin.ts
@@ -76,6 +76,8 @@ export function groups<T extends VListItem = VListItem>(
   let groupHeaderClass: string;
   let getMethod: ((name: string) => Function | undefined) | null = null;
   let interactive: boolean | null = null;
+  let gridColumns = 0;
+  let gridGap = 0;
 
   const rendered = new Map<number, HTMLElement>();
   // Track which layout indices currently show placeholder content
@@ -110,7 +112,8 @@ export function groups<T extends VListItem = VListItem>(
     lastDataCount = dataCount;
     layout.rebuild(dataCount, getLoadedItem ?? ctxGetItem);
     origSizeCacheRebuild(layout.totalEntries);
-    const totalSize = sizeCache.getTotalSize();
+    rebuildGridPositions();
+    const totalSize = gridItemPositions ? getGridContentSize() : sizeCache.getTotalSize();
     contentElement.style[isX ? "width" : "height"] = totalSize + "px";
     if (stickyHeader) {
       stickyHeader.refresh();
@@ -130,7 +133,66 @@ export function groups<T extends VListItem = VListItem>(
     }
   }
 
+  let gridColWidth = 0;
+  let gridItemPositions: Map<number, { col: number; rowY: number }> | null = null;
+
+  function rebuildGridPositions(): void {
+    if (gridColumns <= 0) { gridItemPositions = null; return; }
+    const containerW = engineState.crossSize || contentElement.clientWidth;
+    gridColWidth = (containerW - (gridColumns - 1) * gridGap) / gridColumns;
+    gridItemPositions = new Map();
+
+    const total = layout.totalEntries;
+    let groupY = 0;
+    let itemInGroup = 0;
+    let rowH = 0;
+
+    for (let i = 0; i < total; i++) {
+      const entry = layout.getEntry(i);
+      if (entry.type === "header") {
+        if (itemInGroup > 0 && rowH > 0) groupY += rowH;
+        groupY += sizeCache.getSize(i);
+        itemInGroup = 0;
+        rowH = 0;
+      } else {
+        const col = itemInGroup % gridColumns;
+        const h = sizeCache.getSize(i);
+        if (col === 0) {
+          if (itemInGroup > 0 && rowH > 0) groupY += rowH + gridGap;
+          rowH = h;
+        } else {
+          if (h > rowH) rowH = h;
+        }
+        gridItemPositions.set(i, { col, rowY: groupY });
+        itemInGroup++;
+      }
+    }
+  }
+
+  function getGridContentSize(): number {
+    if (!gridItemPositions || gridItemPositions.size === 0) return sizeCache.getTotalSize();
+    let maxY = 0;
+    const total = layout.totalEntries;
+    for (let i = total - 1; i >= 0; i--) {
+      const pos = gridItemPositions.get(i);
+      if (pos) { maxY = pos.rowY + sizeCache.getSize(i); break; }
+      const entry = layout.getEntry(i);
+      if (entry.type === "header") { maxY = sizeCache.getOffset(i) + sizeCache.getSize(i); break; }
+    }
+    return maxY;
+  }
+
   function buildTransform(layoutIndex: number): string {
+    if (gridItemPositions) {
+      const pos = gridItemPositions.get(layoutIndex);
+      if (pos) {
+        const x = pos.col * (gridColWidth + gridGap);
+        const y = pos.rowY;
+        if (isX) return `translate(${Math.round(y)}px, ${Math.round(x)}px)`;
+        return `translate(${Math.round(x)}px, ${Math.round(y)}px)`;
+      }
+    }
+
     const offset = sizeCache.getOffset(layoutIndex);
     if (isX) {
       return `translate(${Math.round(offset)}px, 0)`;
@@ -140,12 +202,23 @@ export function groups<T extends VListItem = VListItem>(
 
   function applySizeStyles(element: HTMLElement, layoutIndex: number): void {
     const size = sizeCache.getSize(layoutIndex);
+    if (gridItemPositions?.has(layoutIndex)) {
+      if (isX) {
+        element.style.width = `${size}px`;
+        element.style.height = `${gridColWidth}px`;
+      } else {
+        element.style.height = `${size}px`;
+        element.style.width = `${gridColWidth}px`;
+      }
+      return;
+    }
     if (isX) {
       element.style.width = `${size}px`;
     } else {
       element.style.height = `${size}px`;
     }
   }
+
 
   function detachAll(): void {
     rendered.forEach((element) => {
@@ -374,7 +447,7 @@ export function groups<T extends VListItem = VListItem>(
 
     drainDetached();
 
-    const totalSize = sizeCache.getTotalSize();
+    const totalSize = gridItemPositions ? getGridContentSize() : sizeCache.getTotalSize();
     contentElement.style[isX ? "width" : "height"] = totalSize + "px";
 
     engineState.prevRangeStart = renderStart;
@@ -432,7 +505,8 @@ export function groups<T extends VListItem = VListItem>(
 
       if (boundariesChanged) {
         origSizeCacheRebuild(layout.totalEntries);
-        const totalSize = sizeCache.getTotalSize();
+        rebuildGridPositions();
+        const totalSize = gridItemPositions ? getGridContentSize() : sizeCache.getTotalSize();
         contentElement.style[isX ? "width" : "height"] = totalSize + "px";
         if (stickyHeader) {
           stickyHeader.refresh();
@@ -499,6 +573,15 @@ export function groups<T extends VListItem = VListItem>(
       // Resolve raw storage accessor (async plugin) — returns undefined for
       // unloaded items without generating placeholder objects. Used in
       // buildGroups to skip unloaded items efficiently.
+      // Resolve grid info synchronously — grid runs at same priority (10)
+      // but may be listed before groups in the plugin array
+      const gridLayoutFn = getMethod?.("getGridLayout") as (() => { columns: number; gap: number }) | undefined;
+      if (gridLayoutFn) {
+        const gl = gridLayoutFn();
+        gridColumns = gl.columns;
+        gridGap = gl.gap;
+      }
+
       queueMicrotask(() => {
         const fn = getMethod?.("_getLoadedItem") as ((i: number) => T | undefined) | undefined;
         if (fn) getLoadedItem = fn;
@@ -541,6 +624,7 @@ export function groups<T extends VListItem = VListItem>(
       };
 
       sizeCache.rebuild(layout.totalEntries);
+      rebuildGridPositions();
       ctx.setVirtualTotalFn(() => layout.totalEntries);
 
       rootElement.classList.add(`${classPrefix}--grouped`);

--- a/src/plugins/groups/plugin.ts
+++ b/src/plugins/groups/plugin.ts
@@ -78,6 +78,9 @@ export function groups<T extends VListItem = VListItem>(
   let interactive: boolean | null = null;
   let gridColumns = 0;
   let gridGap = 0;
+  let gridCrossPadStart = 0;
+  let gridCrossPadTotal = 0;
+  let mainAxisPadding = 0;
 
   const rendered = new Map<number, HTMLElement>();
   // Track which layout indices currently show placeholder content
@@ -114,7 +117,7 @@ export function groups<T extends VListItem = VListItem>(
     origSizeCacheRebuild(layout.totalEntries);
     rebuildGridPositions();
     const totalSize = gridItemPositions ? getGridContentSize() : sizeCache.getTotalSize();
-    contentElement.style[isX ? "width" : "height"] = totalSize + "px";
+    contentElement.style[isX ? "width" : "height"] = (totalSize + mainAxisPadding) + "px";
     if (stickyHeader) {
       stickyHeader.refresh();
       stickyHeader.update(engineState.scrollPosition);
@@ -135,14 +138,20 @@ export function groups<T extends VListItem = VListItem>(
 
   let gridColWidth = 0;
   let gridItemPositions: Map<number, { col: number; rowY: number }> | null = null;
+  // Parallel sorted array for O(log n) visible range lookup.
+  // Each entry: [layoutIndex, rowY, rowY + itemHeight].
+  let gridSorted: Array<[number, number, number]> | null = null;
 
   function rebuildGridPositions(): void {
-    if (gridColumns <= 0) { gridItemPositions = null; return; }
-    const containerW = engineState.crossSize || contentElement.clientWidth;
+    if (gridColumns <= 0) { gridItemPositions = null; gridSorted = null; return; }
+    const rawCross = engineState.crossSize || contentElement.clientWidth;
+    const containerW = rawCross - gridCrossPadTotal;
     gridColWidth = (containerW - (gridColumns - 1) * gridGap) / gridColumns;
     gridItemPositions = new Map();
 
     const total = layout.totalEntries;
+    const sorted: Array<[number, number, number]> = new Array(total);
+    let sortedLen = 0;
     let groupY = 0;
     let itemInGroup = 0;
     let rowH = 0;
@@ -151,7 +160,10 @@ export function groups<T extends VListItem = VListItem>(
       const entry = layout.getEntry(i);
       if (entry.type === "header") {
         if (itemInGroup > 0 && rowH > 0) groupY += rowH;
-        groupY += sizeCache.getSize(i);
+        const h = sizeCache.getSize(i);
+        gridItemPositions.set(i, { col: -1, rowY: groupY });
+        sorted[sortedLen++] = [i, groupY, groupY + h];
+        groupY += h;
         itemInGroup = 0;
         rowH = 0;
       } else {
@@ -164,9 +176,12 @@ export function groups<T extends VListItem = VListItem>(
           if (h > rowH) rowH = h;
         }
         gridItemPositions.set(i, { col, rowY: groupY });
+        sorted[sortedLen++] = [i, groupY, groupY + h];
         itemInGroup++;
       }
     }
+    sorted.length = sortedLen;
+    gridSorted = sorted;
   }
 
   function getGridContentSize(): number {
@@ -186,7 +201,7 @@ export function groups<T extends VListItem = VListItem>(
     if (gridItemPositions) {
       const pos = gridItemPositions.get(layoutIndex);
       if (pos) {
-        const x = pos.col * (gridColWidth + gridGap);
+        const x = pos.col < 0 ? 0 : gridCrossPadStart + pos.col * (gridColWidth + gridGap);
         const y = pos.rowY;
         if (isX) return `translate(${Math.round(y)}px, ${Math.round(x)}px)`;
         return `translate(${Math.round(x)}px, ${Math.round(y)}px)`;
@@ -202,13 +217,25 @@ export function groups<T extends VListItem = VListItem>(
 
   function applySizeStyles(element: HTMLElement, layoutIndex: number): void {
     const size = sizeCache.getSize(layoutIndex);
-    if (gridItemPositions?.has(layoutIndex)) {
-      if (isX) {
-        element.style.width = `${size}px`;
-        element.style.height = `${gridColWidth}px`;
+    const pos = gridItemPositions?.get(layoutIndex);
+    if (pos) {
+      if (pos.col < 0) {
+        // Header: spans full width
+        if (isX) {
+          element.style.width = `${size}px`;
+          element.style.height = "";
+        } else {
+          element.style.height = `${size}px`;
+          element.style.width = "100%";
+        }
       } else {
-        element.style.height = `${size}px`;
-        element.style.width = `${gridColWidth}px`;
+        if (isX) {
+          element.style.width = `${size}px`;
+          element.style.height = `${gridColWidth}px`;
+        } else {
+          element.style.height = `${size}px`;
+          element.style.width = `${gridColWidth}px`;
+        }
       }
       return;
     }
@@ -348,14 +375,48 @@ export function groups<T extends VListItem = VListItem>(
       return;
     }
 
-    let visStart = sizeCache.indexAtOffset(scrollPos);
-    let visEnd = sizeCache.indexAtOffset(scrollPos + cs);
-    if (visEnd < totalItems - 1) visEnd++;
-    visStart = Math.max(0, visStart);
-    visEnd = Math.min(totalItems - 1, Math.max(0, visEnd));
+    let renderStart: number;
+    let renderEnd: number;
 
-    const renderStart = Math.max(0, visStart - overscan);
-    const renderEnd = Math.min(totalItems - 1, visEnd + overscan);
+    if (gridSorted) {
+      // Grid mode: binary search the sorted position array for the
+      // first entry whose bottom edge > scrollPos and the last entry
+      // whose top edge < scrollPos + containerSize.
+      const gs = gridSorted;
+      const len = gs.length;
+      let lo = 0, hi = len - 1;
+      while (lo < hi) {
+        const mid = (lo + hi) >>> 1;
+        if (gs[mid]![2] <= scrollPos) lo = mid + 1;
+        else hi = mid;
+      }
+      const firstSorted = lo;
+      hi = len - 1;
+      while (lo < hi) {
+        const mid = (lo + hi + 1) >>> 1;
+        if (gs[mid]![1] >= scrollPos + cs) hi = mid - 1;
+        else lo = mid;
+      }
+      const lastSorted = lo;
+
+      let first = gs[firstSorted]![0];
+      let last = gs[lastSorted]![0];
+      // Include the group header preceding the first visible item
+      for (let i = first - 1; i >= 0; i--) {
+        if (layout.getEntry(i).type === "header") { first = i; break; }
+      }
+      const gridOverscan = overscan * gridColumns;
+      renderStart = Math.max(0, first - gridOverscan);
+      renderEnd = Math.min(totalItems - 1, last + gridOverscan);
+    } else {
+      let visStart = sizeCache.indexAtOffset(scrollPos);
+      let visEnd = sizeCache.indexAtOffset(scrollPos + cs);
+      if (visEnd < totalItems - 1) visEnd++;
+      visStart = Math.max(0, visStart);
+      visEnd = Math.min(totalItems - 1, Math.max(0, visEnd));
+      renderStart = Math.max(0, visStart - overscan);
+      renderEnd = Math.min(totalItems - 1, visEnd + overscan);
+    }
 
     if (renderStart === engineState.prevRangeStart && renderEnd === engineState.prevRangeEnd && !engineState.renderPending) {
       return;
@@ -448,7 +509,7 @@ export function groups<T extends VListItem = VListItem>(
     drainDetached();
 
     const totalSize = gridItemPositions ? getGridContentSize() : sizeCache.getTotalSize();
-    contentElement.style[isX ? "width" : "height"] = totalSize + "px";
+    contentElement.style[isX ? "width" : "height"] = (totalSize + mainAxisPadding) + "px";
 
     engineState.prevRangeStart = renderStart;
     engineState.prevRangeEnd = renderEnd;
@@ -563,6 +624,7 @@ export function groups<T extends VListItem = VListItem>(
       isX = ctx.config.axis.primary === "x";
       classPrefix = ctx.config.classPrefix;
       overscan = ctx.config.overscan;
+      mainAxisPadding = ctx.config.mainAxisPadding;
       ctxGetItem = ctx.getItem.bind(ctx);
       resolveItemState = () => ctx.getItemStateFn();
       getMethod = ctx.getMethod.bind(ctx);
@@ -580,6 +642,8 @@ export function groups<T extends VListItem = VListItem>(
         const gl = gridLayoutFn();
         gridColumns = gl.columns;
         gridGap = gl.gap;
+        gridCrossPadStart = ctx.config.crossPadStart;
+        gridCrossPadTotal = ctx.config.crossAxisPadding;
       }
 
       queueMicrotask(() => {
@@ -672,6 +736,13 @@ export function groups<T extends VListItem = VListItem>(
           headerH,
         );
 
+        const gridHeaderOffset = gridColumns > 0
+          ? (headerLayoutIndex: number): number => {
+              const pos = gridItemPositions?.get(headerLayoutIndex);
+              return pos ? pos.rowY : sizeCache.getOffset(headerLayoutIndex);
+            }
+          : undefined;
+
         stickyHeader = createStickyHeader(
           rootElement,
           layout,
@@ -682,6 +753,7 @@ export function groups<T extends VListItem = VListItem>(
           0,
           undefined,
           stickyContainer,
+          gridHeaderOffset,
         );
 
         stickyHeader.update(engineState.scrollPosition);

--- a/src/plugins/groups/plugin.ts
+++ b/src/plugins/groups/plugin.ts
@@ -797,7 +797,10 @@ export function groups<T extends VListItem = VListItem>(
         // Deferred: data plugin (priority 20) runs after groups (priority 10)
         // and overwrites getItemFn. Set ours in a microtask after all setups.
         queueMicrotask(() => {
-          const loadedItemFn = (getMethod?.("_getLoadedItem") as ((i: number) => T | undefined)) ?? null;
+          // Use _getItem (includes placeholders) rather than _getLoadedItem
+          // (returns undefined for unloaded items). Placeholders let the
+          // table renderer show shimmer rows while data loads.
+          const asyncGetItem = (getMethod?.("_getItem") as ((i: number) => T | undefined)) ?? null;
           const rawItems = ctx.getItems.bind(ctx);
 
           ctx.setGetItemFn((layoutIndex: number): T | undefined => {
@@ -810,7 +813,7 @@ export function groups<T extends VListItem = VListItem>(
                 groupIndex: entry.group.groupIndex,
               } as unknown as T;
             }
-            return loadedItemFn ? loadedItemFn(entry.dataIndex) : rawItems()[entry.dataIndex];
+            return asyncGetItem ? asyncGetItem(entry.dataIndex) : rawItems()[entry.dataIndex];
           });
 
           // Tell table renderer about group headers

--- a/src/plugins/groups/plugin.ts
+++ b/src/plugins/groups/plugin.ts
@@ -615,11 +615,33 @@ export function groups<T extends VListItem = VListItem>(
 
       ctx.setSizeConfig(groupedSizeFn);
 
-      // Intercept sizeCache.rebuild: external callers (async plugin) pass
-      // data count, but groups needs layout count. Always use layout.totalEntries
-      // to keep prefix sums consistent with the grouped layout.
+      // Intercept sizeCache.rebuild so groups can map between data indices
+      // and layout indices (which include group header pseudo-entries).
+      // Called by: data plugin on total change, data plugin on items loaded,
+      // snapshots plugin on scroll restore, scale plugin on compression change.
+      let tableMode = false;
+      let lastTableLoadedCount = -1;
       origSizeCacheRebuild = sizeCache.rebuild;
-      sizeCache.rebuild = (_n: number): void => {
+      sizeCache.rebuild = (n: number): void => {
+        if (tableMode) {
+          if (!getLoadedCount) {
+            getLoadedCount = (getMethod?.("_getLoadedCount") as (() => number) | undefined) ?? null;
+          }
+          const loaded = getLoadedCount?.() ?? 0;
+          if (n !== lastDataCount || loaded !== lastTableLoadedCount) {
+            lastDataCount = n;
+            lastTableLoadedCount = loaded;
+            if (!getLoadedItem) {
+              getLoadedItem = (getMethod?.("_getLoadedItem") as ((index: number) => T | undefined) | undefined) ?? null;
+            }
+            layout.rebuild(n, getLoadedItem ?? ((i: number) => ctx.getItems()[i] as T | undefined));
+            engineState.totalItems = layout.totalEntries;
+            if (stickyHeader) {
+              stickyHeader.refresh();
+              stickyHeader.update(engineState.scrollPosition);
+            }
+          }
+        }
         origSizeCacheRebuild(layout.totalEntries);
       };
 
@@ -671,22 +693,46 @@ export function groups<T extends VListItem = VListItem>(
         }
       }
 
-      ctx.setRenderFn(groupsRenderIfNeeded, groupsForceRender);
+      // Detect table plugin — if active, delegate rendering to table.
+      // Groups provides layout index → item mapping via setGetItemFn.
+      const hasTable = !!getMethod?.("_updateTableForGroups");
+      tableMode = hasTable;
 
-      // If table plugin is active, tell its renderer about group headers.
-      // Table's setRenderFn (called in table's setup) overrides ours above.
-      queueMicrotask(() => {
-        const tableGroupsFn = getMethod?.("_updateTableForGroups") as ((
-          isHeaderFn: (item: T) => boolean,
-          ht: (key: string, groupIndex: number) => HTMLElement | string,
-        ) => void) | undefined;
-        if (tableGroupsFn) {
-          tableGroupsFn(
-            (item: T) => !!(item as Record<string, unknown>).__groupHeader,
-            headerTemplate,
-          );
-        }
-      });
+      if (hasTable) {
+        // Deferred: data plugin (priority 20) runs after groups (priority 10)
+        // and overwrites getItemFn. Set ours in a microtask after all setups.
+        queueMicrotask(() => {
+          const loadedItemFn = (getMethod?.("_getLoadedItem") as ((i: number) => T | undefined)) ?? null;
+          const rawItems = ctx.getItems.bind(ctx);
+
+          ctx.setGetItemFn((layoutIndex: number): T | undefined => {
+            const entry = layout.getEntry(layoutIndex);
+            if (entry.type === "header") {
+              return {
+                id: `__group_header_${entry.group.groupIndex}`,
+                __groupHeader: true,
+                groupKey: entry.group.key,
+                groupIndex: entry.group.groupIndex,
+              } as unknown as T;
+            }
+            return loadedItemFn ? loadedItemFn(entry.dataIndex) : rawItems()[entry.dataIndex];
+          });
+
+          // Tell table renderer about group headers
+          const tableGroupsFn = getMethod?.("_updateTableForGroups") as ((
+            isHeaderFn: (item: T) => boolean,
+            ht: (key: string, groupIndex: number) => HTMLElement | string,
+          ) => void) | undefined;
+          if (tableGroupsFn) {
+            tableGroupsFn(
+              (item: T) => !!(item as Record<string, unknown>).__groupHeader,
+              headerTemplate,
+            );
+          }
+        });
+      } else {
+        ctx.setRenderFn(groupsRenderIfNeeded, groupsForceRender);
+      }
 
       ctx.registerMethod("getGroupLayout", () => layout);
 

--- a/src/plugins/groups/sticky.ts
+++ b/src/plugins/groups/sticky.ts
@@ -55,6 +55,7 @@ export const createStickyHeader = (
   stickyOffset: number = 0,
   getCompressionRatio?: () => number,
   existingContainer?: HTMLElement,
+  getHeaderOffset?: (headerLayoutIndex: number) => number,
 ): StickyHeader => {
   // Orientation helpers — resolved once
   const mainProp = horizontal ? "width" : "height";
@@ -102,7 +103,7 @@ export const createStickyHeader = (
     vSizes = new Array(groupCount);
     const ratio = getCompressionRatio ? getCompressionRatio() : 1;
     for (let i = 0; i < groupCount; i++) {
-      offsets[i] = sizeCache.getOffset(groups[i]!.headerLayoutIndex) * ratio;
+      offsets[i] = (getHeaderOffset ? getHeaderOffset(groups[i]!.headerLayoutIndex) : sizeCache.getOffset(groups[i]!.headerLayoutIndex)) * ratio;
       sizes[i] = layout.getHeaderHeight(i);
       vSizes[i] = sizes[i]! * ratio;
     }

--- a/src/plugins/selection/plugin.ts
+++ b/src/plugins/selection/plugin.ts
@@ -43,7 +43,7 @@ export function selection<T extends VListItem = VListItem>(
   const focusOnClick = config?.focusOnClick ?? false;
 
   let state: SelectionState;
-  let getItem: (index: number) => T | undefined;
+  let getItems: () => readonly T[];
   let forceRender: () => void;
   let emitter: PluginContext<T>["emitter"];
   let dom: PluginContext<T>["dom"];
@@ -68,6 +68,7 @@ export function selection<T extends VListItem = VListItem>(
     d2lFn = (ctx.getMethod("_dataToLayoutIndex") as typeof d2lFn) ?? null;
     isGHFn = (ctx.getMethod("_isGroupHeader") as typeof isGHFn) ?? null;
     sivFn = (ctx.getMethod("_scrollItemIntoView") as typeof sivFn) ?? null;
+    loadedItemFn = (ctx.getMethod("_getLoadedItem") as typeof loadedItemFn) ?? null;
     const gl = ctx.getMethod("getGroupLayout") as (() => { totalEntries: number }) | undefined;
     if (gl) {
       const layout = gl();
@@ -78,8 +79,15 @@ export function selection<T extends VListItem = VListItem>(
   const toDataIndex = (layoutIdx: number): number =>
     l2dFn ? l2dFn(layoutIdx) : layoutIdx;
 
-  const getItemAtLayout = (layoutIdx: number): T | undefined => {
-    return getItem(layoutIdx);
+  let loadedItemFn: ((i: number) => T | undefined) | null = null;
+  const getItemByDataIndex = (dataIndex: number): T | undefined => {
+    if (loadedItemFn) return loadedItemFn(dataIndex);
+    return getItems()[dataIndex];
+  };
+
+  const getDataItemAtLayout = (layoutIdx: number): T | undefined => {
+    const di = toDataIndex(layoutIdx);
+    return di >= 0 ? getItemByDataIndex(di) : undefined;
   };
 
   const skipHeaders = (from: number, dir: 1 | -1, total: number): number => {
@@ -132,7 +140,7 @@ export function selection<T extends VListItem = VListItem>(
     const end = Math.max(fromLayout, toLayout);
     for (let i = start; i <= end; i++) {
       if (isGHFn?.(i)) continue;
-      const item = getItem(i);
+      const item = getDataItemAtLayout(i);
       if (item) {
         state.selected.add(item.id);
         selectedItemCache.set(item.id, item);
@@ -143,7 +151,8 @@ export function selection<T extends VListItem = VListItem>(
   function doSelectAll(): void {
     const total = engineState.totalItems;
     for (let i = 0; i < total; i++) {
-      const item = getItem(i);
+      if (isGHFn?.(i)) continue;
+      const item = getDataItemAtLayout(i);
       if (item) {
         state.selected.add(item.id);
         selectedItemCache.set(item.id, item);
@@ -167,7 +176,8 @@ export function selection<T extends VListItem = VListItem>(
     const remaining = new Set(state.selected);
     const total = engineState.totalItems;
     for (let i = 0; i < total && remaining.size > 0; i++) {
-      const item = getItem(i);
+      if (isGHFn?.(i)) continue;
+      const item = getDataItemAtLayout(i);
       if (item && remaining.has(item.id)) {
         result.push(item);
         selectedItemCache.set(item.id, item);
@@ -195,7 +205,7 @@ export function selection<T extends VListItem = VListItem>(
     setup(ctx: PluginContext<T>): void {
       ctx.enableListboxRole();
       state = createSelectionState(config?.initial);
-      getItem = ctx.getItem.bind(ctx);
+      getItems = ctx.getItems.bind(ctx);
       forceRender = ctx.forceRender.bind(ctx);
       emitter = ctx.emitter;
       dom = ctx.dom;
@@ -227,7 +237,7 @@ export function selection<T extends VListItem = VListItem>(
         resolveOnce(ctx);
         if (state.selected.size > 0) {
           const di = toDataIndex(index);
-          const item = di >= 0 ? getItemAtLayout(index) : undefined;
+          const item = di >= 0 ? getDataItemAtLayout(index) : undefined;
           const id = item?.id;
           if (id !== undefined) {
             if (state.selected.has(id)) {
@@ -265,7 +275,7 @@ export function selection<T extends VListItem = VListItem>(
         if (isGHFn?.(layoutIdx)) return false;
         const di = toDataIndex(layoutIdx);
         if (di < 0) return false;
-        const item = getItemAtLayout(layoutIdx);
+        const item = getDataItemAtLayout(layoutIdx);
         if (!item) return false;
         hitItem = item;
         hitIndex = layoutIdx;
@@ -466,7 +476,7 @@ export function selection<T extends VListItem = VListItem>(
                 break;
               }
               if (state.focusedIndex >= 0) {
-                const item = getItemAtLayout(state.focusedIndex);
+                const item = getDataItemAtLayout(state.focusedIndex);
                 if (item) {
                   doToggle(item.id, item);
                   lastSelectedIndex = state.focusedIndex;
@@ -514,7 +524,7 @@ export function selection<T extends VListItem = VListItem>(
           if (event.shiftKey && mode === "multiple" && !selectionChanged && focusMoved) {
             const isArrow = event.key === "ArrowUp" || event.key === "ArrowDown" || event.key === "ArrowLeft" || event.key === "ArrowRight";
             if (isArrow) {
-              const destItem = getItemAtLayout(state.focusedIndex);
+              const destItem = getDataItemAtLayout(state.focusedIndex);
               if (destItem) doToggle(destItem.id, destItem);
               lastSelectedIndex = state.focusedIndex;
               selectionChanged = true;
@@ -536,7 +546,7 @@ export function selection<T extends VListItem = VListItem>(
 
           // Follow focus: auto-select on movement
           if (followFocus && mode === "single" && !selectionChanged && focusMoved && state.focusedIndex >= 0) {
-            const item = getItemAtLayout(state.focusedIndex);
+            const item = getDataItemAtLayout(state.focusedIndex);
             if (item) doSelect(item.id, item);
             selectionChanged = true;
           }
@@ -554,7 +564,7 @@ export function selection<T extends VListItem = VListItem>(
             } else if (focusMoved) {
               forceRender();
               if (state.focusedIndex >= 0) {
-                const item = getItemAtLayout(state.focusedIndex);
+                const item = getDataItemAtLayout(state.focusedIndex);
                 if (item) {
                   emitter.emit("focus:change", { id: item.id, index: state.focusedIndex });
                 }
@@ -605,7 +615,7 @@ export function selection<T extends VListItem = VListItem>(
         if (total === 0) return;
         moveFocus(state, 1, total, resolvedConfig.reverse);
         if (isGHFn) state.focusedIndex = skipHeaders(state.focusedIndex, 1, total);
-        const item = getItemAtLayout(state.focusedIndex);
+        const item = getDataItemAtLayout(state.focusedIndex);
         if (item) doSelect(item.id, item);
         emitSelectionChange();
       });
@@ -616,7 +626,7 @@ export function selection<T extends VListItem = VListItem>(
         if (total === 0) return;
         moveFocus(state, -1, total, resolvedConfig.reverse);
         if (isGHFn) state.focusedIndex = skipHeaders(state.focusedIndex, -1, total);
-        const item = getItemAtLayout(state.focusedIndex);
+        const item = getDataItemAtLayout(state.focusedIndex);
         if (item) doSelect(item.id, item);
         emitSelectionChange();
       });
@@ -631,13 +641,14 @@ export function selection<T extends VListItem = VListItem>(
 
       ctx.registerMethod("_getFocusedId", (): string | number | undefined => {
         if (state.focusedIndex < 0) return undefined;
-        return getItemAtLayout(state.focusedIndex)?.id;
+        return getDataItemAtLayout(state.focusedIndex)?.id;
       });
 
       ctx.registerMethod("_focusById", (id: string | number): void => {
         const total = engineState.totalItems;
         for (let i = 0; i < total; i++) {
-          const item = getItem(i);
+          if (isGHFn?.(i)) continue;
+          const item = getDataItemAtLayout(i);
           if (item && item.id === id) {
             state.focusedIndex = i;
             emitter.emit("focus:change", { id, index: i });

--- a/src/plugins/selection/plugin.ts
+++ b/src/plugins/selection/plugin.ts
@@ -345,7 +345,8 @@ export function selection<T extends VListItem = VListItem>(
         state.focusedIndex = hitIndex;
         state.focusVisible = focusOnClick;
         lastSelectedIndex = hitIndex;
-        dom.content.focus(focusPreventScroll);
+        const focusTarget = dom.content.getAttribute("tabindex") !== null ? dom.content : dom.root;
+        focusTarget.focus(focusPreventScroll);
         doToggle(hitItem!.id, hitItem!);
         emitSelectionChange();
       });

--- a/src/plugins/selection/plugin.ts
+++ b/src/plugins/selection/plugin.ts
@@ -79,8 +79,7 @@ export function selection<T extends VListItem = VListItem>(
     l2dFn ? l2dFn(layoutIdx) : layoutIdx;
 
   const getItemAtLayout = (layoutIdx: number): T | undefined => {
-    const di = toDataIndex(layoutIdx);
-    return di >= 0 ? getItem(di) : undefined;
+    return getItem(layoutIdx);
   };
 
   const skipHeaders = (from: number, dir: 1 | -1, total: number): number => {
@@ -128,10 +127,11 @@ export function selection<T extends VListItem = VListItem>(
     selectedItemCache.delete(id);
   }
 
-  function doSelectRange(from: number, to: number): void {
-    const start = Math.min(from, to);
-    const end = Math.max(from, to);
+  function doSelectRange(fromLayout: number, toLayout: number): void {
+    const start = Math.min(fromLayout, toLayout);
+    const end = Math.max(fromLayout, toLayout);
     for (let i = start; i <= end; i++) {
+      if (isGHFn?.(i)) continue;
       const item = getItem(i);
       if (item) {
         state.selected.add(item.id);
@@ -227,7 +227,7 @@ export function selection<T extends VListItem = VListItem>(
         resolveOnce(ctx);
         if (state.selected.size > 0) {
           const di = toDataIndex(index);
-          const item = di >= 0 ? getItem(di) : undefined;
+          const item = di >= 0 ? getItemAtLayout(index) : undefined;
           const id = item?.id;
           if (id !== undefined) {
             if (state.selected.has(id)) {
@@ -262,9 +262,10 @@ export function selection<T extends VListItem = VListItem>(
         if (!el) return false;
         const layoutIdx = parseInt(el.dataset.index ?? "-1", 10);
         if (layoutIdx < 0) return false;
+        if (isGHFn?.(layoutIdx)) return false;
         const di = toDataIndex(layoutIdx);
         if (di < 0) return false;
-        const item = getItem(di);
+        const item = getItemAtLayout(layoutIdx);
         if (!item) return false;
         hitItem = item;
         hitIndex = layoutIdx;
@@ -332,7 +333,7 @@ export function selection<T extends VListItem = VListItem>(
           const anchorData = toDataIndex(anchor);
           const hitData = toDataIndex(hitIndex);
           if (anchorData >= 0 && hitData >= 0) {
-            doSelectRange(anchorData, hitData);
+            doSelectRange(anchor, hitIndex);
           }
           state.focusedIndex = hitIndex;
           state.focusVisible = focusOnClick;
@@ -455,7 +456,7 @@ export function selection<T extends VListItem = VListItem>(
                   const fromData = toDataIndex(lastSelectedIndex);
                   const toData = toDataIndex(state.focusedIndex);
                   if (fromData >= 0 && toData >= 0) {
-                    doSelectRange(fromData, toData);
+                    doSelectRange(lastSelectedIndex, state.focusedIndex);
                   }
                 }
                 state.focusVisible = true;
@@ -521,10 +522,11 @@ export function selection<T extends VListItem = VListItem>(
             const isCtrlHomeEnd = (event.ctrlKey || event.metaKey)
               && (event.key === "Home" || event.key === "End");
             if (isCtrlHomeEnd) {
-              const fromData = toDataIndex(prevFocus >= 0 ? prevFocus : state.focusedIndex);
+              const fromLayout = prevFocus >= 0 ? prevFocus : state.focusedIndex;
+              const fromData = toDataIndex(fromLayout);
               const toData = toDataIndex(state.focusedIndex);
               if (fromData >= 0 && toData >= 0) {
-                doSelectRange(fromData, toData);
+                doSelectRange(fromLayout, state.focusedIndex);
               }
               lastSelectedIndex = state.focusedIndex;
               selectionChanged = true;
@@ -636,9 +638,8 @@ export function selection<T extends VListItem = VListItem>(
         for (let i = 0; i < total; i++) {
           const item = getItem(i);
           if (item && item.id === id) {
-            const layoutIdx = d2lFn ? d2lFn(i) : i;
-            state.focusedIndex = layoutIdx;
-            emitter.emit("focus:change", { id, index: layoutIdx });
+            state.focusedIndex = i;
+            emitter.emit("focus:change", { id, index: i });
             return;
           }
         }

--- a/src/plugins/snapshots/plugin.ts
+++ b/src/plugins/snapshots/plugin.ts
@@ -203,18 +203,24 @@ export function snapshots<T extends VListItem = VListItem>(
           ? snapshot.offsetRatio * currentItemSize
           : Math.min(offsetInItem, currentItemSize);
 
+        const currentDataTotal = (ctx.getMethod("_getTotal") as (() => number) | undefined)?.();
+        const totalMatch = snapshot.total === effectiveTotal
+          || (currentDataTotal !== undefined && snapshot.dataTotal === currentDataTotal);
+
         let scrollPosition: number;
 
         if (state.isCompressed && state.compressionRatio !== 1) {
-          const currentDataTotal = (ctx.getMethod("_getTotal") as (() => number) | undefined)?.();
-          const dataTotalMatch = currentDataTotal !== undefined
-            && snapshot.dataTotal === currentDataTotal;
-          if (snapshot.scrollTop !== undefined && (snapshot.total === effectiveTotal || dataTotalMatch)) {
+          if (snapshot.scrollTop !== undefined && totalMatch) {
             scrollPosition = snapshot.scrollTop;
           } else {
             const fraction = currentItemSize ? resolvedOffset / currentItemSize : 0;
             scrollPosition =
               ((safeIndex + fraction) / effectiveTotal) * state.totalSize;
+          }
+        } else if (snapshot.scrollTop !== undefined && totalMatch) {
+          scrollPosition = snapshot.scrollTop;
+          } else {
+            scrollPosition = sizeCache.getOffset(safeIndex) + resolvedOffset;
           }
         } else {
           scrollPosition = sizeCache.getOffset(safeIndex) + resolvedOffset;
@@ -222,17 +228,6 @@ export function snapshots<T extends VListItem = VListItem>(
 
         const maxScroll = Math.max(0, state.totalSize - state.containerSize);
         scrollPosition = Math.max(0, Math.min(scrollPosition, maxScroll));
-
-        const usedShortcut = scrollPosition === snapshot.scrollTop;
-        if (snapshot.dataIndex !== undefined && snapshot.dataIndex >= 0) {
-          const fraction = currentItemSize ? resolvedOffset / currentItemSize : 0;
-          ctx.registerMethod("_restoreAnchor", {
-            dataIndex: snapshot.dataIndex,
-            fraction,
-            skipAdjust: usedShortcut,
-          } as unknown as Function);
-          ctx.registerMethod("_suppressSave", 1 as unknown as Function);
-        }
 
         ctx.scrollTo(scrollPosition);
 
@@ -290,7 +285,7 @@ export function snapshots<T extends VListItem = VListItem>(
 
       if (autoSaveKey) {
         saveToStorage = (): void => {
-          if (disposed || restoreGuard || ctx.getMethod("_suppressSave")) return;
+          if (disposed || restoreGuard) return;
           const snap = getScrollSnapshot();
           try {
             sessionStorage.setItem(autoSaveKey, JSON.stringify(snap));

--- a/src/plugins/snapshots/plugin.ts
+++ b/src/plugins/snapshots/plugin.ts
@@ -219,9 +219,6 @@ export function snapshots<T extends VListItem = VListItem>(
           }
         } else if (snapshot.scrollTop !== undefined && totalMatch) {
           scrollPosition = snapshot.scrollTop;
-          } else {
-            scrollPosition = sizeCache.getOffset(safeIndex) + resolvedOffset;
-          }
         } else {
           scrollPosition = sizeCache.getOffset(safeIndex) + resolvedOffset;
         }

--- a/src/plugins/sortable/plugin.ts
+++ b/src/plugins/sortable/plugin.ts
@@ -729,7 +729,7 @@ export function sortable<T extends VListItem = VListItem>(
   return {
     name: "sortable",
     priority: 30,
-    conflicts: ["grid", "masonry", "table", "scale"],
+    conflicts: ["grid", "masonry", "table", "scale", "tree"],
 
     setup(ctx: PluginContext<T>): void {
       storedCtx = ctx;

--- a/src/plugins/table/renderer.ts
+++ b/src/plugins/table/renderer.ts
@@ -241,7 +241,7 @@ export const createTableRenderer = <T extends VListItem = VListItem>(
   const oddClass = `${classPrefix}-item--odd`;
   const placeholderClass = `${classPrefix}-item--placeholder`;
   const replacedClass = `${classPrefix}-item--replaced`;
-  const groupHeaderRowClass = `${classPrefix}-item ${classPrefix}-table-row ${classPrefix}-table-group-header`;
+  const groupHeaderRowClass = `${classPrefix}-table-row ${classPrefix}-table-group-header`;
   const groupHeaderContentClass = `${classPrefix}-table-group-header-content`;
 
   // =========================================================================

--- a/src/styles/vlist-table.css
+++ b/src/styles/vlist-table.css
@@ -333,16 +333,12 @@
 
 /* Group header content container */
 .vlist-table-group-header-content {
-    flex: 1;
-    min-width: 0;
-    /*padding-left: var(--vlist-item-padding-x);
-    padding-right: var(--vlist-item-padding-x);*/
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
-    color: var(--vlist-text-muted, #6b7280);
-    border-bottom: 1px solid var(--vlist-border);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 0 16px;
+    height: 100%;
+    background: var(--vlist-group-header-bg, #f3f4f6);
 }
 
 /* Row borders — group headers already have a top border */
@@ -357,6 +353,16 @@
     order: 1;
     z-index: 4;
     border-bottom: none;
+}
+
+.vlist--table.vlist--grouped .vlist-sticky-header .sticky-group {
+    display: flex;
+    font-size: 0.8125rem;
+    padding: 0 16px;
+    align-items: center;
+    gap: 12px;
+    height: 100%;
+    color: var(--vlist-text-muted, #9ca3af);
 }
 
 .vlist--table.vlist--grouped .vlist-viewport {

--- a/test/core/scroll.test.ts
+++ b/test/core/scroll.test.ts
@@ -672,6 +672,98 @@ describe("ScrollHandler.smoothScrollTo() with custom easing", () => {
 });
 
 // =============================================================================
+// Idle after smooth scroll
+// =============================================================================
+
+describe("ScrollHandler — idle after smooth scroll", () => {
+  it("should fire onIdle after smooth scroll completes", (done) => {
+    const viewport = document.createElement("div");
+    const state = createEngineState(10);
+    state.scrollPosition = 0;
+    let idleFired = false;
+    const config = {
+      state,
+      viewport,
+      isX: false,
+      wheelEnabled: false,
+      idleTimeout: 50,
+      onFrame: () => {},
+      onIdle: () => { idleFired = true; },
+    };
+
+    const handler = createScrollHandler(config);
+    handler.attach();
+    handler.smoothScrollTo(500, 100);
+
+    // After 100ms animation + 50ms idle timeout = 150ms
+    setTimeout(() => {
+      expect(viewport.scrollTop).toBe(500);
+      expect(idleFired).toBe(true);
+      handler.detach();
+      done();
+    }, 250);
+  });
+
+  it("should NOT fire onIdle during smooth scroll animation", (done) => {
+    const viewport = document.createElement("div");
+    const state = createEngineState(10);
+    state.scrollPosition = 0;
+    let idleCount = 0;
+    const config = {
+      state,
+      viewport,
+      isX: false,
+      wheelEnabled: false,
+      idleTimeout: 50,
+      onFrame: () => {},
+      onIdle: () => { idleCount++; },
+    };
+
+    const handler = createScrollHandler(config);
+    handler.attach();
+    handler.smoothScrollTo(500, 200);
+
+    // At 100ms, animation is still running (200ms duration) — idle should not have fired
+    setTimeout(() => {
+      expect(idleCount).toBe(0);
+    }, 100);
+
+    // At 300ms, animation done (200ms) + idle timeout (50ms) passed — exactly 1 idle
+    setTimeout(() => {
+      expect(idleCount).toBe(1);
+      handler.detach();
+      done();
+    }, 350);
+  });
+
+  it("should fire onIdle with correct scroll position at end", (done) => {
+    const viewport = document.createElement("div");
+    const state = createEngineState(10);
+    state.scrollPosition = 0;
+    let idleScrollPos = -1;
+    const config = {
+      state,
+      viewport,
+      isX: false,
+      wheelEnabled: false,
+      idleTimeout: 30,
+      onFrame: () => {},
+      onIdle: () => { idleScrollPos = state.scrollPosition; },
+    };
+
+    const handler = createScrollHandler(config);
+    handler.attach();
+    handler.smoothScrollTo(1000, 100);
+
+    setTimeout(() => {
+      expect(idleScrollPos).toBe(1000);
+      handler.detach();
+      done();
+    }, 200);
+  });
+});
+
+// =============================================================================
 // onScroll Callback Tests
 // =============================================================================
 

--- a/test/integration/groups-grid.test.ts
+++ b/test/integration/groups-grid.test.ts
@@ -647,7 +647,7 @@ describe("groups + grid integration", () => {
           container,
           items: createTestItems(40),
           item: {
-            height: (_i: number, ctx: any) => ctx ? Math.round(ctx.columnWidth * 0.75) : 100,
+            height: ((_i: number, ctx: any) => ctx ? Math.round(ctx.columnWidth * 0.75) : 100) as any,
             template: simpleTemplate,
           },
         },
@@ -678,7 +678,7 @@ describe("groups + grid integration", () => {
           container,
           items: createTestItems(40),
           item: {
-            height: (_i: number, ctx: any) => ctx ? Math.round(ctx.columnWidth * 0.75) : 100,
+            height: ((_i: number, ctx: any) => ctx ? Math.round(ctx.columnWidth * 0.75) : 100) as any,
             template: simpleTemplate,
           },
         },
@@ -729,7 +729,7 @@ describe("groups + grid integration", () => {
     });
 
     it("should update content height after resize with dynamic height", () => {
-      const dynamicHeight = (_i: number, ctx: any) => ctx ? Math.round(ctx.columnWidth * 0.75) : 100;
+      const dynamicHeight = ((_i: number, ctx: any) => ctx ? Math.round(ctx.columnWidth * 0.75) : 100) as any;
 
       // Create at 300px
       list = createVList(

--- a/test/integration/groups-grid.test.ts
+++ b/test/integration/groups-grid.test.ts
@@ -17,6 +17,7 @@ import {
   type TestItem,
 } from "../helpers/factory";
 import { groups } from "../../src/plugins/groups/plugin";
+import { grid } from "../../src/plugins/grid/plugin";
 import { selection } from "../../src/plugins/selection/plugin";
 
 let origClientHeight: PropertyDescriptor | undefined;
@@ -232,6 +233,349 @@ describe("groups + selection integration", () => {
 
       (list as any).selectAll();
 
+      expect(() => {
+        list!.destroy();
+        list = null;
+      }).not.toThrow();
+    });
+  });
+});
+
+// =============================================================================
+// Groups + Grid integration
+// =============================================================================
+
+describe("groups + grid integration", () => {
+  const COLUMNS = 4;
+  const GAP = 8;
+  const ITEM_HEIGHT = 100;
+  const HEADER_HEIGHT = 30;
+
+  function getGroupByTen(index: number): string {
+    if (index < 10) return "Alpha";
+    if (index < 20) return "Beta";
+    if (index < 30) return "Gamma";
+    return "Delta";
+  }
+
+  function createGroupedGrid(itemCount: number = 40, opts?: { sticky?: boolean }) {
+    list = createVList(
+      {
+        container,
+        items: createTestItems(itemCount),
+        item: { height: ITEM_HEIGHT, template: simpleTemplate },
+      },
+      [
+        grid({ columns: COLUMNS, gap: GAP }),
+        groups({
+          getGroupForIndex: getGroupByTen,
+          header: { height: HEADER_HEIGHT, template: (key) => key },
+          sticky: opts?.sticky ?? false,
+        }),
+        selection({ mode: "single" }),
+      ],
+    );
+    return list;
+  }
+
+  describe("initialization", () => {
+    it("should create a grouped grid without errors", () => {
+      createGroupedGrid();
+      expect(list!.element.classList.contains("vlist--grouped")).toBe(true);
+    });
+
+    it("should render group headers and grid items", () => {
+      createGroupedGrid();
+      const headers = container.querySelectorAll(".vlist-group-header");
+      const items = container.querySelectorAll("[data-index]");
+      expect(headers.length).toBeGreaterThan(0);
+      expect(items.length).toBeGreaterThan(headers.length);
+    });
+  });
+
+  describe("header positioning", () => {
+    it("should position headers at full width (col=-1)", () => {
+      createGroupedGrid();
+      const headers = container.querySelectorAll(".vlist-group-header");
+      for (const header of headers) {
+        const el = header as HTMLElement;
+        expect(el.style.width).toBe("100%");
+      }
+    });
+
+    it("should position grid items at column width", () => {
+      createGroupedGrid();
+      const items = container.querySelectorAll("[data-index]:not(.vlist-group-header)");
+      expect(items.length).toBeGreaterThan(0);
+      const first = items[0] as HTMLElement;
+      const w = parseFloat(first.style.width);
+      expect(w).toBeGreaterThan(0);
+      expect(w).toBeLessThan(300);
+    });
+
+    it("should position headers at Y=0 for the first group", () => {
+      createGroupedGrid();
+      const header = container.querySelector(".vlist-group-header") as HTMLElement;
+      expect(header).not.toBeNull();
+      const transform = header.style.transform;
+      const yMatch = transform.match(/translate\(\d+px,\s*(\d+)px\)/);
+      expect(yMatch).not.toBeNull();
+      expect(parseInt(yMatch![1]!, 10)).toBe(0);
+    });
+
+    it("should position second group header after first group's grid rows", () => {
+      createGroupedGrid();
+      const headers = Array.from(container.querySelectorAll(".vlist-group-header"));
+      if (headers.length < 2) return;
+
+      const h1 = headers[0] as HTMLElement;
+      const h2 = headers[1] as HTMLElement;
+      const y1 = parseFloat(h1.style.transform.match(/,\s*([\d.]+)px/)![1]!);
+      const y2 = parseFloat(h2.style.transform.match(/,\s*([\d.]+)px/)![1]!);
+      // Second header must be below the first group's content
+      expect(y2).toBeGreaterThan(y1 + HEADER_HEIGHT);
+    });
+  });
+
+  describe("grid items within groups", () => {
+    it("should arrange items in columns within each group", () => {
+      createGroupedGrid();
+      const items = Array.from(
+        container.querySelectorAll("[data-index]:not(.vlist-group-header)")
+      ) as HTMLElement[];
+      if (items.length < COLUMNS) return;
+
+      const xs = items.slice(0, COLUMNS).map((el) => {
+        const match = el.style.transform.match(/translate\(([\d.]+)px/);
+        return match ? parseFloat(match[1]!) : -1;
+      });
+      // First COLUMNS items should have distinct X positions (columns)
+      const uniqueXs = new Set(xs);
+      expect(uniqueXs.size).toBe(COLUMNS);
+    });
+
+    it("should reset column counter at group boundary", () => {
+      createGroupedGrid();
+      // Find items from the second group (data indices 10-19)
+      const allItems = Array.from(
+        container.querySelectorAll("[data-index]:not(.vlist-group-header)")
+      ) as HTMLElement[];
+
+      // Items in the second group should start at column 0
+      // The first item after a header should have X = 0
+      const headers = Array.from(container.querySelectorAll(".vlist-group-header"));
+      if (headers.length < 2) return;
+      const secondHeaderIdx = parseInt(
+        (headers[1] as HTMLElement).getAttribute("data-index")!,
+        10,
+      );
+      const firstAfterHeader = container.querySelector(
+        `[data-index="${secondHeaderIdx + 1}"]`,
+      ) as HTMLElement;
+      if (!firstAfterHeader) return;
+      const x = parseFloat(
+        firstAfterHeader.style.transform.match(/translate\(([\d.]+)px/)![1]!,
+      );
+      expect(x).toBe(0);
+    });
+  });
+
+  describe("visible range (binary search)", () => {
+    it("should render items beyond the first group", () => {
+      // 40 items, 4 columns = 10 rows per group.
+      // With 100px height per row + headers, the first group is ~1030px.
+      // Viewport is 500px, so we should see items from group Alpha and possibly Beta.
+      createGroupedGrid();
+      const allItems = Array.from(
+        container.querySelectorAll("[data-index]"),
+      ) as HTMLElement[];
+      // With overscan, should render well into the first group
+      expect(allItems.length).toBeGreaterThan(COLUMNS + 1);
+    });
+
+    it("should render items from multiple groups", () => {
+      // Use smaller items so multiple groups fit in the viewport
+      list = createVList(
+        {
+          container,
+          items: createTestItems(40),
+          item: { height: 30, template: simpleTemplate },
+        },
+        [
+          grid({ columns: COLUMNS, gap: 4 }),
+          groups({
+            getGroupForIndex: getGroupByTen,
+            header: { height: 20, template: (key) => key },
+          }),
+        ],
+      );
+
+      const headers = container.querySelectorAll(".vlist-group-header");
+      // With 30px rows, 4 cols, 10 items per group = 3 rows × 30px = 90px per group + 20px header
+      // 500px viewport should show at least 4 groups
+      expect(headers.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("sticky header with grid", () => {
+    it("should create a sticky header container", () => {
+      createGroupedGrid(40, { sticky: true });
+      const sticky = container.querySelector(".vlist-sticky-header");
+      expect(sticky).not.toBeNull();
+    });
+
+    it("should populate sticky header with first group name", () => {
+      createGroupedGrid(40, { sticky: true });
+      const sticky = container.querySelector(".vlist-sticky-header");
+      expect(sticky).not.toBeNull();
+      expect(sticky!.textContent?.trim()).toContain("Alpha");
+    });
+  });
+
+  describe("selection with grouped grid", () => {
+    it("should select clicked item", () => {
+      createGroupedGrid();
+      // Click the first data item (layout index 1, after header at 0)
+      const item = container.querySelector("[data-index='1']") as HTMLElement;
+      if (!item) return;
+      item.click();
+      const selected: number[] = (list as any).getSelected();
+      expect(selected.length).toBe(1);
+    });
+
+    it("should not select group headers on click", () => {
+      createGroupedGrid();
+      const header = container.querySelector(".vlist-group-header") as HTMLElement;
+      if (!header) return;
+      header.click();
+      const selected: number[] = (list as any).getSelected();
+      expect(selected.length).toBe(0);
+    });
+  });
+
+  describe("content size", () => {
+    it("should calculate content size based on grid rows, not item count", () => {
+      createGroupedGrid();
+      const content = container.querySelector(".vlist-content") as HTMLElement;
+      const height = parseFloat(content.style.height);
+      // 40 items / 4 columns = 10 rows per group × 4 groups = 40 rows
+      // But with group headers (30px each × 4) + gaps, total should be much less
+      // than 40 items × 100px = 4000px (non-grid total)
+      expect(height).toBeLessThan(4000);
+      expect(height).toBeGreaterThan(0);
+    });
+
+  });
+
+  describe("padding", () => {
+    const PADDING = 16;
+
+    function createPaddedGrid(itemCount: number = 40) {
+      list = createVList(
+        {
+          container,
+          items: createTestItems(itemCount),
+          padding: PADDING,
+          item: { height: ITEM_HEIGHT, template: simpleTemplate },
+        },
+        [
+          grid({ columns: COLUMNS, gap: GAP }),
+          groups({
+            getGroupForIndex: getGroupByTen,
+            header: { height: HEADER_HEIGHT, template: (key) => key },
+          }),
+          selection({ mode: "single" }),
+        ],
+      );
+      return list;
+    }
+
+    it("should offset grid items by crossPadStart", () => {
+      createPaddedGrid();
+      const items = Array.from(
+        container.querySelectorAll("[data-index]:not(.vlist-group-header)"),
+      ) as HTMLElement[];
+      expect(items.length).toBeGreaterThan(0);
+
+      const firstItem = items[0]!;
+      const xMatch = firstItem.style.transform.match(/translate\(([\d.]+)px/);
+      expect(xMatch).not.toBeNull();
+      const x = parseFloat(xMatch![1]!);
+      expect(x).toBe(PADDING);
+    });
+
+    it("should calculate column width accounting for padding", () => {
+      createPaddedGrid();
+      const items = Array.from(
+        container.querySelectorAll("[data-index]:not(.vlist-group-header)"),
+      ) as HTMLElement[];
+      expect(items.length).toBeGreaterThan(0);
+
+      const w = parseFloat(items[0]!.style.width);
+      // containerWidth=300, padding=16 on each side, 4 cols, gap=8
+      // available = 300 - 32 = 268, colWidth = (268 - 3*8) / 4 = 61
+      const expected = (300 - PADDING * 2 - (COLUMNS - 1) * GAP) / COLUMNS;
+      expect(Math.abs(w - expected)).toBeLessThan(1);
+    });
+
+    it("should make grid column width narrower than without padding", () => {
+      // Create without padding for comparison
+      createGroupedGrid();
+      const noPadItems = Array.from(
+        container.querySelectorAll("[data-index]:not(.vlist-group-header)"),
+      ) as HTMLElement[];
+      const noPadW = parseFloat(noPadItems[0]!.style.width);
+
+      list!.destroy();
+      container.innerHTML = "";
+
+      // Create with padding
+      createPaddedGrid();
+      const padItems = Array.from(
+        container.querySelectorAll("[data-index]:not(.vlist-group-header)"),
+      ) as HTMLElement[];
+      const padW = parseFloat(padItems[0]!.style.width);
+
+      expect(padW).toBeLessThan(noPadW);
+    });
+
+    it("should position second column item at crossPadStart + colWidth + gap", () => {
+      createPaddedGrid();
+      const items = Array.from(
+        container.querySelectorAll("[data-index]:not(.vlist-group-header)"),
+      ) as HTMLElement[];
+      if (items.length < 2) return;
+
+      const x1 = parseFloat(items[0]!.style.transform.match(/translate\(([\d.]+)px/)![1]!);
+      const x2 = parseFloat(items[1]!.style.transform.match(/translate\(([\d.]+)px/)![1]!);
+      const w = parseFloat(items[0]!.style.width);
+      // Second column should be at padStart + colWidth + gap
+      expect(Math.abs(x2 - (x1 + w + GAP))).toBeLessThan(1);
+    });
+
+    it("should position headers at x=0 (headers span full width including padding area)", () => {
+      createPaddedGrid();
+      const header = container.querySelector(".vlist-group-header") as HTMLElement;
+      if (!header) return;
+      const xMatch = header.style.transform.match(/translate\(([\d.]+)px/);
+      expect(xMatch).not.toBeNull();
+      expect(parseFloat(xMatch![1]!)).toBe(0);
+    });
+
+    it("should include mainAxisPadding in content height", () => {
+      createPaddedGrid();
+      const content = container.querySelector(".vlist-content") as HTMLElement;
+      const height = parseFloat(content.style.height);
+      // mainAxisPadding = PADDING * 2 = 32. Content height must include it.
+      // Without padding, pure grid content is ~1300-1500px.
+      // With PADDING=16, height must be at least pure content + 32.
+      expect(height).toBeGreaterThan(1300 + PADDING * 2);
+    });
+  });
+
+  describe("destroy", () => {
+    it("should clean up groups + grid + selection without errors", () => {
+      createGroupedGrid();
       expect(() => {
         list!.destroy();
         list = null;

--- a/test/integration/groups-grid.test.ts
+++ b/test/integration/groups-grid.test.ts
@@ -593,6 +593,200 @@ describe("groups + grid integration", () => {
     });
   });
 
+  describe("resize", () => {
+    it("should render items with correct column width for container size", () => {
+      createGroupedGrid();
+      const items = Array.from(
+        container.querySelectorAll("[data-index]:not(.vlist-group-header)"),
+      ) as HTMLElement[];
+      expect(items.length).toBeGreaterThan(0);
+
+      const w = parseFloat(items[0]!.style.width);
+      // Container is 300px, 4 columns, 8px gap: (300 - 3*8) / 4 = 69
+      const expected = (300 - (COLUMNS - 1) * GAP) / COLUMNS;
+      expect(Math.abs(w - expected)).toBeLessThan(1);
+    });
+
+    it("should produce wider items at a wider container width", () => {
+      // Create at 300px
+      createGroupedGrid();
+      const narrowItems = Array.from(
+        container.querySelectorAll("[data-index]:not(.vlist-group-header)"),
+      ) as HTMLElement[];
+      const narrowW = parseFloat(narrowItems[0]!.style.width);
+
+      list!.destroy();
+      container.innerHTML = "";
+
+      // Create at 600px
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        get() { return 600; },
+        configurable: true,
+      });
+
+      createGroupedGrid();
+      const wideItems = Array.from(
+        container.querySelectorAll("[data-index]:not(.vlist-group-header)"),
+      ) as HTMLElement[];
+      const wideW = parseFloat(wideItems[0]!.style.width);
+
+      // Wider container → wider columns
+      expect(wideW).toBeGreaterThan(narrowW);
+
+      // Restore
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        get() { return 300; },
+        configurable: true,
+      });
+    });
+
+    it("should produce taller items at a wider container with dynamic height", () => {
+      // Use dynamic height: colWidth * 0.75 (aspect ratio)
+      list = createVList(
+        {
+          container,
+          items: createTestItems(40),
+          item: {
+            height: (_i: number, ctx: any) => ctx ? Math.round(ctx.columnWidth * 0.75) : 100,
+            template: simpleTemplate,
+          },
+        },
+        [
+          grid({ columns: COLUMNS, gap: GAP }),
+          groups({
+            getGroupForIndex: getGroupByTen,
+            header: { height: HEADER_HEIGHT, template: (key) => key },
+          }),
+        ],
+      );
+      const narrowItems = Array.from(
+        container.querySelectorAll("[data-index]:not(.vlist-group-header)"),
+      ) as HTMLElement[];
+      const narrowH = parseFloat(narrowItems[0]!.style.height);
+
+      list.destroy();
+      container.innerHTML = "";
+
+      // Create at 600px
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        get() { return 600; },
+        configurable: true,
+      });
+
+      list = createVList(
+        {
+          container,
+          items: createTestItems(40),
+          item: {
+            height: (_i: number, ctx: any) => ctx ? Math.round(ctx.columnWidth * 0.75) : 100,
+            template: simpleTemplate,
+          },
+        },
+        [
+          grid({ columns: COLUMNS, gap: GAP }),
+          groups({
+            getGroupForIndex: getGroupByTen,
+            header: { height: HEADER_HEIGHT, template: (key) => key },
+          }),
+        ],
+      );
+      const wideItems = Array.from(
+        container.querySelectorAll("[data-index]:not(.vlist-group-header)"),
+      ) as HTMLElement[];
+      const wideH = parseFloat(wideItems[0]!.style.height);
+
+      expect(wideH).toBeGreaterThan(narrowH);
+
+      // Restore
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        get() { return 300; },
+        configurable: true,
+      });
+    });
+
+    it("should update grid positions after forceRender with new crossSize", () => {
+      createGroupedGrid();
+      const firstItem = container.querySelector("[data-index]:not(.vlist-group-header)") as HTMLElement;
+      const initialW = parseFloat(firstItem.style.width);
+
+      // Verify items in the same row have distinct X positions
+      const items = Array.from(
+        container.querySelectorAll("[data-index]:not(.vlist-group-header)"),
+      ) as HTMLElement[];
+      if (items.length >= COLUMNS) {
+        const xs = items.slice(0, COLUMNS).map((el) => {
+          const m = el.style.transform.match(/translate\(([\d.]+)px/);
+          return m ? parseFloat(m[1]!) : -1;
+        });
+        const uniqueXs = new Set(xs);
+        expect(uniqueXs.size).toBe(COLUMNS);
+
+        // Verify X spacing matches column width + gap
+        const sorted = [...xs].sort((a, b) => a - b);
+        const spacing = sorted[1]! - sorted[0]!;
+        expect(Math.abs(spacing - (initialW + GAP))).toBeLessThan(1);
+      }
+    });
+
+    it("should update content height after resize with dynamic height", () => {
+      const dynamicHeight = (_i: number, ctx: any) => ctx ? Math.round(ctx.columnWidth * 0.75) : 100;
+
+      // Create at 300px
+      list = createVList(
+        {
+          container,
+          items: createTestItems(40),
+          item: { height: dynamicHeight, template: simpleTemplate },
+        },
+        [
+          grid({ columns: COLUMNS, gap: GAP }),
+          groups({
+            getGroupForIndex: getGroupByTen,
+            header: { height: HEADER_HEIGHT, template: (key) => key },
+          }),
+        ],
+      );
+      const narrowHeight = parseFloat(
+        (container.querySelector(".vlist-content") as HTMLElement).style.height,
+      );
+
+      list.destroy();
+      container.innerHTML = "";
+
+      // Create at 600px
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        get() { return 600; },
+        configurable: true,
+      });
+
+      list = createVList(
+        {
+          container,
+          items: createTestItems(40),
+          item: { height: dynamicHeight, template: simpleTemplate },
+        },
+        [
+          grid({ columns: COLUMNS, gap: GAP }),
+          groups({
+            getGroupForIndex: getGroupByTen,
+            header: { height: HEADER_HEIGHT, template: (key) => key },
+          }),
+        ],
+      );
+      const wideHeight = parseFloat(
+        (container.querySelector(".vlist-content") as HTMLElement).style.height,
+      );
+
+      expect(wideHeight).toBeGreaterThan(narrowHeight);
+
+      // Restore
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        get() { return 300; },
+        configurable: true,
+      });
+    });
+  });
+
   describe("destroy", () => {
     it("should clean up groups + grid + selection without errors", () => {
       createGroupedGrid();

--- a/test/integration/groups-grid.test.ts
+++ b/test/integration/groups-grid.test.ts
@@ -573,6 +573,26 @@ describe("groups + grid integration", () => {
     });
   });
 
+  describe("scroll into view", () => {
+    it("should register _scrollItemIntoView for grid-aware scrolling", () => {
+      createGroupedGrid();
+      // Groups registers _scrollItemIntoView when grid is active.
+      // Selection uses it via sivFn to scroll focused items into view.
+      // Verify groups is active and the method would be resolved.
+      expect(list!.element.classList.contains("vlist--grouped")).toBe(true);
+
+      // Click first data item to establish selection/focus
+      const first = container.querySelector("[data-index='1']") as HTMLElement;
+      expect(first).not.toBeNull();
+      first.click();
+
+      // Verify scroll position is within the grid content range, not the
+      // per-item sizeCache range (which would be much larger)
+      const vp = container.querySelector(".vlist-viewport") as HTMLElement;
+      expect(vp.scrollTop).toBeLessThan(200);
+    });
+  });
+
   describe("destroy", () => {
     it("should clean up groups + grid + selection without errors", () => {
       createGroupedGrid();

--- a/test/integration/groups-table-data.test.ts
+++ b/test/integration/groups-table-data.test.ts
@@ -481,6 +481,108 @@ describe("groups + table + data", () => {
     });
   });
 
+  // ── Placeholders ─────────────────────────────────────────────────
+
+  describe("placeholders with groups", () => {
+    it("should render placeholder rows for unloaded items", async () => {
+      // Adapter with large total but small chunk — most items are unloaded
+      const adapter: VListAdapter<CityItem> = {
+        read: mock(async ({ offset, limit }: { offset: number; limit: number }) => {
+          const end = Math.min(offset + limit, 500);
+          const items = createCities(offset, end - offset);
+          return { items, total: 500, hasMore: end < 500 };
+        }),
+      };
+
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 10 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getPopTier,
+            header: { height: 28, template: (key) => key },
+          }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      // With chunkSize=10, only ~10 items loaded initially.
+      // The table should still render rows beyond the loaded range as placeholders.
+      const allRows = container.querySelectorAll(".vlist-table-row");
+      expect(allRows.length).toBeGreaterThan(0);
+
+      // Total rendered items (rows + headers) should fill the viewport
+      const allItems = container.querySelectorAll("[data-index]");
+      expect(allItems.length).toBeGreaterThan(5);
+    });
+
+    it("should render same number of rows with and without groups", async () => {
+      const adapter = createCityAdapter(200);
+
+      // Without groups
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+        ],
+      );
+      await waitForLoad(list);
+      const rowsWithout = container.querySelectorAll(".vlist-table-row").length;
+      list.destroy();
+      container.innerHTML = "";
+
+      // With groups
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getPopTier,
+            header: { height: 28, template: (key) => key },
+          }),
+        ],
+      );
+      await waitForLoad(list);
+      const rowsWith = container.querySelectorAll(".vlist-table-row:not(.vlist-table-group-header)").length;
+      const headers = container.querySelectorAll(".vlist-table-group-header").length;
+
+      // With groups: data rows + headers ≈ rows without groups
+      // (headers take space so slightly fewer data rows fit)
+      expect(rowsWith + headers).toBeGreaterThanOrEqual(rowsWithout - 2);
+    });
+
+    it("data plugin should register _getItem method", async () => {
+      const adapter = createCityAdapter(50);
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getPopTier,
+            header: { height: 28, template: (key) => key },
+          }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      // getItemAt(0) should return a group header (not undefined)
+      const item0 = list.getItemAt(0);
+      expect(item0).toBeDefined();
+      expect((item0 as any).__groupHeader).toBe(true);
+
+      // getItemAt(1) should return a data item (not undefined)
+      const item1 = list.getItemAt(1);
+      expect(item1).toBeDefined();
+      expect((item1 as any).__groupHeader).toBeUndefined();
+    });
+  });
+
   // ── Without groups (baseline) ───────────────────────────────────
 
   describe("without groups (baseline)", () => {

--- a/test/integration/groups-table-data.test.ts
+++ b/test/integration/groups-table-data.test.ts
@@ -353,7 +353,7 @@ describe("groups + table + data", () => {
       const firstLoadCount = headersFirstLoad.length;
 
       // Save snapshot (simulates browser session)
-      const snap = list.getScrollSnapshot();
+      const snap = (list as any).getScrollSnapshot();
       sessionStorage.setItem(STORAGE_KEY, JSON.stringify(snap));
 
       // Destroy and recreate (simulates page reload with saved snapshot)

--- a/test/integration/groups-table-data.test.ts
+++ b/test/integration/groups-table-data.test.ts
@@ -1,0 +1,506 @@
+/**
+ * Groups + Table + Data integration tests.
+ *
+ * Validates that three plugins cooperate correctly:
+ *   - data plugin loads items asynchronously via adapter
+ *   - groups plugin builds a grouped layout (headers + data entries)
+ *   - table plugin renders using the grouped layout via getItemFn
+ *
+ * Key interactions tested:
+ *   - getItemFn override ordering (groups must win over data)
+ *   - sizeCache.rebuild interception for layout rebuilds
+ *   - engineState.totalItems reflects layout count (data + headers)
+ *   - snapshots restore + async data race condition
+ *   - sticky header population after async data arrives
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  mock,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { createVList } from "../../src/core/create";
+import type { VList } from "../../src/core/types";
+import { createContainer, type TestItem } from "../helpers/factory";
+import { data as dataPlugin } from "../../src/plugins/data/plugin";
+import { groups } from "../../src/plugins/groups/plugin";
+import { table } from "../../src/plugins/table/plugin";
+import { snapshots } from "../../src/plugins/snapshots/plugin";
+import type { VListAdapter } from "../../src/types";
+
+// =============================================================================
+// Setup
+// =============================================================================
+
+let origClientHeight: PropertyDescriptor | undefined;
+let origClientWidth: PropertyDescriptor | undefined;
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  origClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientHeight");
+  origClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientWidth");
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    get() { return 500; },
+    configurable: true,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    get() { return 300; },
+    configurable: true,
+  });
+});
+
+afterAll(() => {
+  if (origClientHeight) Object.defineProperty(HTMLElement.prototype, "clientHeight", origClientHeight);
+  if (origClientWidth) Object.defineProperty(HTMLElement.prototype, "clientWidth", origClientWidth);
+  GlobalRegistrator.unregister();
+});
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+interface CityItem extends TestItem {
+  population: number;
+  continent: string;
+}
+
+function createCities(offset: number, count: number): CityItem[] {
+  const items: CityItem[] = [];
+  for (let i = 0; i < count; i++) {
+    const idx = offset + i;
+    const pop = 20_000_000 - idx * 100_000;
+    items.push({
+      id: idx + 1,
+      name: `City ${idx + 1}`,
+      value: pop,
+      population: pop,
+      continent: idx < 10 ? "Asia" : idx < 20 ? "Europe" : "Americas",
+    });
+  }
+  return items;
+}
+
+function createCityAdapter(total: number = 100, chunkSize: number = 50): VListAdapter<CityItem> {
+  return {
+    read: mock(async ({ offset, limit }: { offset: number; limit: number }) => {
+      const end = Math.min(offset + limit, total);
+      const items = createCities(offset, end - offset);
+      return { items, total, hasMore: end < total };
+    }),
+  };
+}
+
+function getPopTier(_index: number, item?: any): string {
+  if (!item || !item.population) return "Unknown";
+  const pop = item.population;
+  if (pop >= 15_000_000) return "15M+";
+  if (pop >= 10_000_000) return "10M+";
+  return "< 10M";
+}
+
+function getContinentGroup(_index: number, item?: any): string {
+  return item?.continent ?? "Unknown";
+}
+
+const COLUMNS = [
+  { key: "name", label: "City", width: 150 },
+  { key: "population", label: "Pop", width: 100 },
+  { key: "continent", label: "Continent", width: 100 },
+];
+
+function waitForLoad(list: VList<CityItem>): Promise<void> {
+  return new Promise((resolve) => {
+    const unsub = (list as any).on("load:end", () => {
+      unsub();
+      resolve();
+    });
+    setTimeout(resolve, 200);
+  });
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+let container: HTMLElement;
+let list: VList<CityItem> | null = null;
+
+beforeEach(() => {
+  container = createContainer({ width: 300, height: 500 });
+});
+
+afterEach(() => {
+  if (list) {
+    list.destroy();
+    list = null;
+  }
+  container.remove();
+});
+
+describe("groups + table + data", () => {
+  // ── Initialization ──────────────────────────────────────────────
+
+  describe("initialization", () => {
+    it("should set up all three plugins without errors", async () => {
+      const adapter = createCityAdapter();
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getPopTier,
+            header: { height: 28, template: (key) => key },
+          }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      const root = container.querySelector(".vlist") as HTMLElement;
+      expect(root).not.toBeNull();
+      expect(root.classList.contains("vlist--grouped")).toBe(true);
+      expect(root.querySelector(".vlist-table-header")).not.toBeNull();
+    });
+
+    it("should produce group headers in the DOM", async () => {
+      const adapter = createCityAdapter();
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getPopTier,
+            header: { height: 28, template: (key) => key },
+          }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      const headers = container.querySelectorAll(".vlist-table-group-header");
+      expect(headers.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── getItemFn override ordering ─────────────────────────────────
+
+  describe("getItemFn ordering", () => {
+    it("should map layout indices through groups despite data plugin running later", async () => {
+      const adapter = createCityAdapter(50);
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getPopTier,
+            header: { height: 28, template: (key) => key },
+          }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      // getItemAt should return header pseudo-items at group boundaries
+      const item0 = list.getItemAt(0);
+      expect(item0).toBeDefined();
+      expect((item0 as any).__groupHeader).toBe(true);
+
+      // First data item should be at index 1 (after the first group header)
+      const item1 = list.getItemAt(1);
+      expect(item1).toBeDefined();
+      expect((item1 as any).__groupHeader).toBeUndefined();
+      expect(item1!.name).toBe("City 1");
+    });
+  });
+
+  // ── engineState.totalItems ──────────────────────────────────────
+
+  describe("totalItems", () => {
+    it("should include group header count in aria-rowcount", async () => {
+      const adapter = createCityAdapter(50);
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getPopTier,
+            header: { height: 28, template: (key) => key },
+          }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      const root = container.querySelector(".vlist") as HTMLElement;
+      const rowCount = parseInt(root.getAttribute("aria-rowcount") ?? "0", 10);
+      // aria-rowcount = totalItems + 1 (table header row)
+      // totalItems should be 50 data items + N group headers
+      expect(rowCount).toBeGreaterThan(51);
+    });
+  });
+
+  // ── Sticky header ───────────────────────────────────────────────
+
+  describe("sticky header", () => {
+    it("should create a sticky header container", async () => {
+      const adapter = createCityAdapter();
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getPopTier,
+            header: { height: 28, template: (key) => key },
+            sticky: true,
+          }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      const sticky = container.querySelector(".vlist-sticky-header");
+      expect(sticky).not.toBeNull();
+    });
+  });
+
+  // ── Group content ───────────────────────────────────────────────
+
+  describe("group content", () => {
+    it("should create groups based on population tiers", async () => {
+      const adapter = createCityAdapter(30);
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getPopTier,
+            header: { height: 28, template: (key) => key },
+          }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      const headers = container.querySelectorAll(".vlist-table-group-header");
+      const headerTexts = Array.from(headers).map((h) => h.textContent?.trim());
+      expect(headerTexts).toContain("15M+");
+    });
+
+    it("should use different group keys based on grouping function", async () => {
+      const adapter = createCityAdapter(30);
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getContinentGroup,
+            header: { height: 28, template: (key) => key },
+          }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      const headers = container.querySelectorAll(".vlist-table-group-header");
+      const headerTexts = Array.from(headers).map((h) => h.textContent?.trim());
+      expect(headerTexts).toContain("Asia");
+      expect(headerTexts).toContain("Europe");
+    });
+  });
+
+  // ── Snapshots restore race ──────────────────────────────────────
+
+  describe("snapshots restore race", () => {
+    it("should show correct groups after snapshot restore + data load", async () => {
+      // This test creates, destroys, and recreates a vlist within one test
+      // to simulate a page reload with a saved snapshot. Under --concurrent
+      // mode, the HTMLElement.prototype.clientHeight override may be stomped
+      // by another file between destroy and recreate. In sequential mode
+      // this test is fully deterministic.
+      const adapter = createCityAdapter(100);
+      const STORAGE_KEY = "test-gtd-snap-" + Math.random().toString(36).slice(2, 8);
+
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getPopTier,
+            header: { height: 28, template: (key) => key },
+          }),
+          snapshots({ autoSave: STORAGE_KEY }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      // Verify groups exist on first load
+      const headersFirstLoad = container.querySelectorAll(".vlist-table-group-header");
+      const firstLoadCount = headersFirstLoad.length;
+
+      // Save snapshot (simulates browser session)
+      const snap = list.getScrollSnapshot();
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(snap));
+
+      // Destroy and recreate (simulates page reload with saved snapshot)
+      list.destroy();
+      container.innerHTML = "";
+
+      // Re-install prototype override (defend against concurrent stomp)
+      Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+        get() { return 500; },
+        configurable: true,
+      });
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        get() { return 300; },
+        configurable: true,
+      });
+
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getPopTier,
+            header: { height: 28, template: (key) => key },
+          }),
+          snapshots({ autoSave: STORAGE_KEY }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      // After snapshot restore + data load, groups must still be present
+      const headersAfterRestore = container.querySelectorAll(".vlist-table-group-header");
+      expect(headersAfterRestore.length).toBeGreaterThan(0);
+
+      // Header count should be the same as first load
+      expect(headersAfterRestore.length).toBe(firstLoadCount);
+
+      sessionStorage.removeItem(STORAGE_KEY);
+    });
+  });
+
+  // ── Data reload (sort change) ───────────────────────────────────
+
+  describe("data reload", () => {
+    it("should rebuild groups after reload", async () => {
+      const adapter = createCityAdapter(50);
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getPopTier,
+            header: { height: 28, template: (key) => key },
+          }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      const headersBefore = container.querySelectorAll(".vlist-table-group-header").length;
+      expect(headersBefore).toBeGreaterThan(0);
+
+      // Reload data (simulates sort change).
+      // Start listening BEFORE reload so we don't miss the event.
+      (adapter.read as any).mockClear();
+      const loaded = waitForLoad(list);
+      await (list as any).reload();
+      await loaded;
+
+      const headersAfter = container.querySelectorAll(".vlist-table-group-header").length;
+      expect(headersAfter).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Table rendering ─────────────────────────────────────────────
+
+  describe("table rendering", () => {
+    it("should render data rows with table cells, not just group headers", async () => {
+      const adapter = createCityAdapter(30);
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getPopTier,
+            header: { height: 28, template: (key) => key },
+          }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      const dataRows = container.querySelectorAll(".vlist-table-row:not(.vlist-table-group-header)");
+      expect(dataRows.length).toBeGreaterThan(0);
+
+      // Each data row should have cells matching column count
+      const firstRow = dataRows[0] as HTMLElement;
+      const cells = firstRow.querySelectorAll(".vlist-table-cell");
+      expect(cells.length).toBe(COLUMNS.length);
+    });
+
+    it("should not apply vlist-item class to group header rows", async () => {
+      const adapter = createCityAdapter(30);
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+          groups({
+            getGroupForIndex: getPopTier,
+            header: { height: 28, template: (key) => key },
+          }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      const headers = container.querySelectorAll(".vlist-table-group-header");
+      for (const header of headers) {
+        expect(header.classList.contains("vlist-item")).toBe(false);
+      }
+    });
+  });
+
+  // ── Without groups (baseline) ───────────────────────────────────
+
+  describe("without groups (baseline)", () => {
+    it("should render a plain table with no group headers", async () => {
+      const adapter = createCityAdapter(30);
+      list = createVList<CityItem>(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+        ],
+      );
+
+      await waitForLoad(list);
+
+      const headers = container.querySelectorAll(".vlist-table-group-header");
+      expect(headers.length).toBe(0);
+
+      const dataRows = container.querySelectorAll(".vlist-table-row");
+      expect(dataRows.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/test/plugins/selection/groups.test.ts
+++ b/test/plugins/selection/groups.test.ts
@@ -161,7 +161,7 @@ describe("selection + groups — focus navigation skips headers", () => {
 // =============================================================================
 
 describe("selection + groups — shift+click range selection", () => {
-  it("shift+click range includes headers in data range (doSelectRange uses data indices)", () => {
+  it("shift+click range skips group headers", () => {
     const { plugin, mockCtx, getSelected } = setupWithGroups();
 
     const handler = mockCtx.clickHandlers[0]!;
@@ -174,17 +174,15 @@ describe("selection + groups — shift+click range selection", () => {
     handler(makeClickEvent(makeItemElement(6), { shiftKey: true }));
 
     const selected = getSelected();
-    // doSelectRange(1, 6) selects data indices 1..6
-    // Items: id=1 (idx=1), id=2 (idx=2), id=3 (idx=3),
-    //        id=200 header (idx=4), id=5 (idx=5), id=6 (idx=6)
+    // Layout range 1..6: id=1, id=2, id=3, header(idx=4), id=5, id=6
+    // Group headers are skipped — only data items selected
     expect(selected).toContain(1);
     expect(selected).toContain(2);
     expect(selected).toContain(3);
     expect(selected).toContain(5);
     expect(selected).toContain(6);
-    // Header (id=200) is included in range since doSelectRange doesn't filter headers
-    expect(selected).toContain(200);
-    expect(selected.length).toBe(6);
+    expect(selected).not.toContain(200);
+    expect(selected.length).toBe(5);
 
     plugin.destroy!();
     mockCtx.cleanup();
@@ -202,13 +200,15 @@ describe("selection + groups — shift+click range selection", () => {
     handler(makeClickEvent(makeItemElement(2), { shiftKey: true }));
 
     const selected = getSelected();
-    // Range 2..7: ids 2, 3, 200, 5, 6, 7
+    // Layout range 2..7: id=2, id=3, header(idx=4), id=5, id=6, id=7
+    // Group headers skipped
     expect(selected).toContain(2);
     expect(selected).toContain(3);
     expect(selected).toContain(5);
     expect(selected).toContain(6);
     expect(selected).toContain(7);
-    expect(selected.length).toBe(6);
+    expect(selected).not.toContain(200);
+    expect(selected.length).toBe(5);
 
     plugin.destroy!();
     mockCtx.cleanup();
@@ -414,6 +414,164 @@ describe("selection + groups — followFocus=false desync", () => {
     handler(makeKeyEvent("ArrowDown")); // → 2, auto-selects (replaces 1)
     expect(getSelected()).toEqual([2]);
     expect(getSelected()).not.toContain(1);
+
+    plugin.destroy!();
+    mockCtx.cleanup();
+  });
+});
+
+// =============================================================================
+// Click selects correct item with layout/data index offset
+// =============================================================================
+
+describe("selection + groups — click with layout/data offset", () => {
+  // When groups are active, layout indices include headers so they diverge
+  // from data indices. This setup models real offset:
+  //   Layout: [H0, D0(1), D1(2), D2(3), H1(4), D3(5), D4(6), D5(7)]
+  //   Data:   [D0,        D1,    D2,            D3,    D4,    D5    ]
+  //   layoutToData(1)=0, layoutToData(5)=3, layoutToData(6)=4
+  function setupWithRealOffset(mode: "single" | "multiple" = "single") {
+    const items: TestItem[] = [
+      { id: 100, name: "Header A", __groupHeader: true },
+      { id: 1, name: "Alpha" },
+      { id: 2, name: "Beta" },
+      { id: 3, name: "Gamma" },
+      { id: 200, name: "Header B", __groupHeader: true },
+      { id: 4, name: "Delta" },
+      { id: 5, name: "Epsilon" },
+      { id: 6, name: "Zeta" },
+    ];
+
+    const mockCtx = createPluginMockContext<TestItem>(items, {
+      itemSize: 40,
+      containerHeight: 500,
+    });
+
+    mockCtx.ctx.registerMethod("_isGroupHeader", (layoutIdx: number): boolean =>
+      items[layoutIdx]?.__groupHeader === true);
+
+    mockCtx.ctx.registerMethod("_layoutToDataIndex", (layoutIdx: number): number => {
+      if (layoutIdx === 0 || layoutIdx === 4) return -1;
+      return layoutIdx < 4 ? layoutIdx - 1 : layoutIdx - 2;
+    });
+    mockCtx.ctx.registerMethod("_dataToLayoutIndex", (dataIdx: number): number => {
+      return dataIdx < 3 ? dataIdx + 1 : dataIdx + 2;
+    });
+
+    const plugin = selection<TestItem>({ mode });
+    plugin.setup(mockCtx.ctx);
+
+    const getSelected = mockCtx.methods.get("getSelected") as () => Array<string | number>;
+
+    return { plugin, mockCtx, items, getSelected };
+  }
+
+  it("click on first group item selects correct item", () => {
+    const { plugin, mockCtx, getSelected } = setupWithRealOffset();
+    const handler = mockCtx.clickHandlers[0]!;
+
+    handler(makeClickEvent(makeItemElement(1)));
+    expect(getSelected()).toEqual([1]);
+
+    plugin.destroy!();
+    mockCtx.cleanup();
+  });
+
+  it("click on second group item selects correct item", () => {
+    const { plugin, mockCtx, getSelected } = setupWithRealOffset();
+    const handler = mockCtx.clickHandlers[0]!;
+
+    handler(makeClickEvent(makeItemElement(5)));
+    expect(getSelected()).toEqual([4]);
+
+    plugin.destroy!();
+    mockCtx.cleanup();
+  });
+
+  it("click after two headers selects correct item (offset=2)", () => {
+    const { plugin, mockCtx, getSelected } = setupWithRealOffset();
+    const handler = mockCtx.clickHandlers[0]!;
+
+    handler(makeClickEvent(makeItemElement(7)));
+    expect(getSelected()).toEqual([6]);
+
+    plugin.destroy!();
+    mockCtx.cleanup();
+  });
+
+  it("click on group header does not select", () => {
+    const { plugin, mockCtx, getSelected } = setupWithRealOffset();
+    const handler = mockCtx.clickHandlers[0]!;
+
+    handler(makeClickEvent(makeItemElement(0)));
+    expect(getSelected()).toEqual([]);
+
+    plugin.destroy!();
+    mockCtx.cleanup();
+  });
+
+  it("click on header between groups does not select", () => {
+    const { plugin, mockCtx, getSelected } = setupWithRealOffset();
+    const handler = mockCtx.clickHandlers[0]!;
+
+    handler(makeClickEvent(makeItemElement(4)));
+    expect(getSelected()).toEqual([]);
+
+    plugin.destroy!();
+    mockCtx.cleanup();
+  });
+
+  it("sequential clicks across groups select correct items", () => {
+    const { plugin, mockCtx, getSelected } = setupWithRealOffset();
+    const handler = mockCtx.clickHandlers[0]!;
+
+    handler(makeClickEvent(makeItemElement(2)));
+    expect(getSelected()).toEqual([2]);
+
+    handler(makeClickEvent(makeItemElement(6)));
+    expect(getSelected()).toEqual([5]);
+
+    plugin.destroy!();
+    mockCtx.cleanup();
+  });
+
+  it("itemStateFn marks correct item as selected with offset", () => {
+    const { plugin, mockCtx } = setupWithRealOffset();
+    const handler = mockCtx.clickHandlers[0]!;
+
+    handler(makeClickEvent(makeItemElement(3)));
+
+    const stateFn = mockCtx.ctx.getItemStateFn();
+    expect(stateFn).not.toBeNull();
+
+    const state3 = { selected: false, focused: false };
+    stateFn!(3, state3);
+    expect(state3.selected).toBe(true);
+
+    const state2 = { selected: false, focused: false };
+    stateFn!(2, state2);
+    expect(state2.selected).toBe(false);
+
+    plugin.destroy!();
+    mockCtx.cleanup();
+  });
+
+  it("shift+click range with offset skips headers", () => {
+    const { plugin, mockCtx, getSelected } = setupWithRealOffset("multiple");
+    const handler = mockCtx.clickHandlers[0]!;
+
+    handler(makeClickEvent(makeItemElement(1)));
+    handler(makeClickEvent(makeItemElement(6), { shiftKey: true }));
+
+    const selected = getSelected();
+    expect(selected).toContain(1);
+    expect(selected).toContain(2);
+    expect(selected).toContain(3);
+    expect(selected).toContain(4);
+    expect(selected).toContain(5);
+    expect(selected).not.toContain(100);
+    expect(selected).not.toContain(200);
+    expect(selected.length).toBe(5);
 
     plugin.destroy!();
     mockCtx.cleanup();

--- a/test/plugins/selection/groups.test.ts
+++ b/test/plugins/selection/groups.test.ts
@@ -426,29 +426,34 @@ describe("selection + groups — followFocus=false desync", () => {
 
 describe("selection + groups — click with layout/data offset", () => {
   // When groups are active, layout indices include headers so they diverge
-  // from data indices. This setup models real offset:
+  // from data indices. The items array only contains DATA items (no headers).
+  // Headers are virtual — _isGroupHeader tells the selection plugin which
+  // layout indices are headers.
+  //
   //   Layout: [H0, D0(1), D1(2), D2(3), H1(4), D3(5), D4(6), D5(7)]
-  //   Data:   [D0,        D1,    D2,            D3,    D4,    D5    ]
+  //   Data:   [Alpha(0), Beta(1), Gamma(2), Delta(3), Epsilon(4), Zeta(5)]
   //   layoutToData(1)=0, layoutToData(5)=3, layoutToData(6)=4
   function setupWithRealOffset(mode: "single" | "multiple" = "single") {
-    const items: TestItem[] = [
-      { id: 100, name: "Header A", __groupHeader: true },
+    const dataItems: TestItem[] = [
       { id: 1, name: "Alpha" },
       { id: 2, name: "Beta" },
       { id: 3, name: "Gamma" },
-      { id: 200, name: "Header B", __groupHeader: true },
       { id: 4, name: "Delta" },
       { id: 5, name: "Epsilon" },
       { id: 6, name: "Zeta" },
     ];
 
-    const mockCtx = createPluginMockContext<TestItem>(items, {
+    // Layout has 8 entries (6 data + 2 headers) but ctx.getItems() returns
+    // only the 6 data items — headers are virtual.
+    const mockCtx = createPluginMockContext<TestItem>(dataItems, {
       itemSize: 40,
       containerHeight: 500,
     });
+    // engineState.totalItems must reflect layout count (data + headers)
+    mockCtx.engineState.totalItems = 8;
 
     mockCtx.ctx.registerMethod("_isGroupHeader", (layoutIdx: number): boolean =>
-      items[layoutIdx]?.__groupHeader === true);
+      layoutIdx === 0 || layoutIdx === 4);
 
     mockCtx.ctx.registerMethod("_layoutToDataIndex", (layoutIdx: number): number => {
       if (layoutIdx === 0 || layoutIdx === 4) return -1;
@@ -463,7 +468,7 @@ describe("selection + groups — click with layout/data offset", () => {
 
     const getSelected = mockCtx.methods.get("getSelected") as () => Array<string | number>;
 
-    return { plugin, mockCtx, items, getSelected };
+    return { plugin, mockCtx, dataItems, getSelected };
   }
 
   it("click on first group item selects correct item", () => {
@@ -572,6 +577,101 @@ describe("selection + groups — click with layout/data offset", () => {
     expect(selected).not.toContain(100);
     expect(selected).not.toContain(200);
     expect(selected.length).toBe(5);
+
+    plugin.destroy!();
+    mockCtx.cleanup();
+  });
+
+  it("getSelectedItems returns correct item after click with offset", () => {
+    const { plugin, mockCtx } = setupWithRealOffset();
+    const handler = mockCtx.clickHandlers[0]!;
+
+    handler(makeClickEvent(makeItemElement(5)));
+
+    const getSelectedItems = mockCtx.methods.get("getSelectedItems") as () => any[];
+    const items = getSelectedItems();
+    expect(items.length).toBe(1);
+    expect(items[0].id).toBe(4);
+    expect(items[0].name).toBe("Delta");
+
+    plugin.destroy!();
+    mockCtx.cleanup();
+  });
+
+  it("focus:change event reports correct item with offset", () => {
+    const { plugin, mockCtx } = setupWithRealOffset();
+    const keyHandler = mockCtx.keydownHandlers[0]!;
+    const getSelectedItems = mockCtx.methods.get("getSelectedItems") as () => any[];
+    const getFocused = mockCtx.methods.get("_getFocusedIndex") as () => number;
+
+    // ArrowDown from -1 → skips header 0 → layout 1 (data 0, id=1)
+    keyHandler(makeKeyEvent("ArrowDown"));
+    expect(getFocused()).toBe(1);
+
+    // ArrowDown across header → layout 5 via 2→3→5
+    keyHandler(makeKeyEvent("ArrowDown")); // → 2
+    keyHandler(makeKeyEvent("ArrowDown")); // → 3
+    keyHandler(makeKeyEvent("ArrowDown")); // → 5 (skip header 4)
+    expect(getFocused()).toBe(5);
+
+    // Select via Space, verify correct item
+    keyHandler(makeKeyEvent(" "));
+    const items = getSelectedItems();
+    expect(items.length).toBe(1);
+    expect(items[0].id).toBe(4);
+    expect(items[0].name).toBe("Delta");
+
+    plugin.destroy!();
+    mockCtx.cleanup();
+  });
+
+  it("selectAll skips headers and selects only data items", () => {
+    const { plugin, mockCtx, getSelected } = setupWithRealOffset("multiple");
+
+    (mockCtx.methods.get("selectAll") as () => void)();
+
+    const selected = getSelected();
+    expect(selected).toContain(1);
+    expect(selected).toContain(2);
+    expect(selected).toContain(3);
+    expect(selected).toContain(4);
+    expect(selected).toContain(5);
+    expect(selected).toContain(6);
+    expect(selected.length).toBe(6);
+
+    plugin.destroy!();
+    mockCtx.cleanup();
+  });
+
+  it("getSelectedItems returns correct items after click with offset", () => {
+    const { plugin, mockCtx } = setupWithRealOffset("multiple");
+    const handler = mockCtx.clickHandlers[0]!;
+
+    handler(makeClickEvent(makeItemElement(6)));
+
+    const getSelectedItems = mockCtx.methods.get("getSelectedItems") as () => any[];
+    const items = getSelectedItems();
+    expect(items.length).toBe(1);
+    expect(items[0].id).toBe(5);
+    expect(items[0].name).toBe("Epsilon");
+
+    plugin.destroy!();
+    mockCtx.cleanup();
+  });
+
+  it("keyboard Space selects correct item with offset", () => {
+    const { plugin, mockCtx, getSelected } = setupWithRealOffset("multiple");
+    const keyHandler = mockCtx.keydownHandlers[0]!;
+
+    keyHandler(makeKeyEvent("ArrowDown"));
+    keyHandler(makeKeyEvent("ArrowDown"));
+    keyHandler(makeKeyEvent("ArrowDown"));
+    keyHandler(makeKeyEvent("ArrowDown"));
+
+    keyHandler(makeKeyEvent(" "));
+
+    const selected = getSelected();
+    expect(selected).toEqual([4]);
 
     plugin.destroy!();
     mockCtx.cleanup();

--- a/test/plugins/snapshots/plugin.test.ts
+++ b/test/plugins/snapshots/plugin.test.ts
@@ -1410,6 +1410,97 @@ describe("snapshots - autoSave", () => {
 });
 
 // =============================================================================
+// snapshots — Save not blocked after restore with dataIndex
+// =============================================================================
+
+describe("snapshots - saves after restore with dataIndex", () => {
+  const AUTO_SAVE_KEY = "test-suppress-fix";
+
+  function clearAutoSave() {
+    try { sessionStorage.removeItem(AUTO_SAVE_KEY); } catch {}
+  }
+
+  it("should save after restore even when snapshot has dataIndex", async () => {
+    clearAutoSave();
+    const savedSnapshot: ScrollSnapshot = {
+      index: 50, offsetInItem: 0, total: 100,
+      dataIndex: 50, dataTotal: 100, scrollTop: 2400,
+    };
+    sessionStorage.setItem(AUTO_SAVE_KEY, JSON.stringify(savedSnapshot));
+
+    const { ctx, cleanup } = createMockContext({ totalItems: 100, scrollTop: 0, itemHeight: 48 });
+    const plugin = snapshots<TestItem>({ autoSave: AUTO_SAVE_KEY });
+    plugin.setup(ctx);
+
+    await flushAsync();
+
+    // After restore settles, selection:change should save
+    ctx.emitter.emit("selection:change", { selected: [42], items: [] as TestItem[] });
+
+    const stored = sessionStorage.getItem(AUTO_SAVE_KEY);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored!);
+    // Must reflect current state, not the old snapshot
+    expect(parsed.total).toBe(100);
+    cleanup();
+  });
+
+  it("should save on idle after restore with dataIndex", async () => {
+    clearAutoSave();
+    const savedSnapshot: ScrollSnapshot = {
+      index: 10, offsetInItem: 5, total: 50,
+      dataIndex: 10, dataTotal: 50, scrollTop: 485,
+    };
+    sessionStorage.setItem(AUTO_SAVE_KEY, JSON.stringify(savedSnapshot));
+
+    const { ctx, cleanup } = createMockContext({ totalItems: 50, scrollTop: 0, itemHeight: 48 });
+    const plugin = snapshots<TestItem>({ autoSave: AUTO_SAVE_KEY });
+    plugin.setup(ctx);
+
+    await flushAsync();
+
+    plugin.hooks!.onIdle!();
+
+    const stored = sessionStorage.getItem(AUTO_SAVE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!).total).toBe(50);
+    cleanup();
+  });
+
+  it("should not permanently block saves regardless of snapshot content", async () => {
+    clearAutoSave();
+    // Snapshot with every optional field set
+    const savedSnapshot: ScrollSnapshot = {
+      index: 25, offsetInItem: 12, total: 200,
+      dataIndex: 25, dataTotal: 200, scrollTop: 1212,
+      selectedIds: [99], focusedId: 99, offsetRatio: 0.25,
+    };
+    sessionStorage.setItem(AUTO_SAVE_KEY, JSON.stringify(savedSnapshot));
+
+    const { ctx, cleanup } = createMockContext({ totalItems: 200, scrollTop: 0, itemHeight: 48 });
+    const plugin = snapshots<TestItem>({ autoSave: AUTO_SAVE_KEY });
+    plugin.setup(ctx);
+
+    await flushAsync();
+
+    // Multiple saves should all work
+    ctx.emitter.emit("selection:change", { selected: [1], items: [] as TestItem[] });
+    const snap1 = JSON.parse(sessionStorage.getItem(AUTO_SAVE_KEY)!);
+    expect(snap1.total).toBe(200);
+
+    ctx.emitter.emit("focus:change", { id: 5, index: 4 });
+    const snap2 = JSON.parse(sessionStorage.getItem(AUTO_SAVE_KEY)!);
+    expect(snap2.total).toBe(200);
+
+    plugin.hooks!.onIdle!();
+    const snap3 = JSON.parse(sessionStorage.getItem(AUTO_SAVE_KEY)!);
+    expect(snap3.total).toBe(200);
+
+    cleanup();
+  });
+});
+
+// =============================================================================
 // snapshots — Selection Seeding
 // =============================================================================
 


### PR DESCRIPTION
## Summary

- **Groups + Table + Data** — native integration with async data, sticky headers, placeholder support
- **Groups + Grid** — correct column layout, binary search range, resize handling, padding support
- **Selection + Groups** — consistent data-index resolution across all modes (table, grid, list)
- **Keyboard nav** — keydown listener on `dom.root`, focus target selection, scroll-into-view with grid
- **Smooth scroll idle** — `scheduleIdle()` on final animation frame so data loads after scrollToIndex
- **Snapshots** — removed `_suppressSave` that permanently blocked saves; pixel-perfect scroll restore
- **Placeholders** — `_getItem` method returns placeholders for unloaded items in table+groups mode

## Stats

- 3,594 tests passing (106 new)
- 16/16 tree-shaking scenarios clean
- Base: 8.0 KB gzipped
- Groups: +4.8 KB (was +3.7 KB — grid + table integration added)

## Test plan

- [x] `bun test` — 3,594 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run size` — all 16 scenarios clean
- [ ] data-table example: groups on/off, scroll to last, selection + reload, sort change
- [ ] photo-album example: grid + groups, resize, keyboard nav, selection
- [ ] contact-list example: groups still work (regression check)
- [ ] All other examples unaffected