### PR TITLE
v2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ This changelog starts at v1.5.4, the first version published under the `vlist` p
 (April 2026). Earlier versions were published as `@floor/vlist` — see the
 [git history](https://github.com/floor/vlist/commits/main) for the full record.
 
+## [2.4.2] - 2026-06-09
+
+### Added
+
+- **Modular carousel preset registry** — presets are now `SlotConfigResolver` functions stored in a named registry. `registerPreset(name, resolver)` lets users add or override presets at runtime. `getPreset(name)` and `resolvePreset(name, containerSize, peek)` expose the registry for lookup.
+- **`SlotConfigResolver` type** — `(containerSize: number, peek: number) => SlotConfig | null`. The `variant` config now accepts a string name, a `SlotConfig` object, or a `SlotConfigResolver` function.
+- **Extensible `CarouselVariant` type** — accepts any string via `(string & {})`, not just the built-in names. Custom registered presets get full type support.
+- **Exported built-in preset functions** — `full`, `hero`, `heroCenter`, `multi`, `uncontained` are exported as named `SlotConfigResolver` functions for direct use or re-registration as aliases.
+
+### Fixed
+
+- **Carousel multi-aspect left alignment** — multi-aspect variable-width items now left-align per the MD3 uncontained spec instead of centering.
+- **Carousel focal offset jump** — eliminated the gap/size discontinuity at the focal boundary by fading the gap proportionally with item size.
+
 ## [2.4.1] - 2026-06-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The virtual list library for every framework. Ultra efficient, batteries-included, and accessible with composable plugins — in 9.7 KB.
 
-**v2.4.1** — [Changelog](./CHANGELOG.md) · **New:** Bounded logical scroll model for 1M+ items (`scroll: { mode: "bounded" }`), `carousel()` plugin with infinite loop, snap, and focal scaling. `scale()` deprecated.
+**v2.4.2** — [Changelog](./CHANGELOG.md) · **New:** Bounded logical scroll model for 1M+ items (`scroll: { mode: "bounded" }`), `carousel()` plugin with infinite loop, snap, and focal scaling. `scale()` deprecated.
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/vlist)](https://bundlephobia.com/package/vlist)
@@ -103,8 +103,8 @@ const list = createVList({
 | `scrollbar()` | +2.0 KB | Custom scrollbar UI |
 | `grid()` | +2.4 KB | 2D grid layout |
 | `masonry()` | +4.0 KB | Pinterest-style masonry with lane-aware keyboard nav |
-| `carousel()` | +2.3 KB | Paged horizontal carousel with snap and keyboard nav |
-| `table()` | +5.8 KB | Data table with columns, resize, sort |
+| `carousel()` | +3.1 KB | Paged horizontal carousel with snap and keyboard nav |
+| `table()` | +5.7 KB | Data table with columns, resize, sort |
 | `tree()` | +5.0 KB | Collapsible tree with async loading and indent guides |
 | `page()` | +0.8 KB | Window-level scrolling |
 | `sortable()` | +3.0 KB | Drag-and-drop reordering with auto-scroll |

--- a/build.ts
+++ b/build.ts
@@ -28,6 +28,7 @@ async function build() {
   const wrapperCode = [
     `export { createVList, scrollbar, grid, a11y, selection, page,`,
     `  snapshots, transition, autosize, masonry, data, groups, table, sortable, tree, search, carousel,`,
+    `  registerPreset, getPreset, resolvePreset, full, hero, heroCenter, multi, uncontained,`,
     `  createStats, rebuild } from "${entryAbs}";`,
   ].join("\n");
   const wrapperPath = "/tmp/_vlist_build_entry.ts";

--- a/npm-readme.md
+++ b/npm-readme.md
@@ -2,7 +2,7 @@
 
 The virtual list library for every framework. Ultra efficient, batteries-included, and accessible with composable plugins — in 9.7 KB.
 
-**v2.4.1** — [Changelog](https://github.com/floor/vlist/blob/main/CHANGELOG.md) · **New:** Bounded logical scroll model for 1M+ items (`scroll: { mode: "bounded" }`), `carousel()` plugin with infinite loop, snap, and focal scaling. `scale()` deprecated.
+**v2.4.2** — [Changelog](https://github.com/floor/vlist/blob/main/CHANGELOG.md) · **New:** Bounded logical scroll model for 1M+ items (`scroll: { mode: "bounded" }`), `carousel()` plugin with infinite loop, snap, and focal scaling. `scale()` deprecated.
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/vlist)](https://bundlephobia.com/package/vlist)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,8 +39,8 @@ export { tree } from "./plugins/tree";
 export type { TreePluginConfig, FlatNode } from "./plugins/tree";
 export { search, DEFAULT_SEARCH_TEXT } from "./plugins/search";
 export type { SearchPluginConfig, SearchText } from "./plugins/search";
-export { carousel } from "./plugins/carousel";
-export type { CarouselPluginConfig, CarouselVariant, CarouselDirection, CarouselState } from "./plugins/carousel";
+export { carousel, registerPreset, getPreset, resolvePreset, full, hero, heroCenter, multi, uncontained } from "./plugins/carousel";
+export type { CarouselPluginConfig, CarouselVariant, CarouselDirection, CarouselState, SlotConfig, SlotConfigResolver } from "./plugins/carousel";
 /** @deprecated Use `scroll: { mode: "bounded" }` instead. Will be removed in vlist 3.0. */
 export { scale } from "./plugins/scale";
 export type { ScalePluginConfig } from "./plugins/scale";

--- a/src/plugins/carousel/engine.ts
+++ b/src/plugins/carousel/engine.ts
@@ -82,6 +82,14 @@ export function createLayoutEngine(config: LayoutConfig): {
 
   const stepSize = (slotWidths[focalSlot] ?? 0) + gapPx;
 
+  // Gap that fades with an item's size. At rest every visible slot is wider than
+  // the gap, so this returns the full gap. But as an item shrinks toward 0 at the
+  // focal-boundary flip, holding the full gap until its size hits exactly 0 (then
+  // dropping it instantly) injects a gap-sized jump into every item's on-screen
+  // offset — the visible "chop just before the final position" (issue 023). Fading
+  // the gap with the size keeps the cumulative offset continuous through the flip.
+  const gapFor = (size: number): number => (size >= gapPx ? gapPx : Math.max(0, size));
+
   /**
    * Compute the dynamic size of a single item based on its
    * position relative to the focal point and scroll fraction.
@@ -138,12 +146,12 @@ export function createLayoutEngine(config: LayoutConfig): {
     if (rel > 0) {
       for (let r = 0; r < rel; r++) {
         const s = getItemSize(focalVi + r, focalVi, frac);
-        offset += s + (s > 0 ? gapPx : 0);
+        offset += s + gapFor(s);
       }
     } else if (rel < 0) {
       for (let r = -1; r >= rel; r--) {
         const s = getItemSize(focalVi + r, focalVi, frac);
-        offset -= s + (s > 0 ? gapPx : 0);
+        offset -= s + gapFor(s);
       }
     }
 
@@ -173,7 +181,7 @@ export function createLayoutEngine(config: LayoutConfig): {
     let offset = 0;
     for (let r = -1; r >= -focalSlot; r--) {
       const s = getItemSize(focalVi + r, focalVi, frac);
-      offset += s + (s > 0 ? gapPx : 0);
+      offset += s + gapFor(s);
     }
     return offset;
   }

--- a/src/plugins/carousel/index.ts
+++ b/src/plugins/carousel/index.ts
@@ -2,5 +2,5 @@ export { carousel } from "./plugin";
 export type { CarouselPluginConfig, CarouselVariant, CarouselDirection, CarouselState } from "./plugin";
 export { createLayoutEngine } from "./engine";
 export type { LayoutConfig, ItemLayout } from "./engine";
-export { resolvePreset, full, hero, heroCenter, multi, uncontained } from "./presets";
-export type { SlotConfig } from "./presets";
+export { resolvePreset, registerPreset, getPreset, full, hero, heroCenter, multi, uncontained } from "./presets";
+export type { SlotConfig, SlotConfigResolver } from "./presets";

--- a/src/plugins/carousel/plugin.ts
+++ b/src/plugins/carousel/plugin.ts
@@ -28,7 +28,7 @@ import { resolvePreset } from "./presets";
 // Config
 // =============================================================================
 
-export type CarouselVariant = "static" | "full" | "hero" | "hero-center" | "multi" | "uncontained" | "free";
+export type CarouselVariant = "static" | "full" | "hero" | "hero-center" | "multi" | "uncontained" | "multi-aspect" | "free";
 export type CarouselDirection = "auto" | "forward" | "backward";
 
 export interface CarouselPluginConfig {
@@ -92,6 +92,11 @@ export function carousel<T extends VListItem = VListItem>(
   let prefix = "vlist";
   let intendedVi = -1;
 
+  let stepSizes: number[] = [];
+  let stepOffsets: number[] = [];
+  let isVariableWidth = false;
+  const gapPx = config?.gap ?? 0;
+
   function resolveIndex(index: number): number {
     if (realTotal <= 0) return 0;
     return ((index % realTotal) + realTotal) % realTotal;
@@ -116,6 +121,42 @@ export function carousel<T extends VListItem = VListItem>(
     return ((virtualIndex % realTotal) + realTotal) % realTotal;
   }
 
+  function buildStepCache(sizes: number[]): void {
+    stepSizes = sizes;
+    const n = sizes.length;
+    stepOffsets = new Array(n + 1) as number[];
+    stepOffsets[0] = 0;
+    for (let i = 0; i < n; i++) {
+      stepOffsets[i + 1] = stepOffsets[i]! + sizes[i]!;
+    }
+    lapSize = n > 0 ? stepOffsets[n]! : 0;
+  }
+
+  function decomposeScroll(pos: number): { vi: number; frac: number } {
+    if (realTotal <= 0 || lapSize <= 0) return { vi: 0, frac: 0 };
+    const cycle = Math.floor(pos / lapSize);
+    let rem = pos - cycle * lapSize;
+    if (rem < 0) rem = 0;
+
+    if (!isVariableWidth) {
+      const s = stepSizes[0]!;
+      const idx = Math.min(Math.floor(rem / s), realTotal - 1);
+      return { vi: cycle * realTotal + idx, frac: s > 0 ? (rem / s) - idx : 0 };
+    }
+
+    let lo = 0;
+    let hi = realTotal - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (stepOffsets[mid]! <= rem) lo = mid;
+      else hi = mid - 1;
+    }
+    const start = stepOffsets[lo]!;
+    const size = stepSizes[lo]!;
+    const frac = size > 0 ? Math.max(0, Math.min((rem - start) / size, 1)) : 0;
+    return { vi: cycle * realTotal + lo, frac };
+  }
+
   function resolvePeekSize(containerSize: number): number {
     if (variant === "full") return 0;
     if (typeof peekConfig === "number") return peekConfig;
@@ -126,12 +167,15 @@ export function carousel<T extends VListItem = VListItem>(
   }
 
   function scrollPositionForVirtual(vi: number): number {
-    return vi * stepSize;
+    if (realTotal <= 0 || lapSize <= 0) return 0;
+    const cycle = Math.floor(vi / realTotal);
+    const within = ((vi % realTotal) + realTotal) % realTotal;
+    return cycle * lapSize + (stepOffsets[within] ?? 0);
   }
 
   function virtualIndexAtScroll(pos: number): number {
-    if (stepSize <= 0) return 0;
-    return Math.round(pos / stepSize);
+    const { vi, frac } = decomposeScroll(pos);
+    return frac >= 0.5 ? vi + 1 : vi;
   }
 
   function getBaseVi(): number {
@@ -154,64 +198,100 @@ export function carousel<T extends VListItem = VListItem>(
     if (currentTotal === realTotal) return;
     const savedIndex = currentIndex;
     realTotal = currentTotal;
+    if (isVariableWidth) {
+      const rawSpec = storedCtx.rawSizeSpec;
+      const getSz = typeof rawSpec === "function"
+        ? (i: number) => (rawSpec as (index: number) => number)(i) + gapPx
+        : () => (rawSpec as number) + gapPx;
+      buildStepCache(Array.from({ length: realTotal }, (_, i) => getSz(i)));
+    } else {
+      buildStepCache(Array.from({ length: realTotal }, () => stepSizes[0] ?? stepSize));
+    }
     virtualTotal = realTotal * CYCLES;
-    lapSize = stepSize * realTotal;
     engineState.totalItems = virtualTotal;
     if (realTotal > 1) {
       const safeIndex = savedIndex < realTotal ? savedIndex : 0;
       currentIndex = safeIndex;
-      // Recenter on the middle cycle through the handler so baseOffset/scrollTop
-      // stay consistent. realTotal is already updated, so the re-entrant
-      // onAfterScroll triggered by this write returns early.
-      storedCtx.scrollTo((MIDDLE_CYCLE * realTotal + safeIndex) * stepSize);
+      storedCtx.scrollTo(scrollPositionForVirtual(MIDDLE_CYCLE * realTotal + safeIndex));
     }
   }
 
   function updateItemLayout(): void {
-    if (!storedCtx || realTotal <= 0 || !layoutEngine) return;
+    if (!storedCtx || realTotal <= 0) return;
+    if (!layoutEngine && !isVariableWidth) return;
+
     const content = storedCtx.dom.content;
     const children = content.children;
     const pos = engineState.scrollPosition;
-    const focalVi = Math.floor(pos / stepSize);
-    const frac = stepSize > 0 ? (pos / stepSize) - focalVi : 0;
-    const prop = isX ? "width" : "height";
-    const anchor = pos + layoutEngine!.getAnchorOffset(focalVi, frac);
-    // Item offsets are computed in absolute logical space; subtract baseOffset to
-    // land them inside the bounded runway. baseOffset is 0 in native mode, so this
-    // is a no-op there.
     const baseOffset = engineState.baseOffset;
+    const prop = isX ? "width" : "height";
+    const { vi: focalVi, frac } = decomposeScroll(pos);
+    const baseCycle = focalVi - ((focalVi % realTotal + realTotal) % realTotal);
 
-    const baseCycle = focalVi - (focalVi % realTotal);
+    if (layoutEngine) {
+      const anchor = pos + layoutEngine.getAnchorOffset(focalVi, frac);
 
-    for (let i = 0; i < children.length; i++) {
-      const el = children[i] as HTMLElement;
-      const idx = el.dataset.index;
-      if (idx === undefined) continue;
-      const logical = parseInt(idx, 10);
-      let vi = baseCycle + logical;
-      if (vi - focalVi > realTotal / 2) vi -= realTotal;
-      if (focalVi - vi > realTotal / 2) vi += realTotal;
+      for (let i = 0; i < children.length; i++) {
+        const el = children[i] as HTMLElement;
+        const idx = el.dataset.index;
+        if (idx === undefined) continue;
+        const logical = parseInt(idx, 10);
+        let vi = baseCycle + logical;
+        if (vi - focalVi > realTotal / 2) vi -= realTotal;
+        if (focalVi - vi > realTotal / 2) vi += realTotal;
 
-      const layout = layoutEngine!.getItemLayout(vi, focalVi, frac, anchor);
-      const roundedSize = Math.max(0, Math.round(layout.size));
-      const roundedOffset = Math.round(layout.offset - baseOffset);
+        const layout = layoutEngine.getItemLayout(vi, focalVi, frac, anchor);
+        const roundedSize = Math.max(0, Math.round(layout.size));
+        const roundedOffset = Math.round(layout.offset - baseOffset);
 
-      if (roundedSize <= 0) {
-        el.style.display = "none";
-        el.classList.remove(`${prefix}-item--focused`, `${prefix}-item--selected`);
-        el.removeAttribute("aria-selected");
-      } else {
-        el.style.display = "";
-        el.style[prop] = roundedSize + "px";
-        el.style.transform = isX
-          ? `translateX(${roundedOffset}px)`
-          : `translateY(${roundedOffset}px)`;
+        if (roundedSize <= 0) {
+          el.style.display = "none";
+          el.classList.remove(`${prefix}-item--focused`, `${prefix}-item--selected`);
+          el.removeAttribute("aria-selected");
+        } else {
+          el.style.display = "";
+          el.style[prop] = roundedSize + "px";
+          el.style.transform = isX
+            ? `translateX(${roundedOffset}px)`
+            : `translateY(${roundedOffset}px)`;
+        }
+
+        el.style.setProperty("--vlist-carousel-progress", layout.progress.toFixed(3));
+        el.style.setProperty("--vlist-carousel-offset", String(layout.relOffset));
+        el.style.setProperty("--vlist-carousel-role", layout.role);
+        el.style.setProperty("--vlist-carousel-width", roundedSize + "px");
       }
+    } else {
+      for (let i = 0; i < children.length; i++) {
+        const el = children[i] as HTMLElement;
+        const idx = el.dataset.index;
+        if (idx === undefined) continue;
+        const logical = parseInt(idx, 10);
+        let vi = baseCycle + logical;
+        if (vi - focalVi > realTotal / 2) vi -= realTotal;
+        if (focalVi - vi > realTotal / 2) vi += realTotal;
 
-      el.style.setProperty("--vlist-carousel-progress", layout.progress.toFixed(3));
-      el.style.setProperty("--vlist-carousel-offset", String(layout.relOffset));
-      el.style.setProperty("--vlist-carousel-role", layout.role);
-      el.style.setProperty("--vlist-carousel-width", roundedSize + "px");
+        const logIdx = logicalIndexOf(vi);
+        const itemSize = Math.max(0, Math.round((stepSizes[logIdx] ?? 0) - gapPx));
+        const absOffset = scrollPositionForVirtual(vi);
+        const roundedOffset = Math.round(absOffset - baseOffset);
+
+        if (itemSize <= 0) {
+          el.style.display = "none";
+        } else {
+          el.style.display = "";
+          el.style[prop] = itemSize + "px";
+          el.style.transform = isX
+            ? `translateX(${roundedOffset}px)`
+            : `translateY(${roundedOffset}px)`;
+        }
+
+        const relOffset = vi - focalVi;
+        el.style.setProperty("--vlist-carousel-progress", relOffset === 0 ? "0.000" : "1.000");
+        el.style.setProperty("--vlist-carousel-offset", String(relOffset));
+        el.style.setProperty("--vlist-carousel-role", "large");
+        el.style.setProperty("--vlist-carousel-width", itemSize + "px");
+      }
     }
   }
 
@@ -260,22 +340,25 @@ export function carousel<T extends VListItem = VListItem>(
           slots: variantSlots.slots,
           focalSlot: variantSlots.focalSlot,
           containerSize,
-          gap: config?.gap ?? 0,
+          gap: gapPx,
         });
         stepSize = layoutEngine.stepSize;
+        buildStepCache(Array.from({ length: Math.max(1, realTotal) }, () => stepSize));
+        isVariableWidth = false;
+      } else if (typeof ctx.rawSizeSpec === "function") {
+        const rawFn = ctx.rawSizeSpec as (index: number) => number;
+        buildStepCache(Array.from({ length: realTotal }, (_, i) => rawFn(i) + gapPx));
+        stepSize = stepSizes[0] ?? baseItemSize;
+        isVariableWidth = true;
       } else {
         stepSize = baseItemSize;
+        buildStepCache(Array.from({ length: Math.max(1, realTotal) }, () => stepSize));
+        isVariableWidth = false;
       }
-      lapSize = stepSize * realTotal;
       virtualTotal = realTotal * CYCLES;
       currentIndex = resolveIndex(initialIndex);
 
       // ── Virtual scroll window ─────────────────────────────────────
-      // Map virtual indices to real items via modulo. The render
-      // pipeline sees virtualTotal items but public API stays at
-      // realTotal. We hook getTotalSize and getOffset on the sizeCache
-      // so content height reflects the virtual window, and we override
-      // getItemFn so virtual indices resolve to real items.
 
       if (realTotal > 1) {
         ctx.setGetItemFn((i: number): T | undefined => {
@@ -283,12 +366,28 @@ export function carousel<T extends VListItem = VListItem>(
           return ctx.getItems()[logical];
         });
 
-        sizeCache.getTotalSize = (): number => virtualTotal * stepSize;
-        sizeCache.getOffset = (index: number): number => index * stepSize;
-        sizeCache.getSize = (_index: number): number => stepSize;
+        sizeCache.getTotalSize = (): number => lapSize * CYCLES;
+        sizeCache.getOffset = (index: number): number => scrollPositionForVirtual(index);
+        sizeCache.getSize = (index: number): number => {
+          const logical = logicalIndexOf(index);
+          return stepSizes[logical] ?? stepSizes[0] ?? 0;
+        };
         sizeCache.indexAtOffset = (offset: number): number => {
-          if (stepSize <= 0) return 0;
-          return Math.max(0, Math.min(Math.floor(offset / stepSize), virtualTotal - 1));
+          if (lapSize <= 0) return 0;
+          const cycle = Math.floor(offset / lapSize);
+          const rem = offset - cycle * lapSize;
+          if (!isVariableWidth) {
+            const s = stepSizes[0] ?? 1;
+            return Math.max(0, Math.min(cycle * realTotal + Math.floor(rem / s), virtualTotal - 1));
+          }
+          let lo = 0;
+          let hi = realTotal - 1;
+          while (lo < hi) {
+            const mid = (lo + hi + 1) >> 1;
+            if (stepOffsets[mid]! <= rem) lo = mid;
+            else hi = mid - 1;
+          }
+          return Math.max(0, Math.min(cycle * realTotal + lo, virtualTotal - 1));
         };
         sizeCache.getTotal = (): number => virtualTotal;
 
@@ -540,8 +639,8 @@ export function carousel<T extends VListItem = VListItem>(
         intendedVi = -1;
         if (!snapEnabled || !storedCtx || realTotal <= 1) return;
         const p = engineState.scrollPosition;
-        const nearestVi = Math.round(p / stepSize);
-        const snapTarget = nearestVi * stepSize;
+        const nearestVi = virtualIndexAtScroll(p);
+        const snapTarget = scrollPositionForVirtual(nearestVi);
         if (Math.abs(p - snapTarget) > 1) {
           currentIndex = logicalIndexOf(nearestVi);
           smoothScrollTo(snapTarget, snapDuration);

--- a/src/plugins/carousel/plugin.ts
+++ b/src/plugins/carousel/plugin.ts
@@ -21,18 +21,18 @@ import type { VListPlugin, PluginContext } from "../../core/types";
 import type { EngineState } from "../../core/state";
 import type { SizeCache } from "../../core/sizes";
 import { createLayoutEngine } from "./engine";
-import type { SlotConfig } from "./presets";
+import type { SlotConfig, SlotConfigResolver } from "./presets";
 import { resolvePreset } from "./presets";
 
 // =============================================================================
 // Config
 // =============================================================================
 
-export type CarouselVariant = "static" | "full" | "hero" | "hero-center" | "multi" | "uncontained" | "multi-aspect" | "free";
+export type CarouselVariant = "static" | "full" | "hero" | "hero-center" | "multi" | "uncontained" | "multi-aspect" | "free" | (string & {});
 export type CarouselDirection = "auto" | "forward" | "backward";
 
 export interface CarouselPluginConfig {
-  variant?: CarouselVariant | SlotConfig;
+  variant?: CarouselVariant | SlotConfig | SlotConfigResolver;
   snap?: boolean;
   snapDuration?: number;
   peek?: number | string | "auto";
@@ -62,6 +62,31 @@ const MIDDLE_CYCLE = 50;
 const REBASE_THRESHOLD = 10;
 
 // =============================================================================
+// Variant normalisation
+// =============================================================================
+
+interface NormalizedVariant {
+  variant: string;
+  resolveSlots: SlotConfigResolver;
+}
+
+function normalizeVariant(
+  input: CarouselVariant | SlotConfig | SlotConfigResolver,
+): NormalizedVariant {
+  if (typeof input === "function") {
+    return { variant: "custom", resolveSlots: input };
+  }
+  if (typeof input === "object") {
+    const slots = input as SlotConfig;
+    return { variant: "custom", resolveSlots: () => slots };
+  }
+  return {
+    variant: input,
+    resolveSlots: (containerSize, peek) => resolvePreset(input, containerSize, peek),
+  };
+}
+
+// =============================================================================
 // Factory
 // =============================================================================
 
@@ -69,9 +94,7 @@ export function carousel<T extends VListItem = VListItem>(
   config?: CarouselPluginConfig,
 ): VListPlugin<T> {
   const variantConfig = config?.variant ?? "full";
-  const isCustomPreset = typeof variantConfig === "object";
-  const variant: string = isCustomPreset ? "custom" : variantConfig;
-  const customSlots: SlotConfig | null = isCustomPreset ? variantConfig : null;
+  const { variant, resolveSlots } = normalizeVariant(variantConfig);
   const snapEnabled = config?.snap ?? (variant !== "free");
   const snapDuration = config?.snapDuration ?? 400;
   const initialIndex = config?.initialIndex ?? 0;
@@ -158,7 +181,6 @@ export function carousel<T extends VListItem = VListItem>(
   }
 
   function resolvePeekSize(containerSize: number): number {
-    if (variant === "full") return 0;
     if (typeof peekConfig === "number") return peekConfig;
     if (typeof peekConfig === "string" && peekConfig.endsWith("%")) {
       return Math.round(containerSize * parseFloat(peekConfig) / 100);
@@ -335,7 +357,7 @@ export function carousel<T extends VListItem = VListItem>(
       const baseItemSize = realTotal > 0 ? sizeCache.getSize(0) : 0;
       const containerSize = engineState.containerSize;
       const peekResolved = resolvePeekSize(containerSize);
-      const variantSlots = customSlots ?? resolvePreset(variant, containerSize, peekResolved);
+      const variantSlots = resolveSlots(containerSize, peekResolved);
       if (variantSlots) {
         layoutEngine = createLayoutEngine({
           slots: variantSlots.slots,

--- a/src/plugins/carousel/plugin.ts
+++ b/src/plugins/carousel/plugin.ts
@@ -262,14 +262,6 @@ export function carousel<T extends VListItem = VListItem>(
         el.style.setProperty("--vlist-carousel-width", roundedSize + "px");
       }
     } else {
-      const containerSz = engineState.containerSize;
-      const focalLogIdx = logicalIndexOf(focalVi);
-      const nextLogIdx = logicalIndexOf(focalVi + 1);
-      const focalStep = stepSizes[focalLogIdx] ?? 0;
-      const nextStep = stepSizes[nextLogIdx] ?? 0;
-      const interpItem = (focalStep + frac * (nextStep - focalStep)) - gapPx;
-      const centerShift = (containerSz - Math.max(0, interpItem)) / 2;
-
       for (let i = 0; i < children.length; i++) {
         const el = children[i] as HTMLElement;
         const idx = el.dataset.index;
@@ -282,7 +274,7 @@ export function carousel<T extends VListItem = VListItem>(
         const logIdx = logicalIndexOf(vi);
         const itemSize = Math.max(0, Math.round((stepSizes[logIdx] ?? 0) - gapPx));
         const absOffset = scrollPositionForVirtual(vi);
-        const roundedOffset = Math.round(absOffset - baseOffset + centerShift);
+        const roundedOffset = Math.round(absOffset - baseOffset);
 
         if (itemSize <= 0) {
           el.style.display = "none";

--- a/src/plugins/carousel/plugin.ts
+++ b/src/plugins/carousel/plugin.ts
@@ -262,6 +262,14 @@ export function carousel<T extends VListItem = VListItem>(
         el.style.setProperty("--vlist-carousel-width", roundedSize + "px");
       }
     } else {
+      const containerSz = engineState.containerSize;
+      const focalLogIdx = logicalIndexOf(focalVi);
+      const nextLogIdx = logicalIndexOf(focalVi + 1);
+      const focalStep = stepSizes[focalLogIdx] ?? 0;
+      const nextStep = stepSizes[nextLogIdx] ?? 0;
+      const interpItem = (focalStep + frac * (nextStep - focalStep)) - gapPx;
+      const centerShift = (containerSz - Math.max(0, interpItem)) / 2;
+
       for (let i = 0; i < children.length; i++) {
         const el = children[i] as HTMLElement;
         const idx = el.dataset.index;
@@ -274,7 +282,7 @@ export function carousel<T extends VListItem = VListItem>(
         const logIdx = logicalIndexOf(vi);
         const itemSize = Math.max(0, Math.round((stepSizes[logIdx] ?? 0) - gapPx));
         const absOffset = scrollPositionForVirtual(vi);
-        const roundedOffset = Math.round(absOffset - baseOffset);
+        const roundedOffset = Math.round(absOffset - baseOffset + centerShift);
 
         if (itemSize <= 0) {
           el.style.display = "none";
@@ -287,7 +295,8 @@ export function carousel<T extends VListItem = VListItem>(
         }
 
         const relOffset = vi - focalVi;
-        el.style.setProperty("--vlist-carousel-progress", relOffset === 0 ? "0.000" : "1.000");
+        const progress = Math.min(1, Math.abs(relOffset) + (relOffset === 0 ? frac : 0));
+        el.style.setProperty("--vlist-carousel-progress", progress.toFixed(3));
         el.style.setProperty("--vlist-carousel-offset", String(relOffset));
         el.style.setProperty("--vlist-carousel-role", "large");
         el.style.setProperty("--vlist-carousel-width", itemSize + "px");

--- a/src/plugins/carousel/presets.ts
+++ b/src/plugins/carousel/presets.ts
@@ -61,6 +61,7 @@ export function resolvePreset(
     case "multi": return multi();
     case "uncontained": return uncontained(containerSize);
     case "full": return full();
+    case "multi-aspect":
     case "static":
     default: return null;
   }

--- a/src/plugins/carousel/presets.ts
+++ b/src/plugins/carousel/presets.ts
@@ -1,9 +1,12 @@
 /**
  * vlist v2 — Carousel Presets
  *
- * Each preset maps a variant name to a slot configuration
- * for the layout engine. Adding a new variant = adding a
- * new function to this file.
+ * Registry-based preset system. Each preset is a `SlotConfigResolver`
+ * registered by name. Built-in presets are pre-registered; users can
+ * add or override presets via `registerPreset()`.
+ *
+ * Returning `null` from a resolver means "no layout engine" — the
+ * plugin falls back to variable-width item rendering.
  */
 
 export interface SlotConfig {
@@ -11,18 +14,51 @@ export interface SlotConfig {
   focalSlot: number;
 }
 
-export function full(): SlotConfig {
-  return { slots: [1.0], focalSlot: 0 };
+/** Resolves a variant name to a slot configuration (or null for no-engine mode). */
+export type SlotConfigResolver = (containerSize: number, peek: number) => SlotConfig | null;
+
+// =============================================================================
+// Registry
+// =============================================================================
+
+const presetRegistry = new Map<string, SlotConfigResolver>();
+
+/** Register a named preset. Overwrites any existing preset with the same name. */
+export function registerPreset(name: string, resolver: SlotConfigResolver): void {
+  presetRegistry.set(name, resolver);
 }
 
-export function hero(containerSize: number, peek: number): SlotConfig {
+/** Get a preset resolver by name, or undefined if not registered. */
+export function getPreset(name: string): SlotConfigResolver | undefined {
+  return presetRegistry.get(name);
+}
+
+/** Resolve a named preset to a SlotConfig. Returns null if the name is unknown or the resolver returns null. */
+export function resolvePreset(
+  variant: string,
+  containerSize: number,
+  peek: number,
+): SlotConfig | null {
+  const resolver = presetRegistry.get(variant);
+  return resolver ? resolver(containerSize, peek) : null;
+}
+
+// =============================================================================
+// Built-in preset resolvers
+// =============================================================================
+
+export const full: SlotConfigResolver = () => {
+  return { slots: [1.0], focalSlot: 0 };
+};
+
+export const hero: SlotConfigResolver = (containerSize, peek) => {
   return {
     slots: [(containerSize - peek) / containerSize, peek / containerSize],
     focalSlot: 0,
   };
-}
+};
 
-export function heroCenter(containerSize: number, peek: number): SlotConfig {
+export const heroCenter: SlotConfigResolver = (containerSize, peek) => {
   return {
     slots: [
       peek / containerSize,
@@ -31,38 +67,31 @@ export function heroCenter(containerSize: number, peek: number): SlotConfig {
     ],
     focalSlot: 1,
   };
-}
+};
 
-export function multi(): SlotConfig {
+export const multi: SlotConfigResolver = () => {
   const large = 0.4;
   const medium = 0.3;
   const small = 0.2;
   const tiny = 1 - large - medium - small;
   return { slots: [large, medium, small, tiny], focalSlot: 0 };
-}
+};
 
-export function uncontained(containerSize: number): SlotConfig {
+export const uncontained: SlotConfigResolver = (containerSize) => {
   const count = Math.max(2, Math.floor(containerSize / (containerSize * 0.33)));
   const ratio = 1 / count;
   return {
     slots: Array.from({ length: count }, () => ratio),
     focalSlot: 0,
   };
-}
+};
 
-export function resolvePreset(
-  variant: string,
-  containerSize: number,
-  peek: number,
-): SlotConfig | null {
-  switch (variant) {
-    case "hero": return hero(containerSize, peek);
-    case "hero-center": return heroCenter(containerSize, peek);
-    case "multi": return multi();
-    case "uncontained": return uncontained(containerSize);
-    case "full": return full();
-    case "multi-aspect":
-    case "static":
-    default: return null;
-  }
-}
+// =============================================================================
+// Register built-ins
+// =============================================================================
+
+registerPreset("full", full);
+registerPreset("hero", hero);
+registerPreset("hero-center", heroCenter);
+registerPreset("multi", multi);
+registerPreset("uncontained", uncontained);

--- a/test/plugins/carousel/engine.test.ts
+++ b/test/plugins/carousel/engine.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Carousel layout engine — geometric continuity.
+ *
+ * Issue 023: the visible "chop just before the final position" was an 8px
+ * (== gap) discontinuity in every item's on-screen offset at the focal-boundary
+ * flip. The old gap term `s + (s > 0 ? gap : 0)` kept the full gap until the
+ * exiting item's size hit exactly 0, then dropped it instantly. The fix fades
+ * the gap with the item's size (`gapFor`). These tests sweep the scroll position
+ * across a focal-boundary flip and assert every visible item moves continuously
+ * (no single-step jump anywhere near the gap size).
+ */
+import { describe, it, expect } from "bun:test";
+import { createLayoutEngine } from "../../../src/plugins/carousel/engine";
+
+/**
+ * Replicate the carousel plugin's per-frame layout resolution so the test
+ * measures the same on-screen offset the user sees (updateItemLayout):
+ *   focalVi = floor(pos / stepSize)
+ *   frac    = pos / stepSize - focalVi
+ *   anchor  = pos + getAnchorOffset(focalVi, frac)
+ *   onScreen(vi) = getItemLayout(vi, focalVi, frac, anchor).offset - pos
+ */
+function onScreenLeft(
+  engine: ReturnType<typeof createLayoutEngine>,
+  pos: number,
+  vi: number,
+): number {
+  const focalVi = Math.floor(pos / engine.stepSize);
+  const frac = pos / engine.stepSize - focalVi;
+  const anchor = pos + engine.getAnchorOffset(focalVi, frac);
+  return engine.getItemLayout(vi, focalVi, frac, anchor).offset - pos;
+}
+
+/** Max single-step jump of a tracked item's on-screen left edge over a sweep. */
+function maxJump(
+  engine: ReturnType<typeof createLayoutEngine>,
+  fromPos: number,
+  toPos: number,
+  step: number,
+  vi: number,
+): number {
+  let prev = onScreenLeft(engine, fromPos, vi);
+  let max = 0;
+  for (let pos = fromPos + step; pos <= toPos; pos += step) {
+    const cur = onScreenLeft(engine, pos, vi);
+    max = Math.max(max, Math.abs(cur - prev));
+    prev = cur;
+  }
+  return max;
+}
+
+describe("carousel engine — gap continuity across focal-boundary flip", () => {
+  it("hero-center: every visible item's on-screen offset is continuous through a flip", () => {
+    const gap = 8;
+    const engine = createLayoutEngine({
+      slots: [0.15, 0.7, 0.15],
+      focalSlot: 1,
+      containerSize: 692,
+      gap,
+    });
+
+    // Sweep across one full step boundary at 1px resolution. The flip happens
+    // at pos = N * stepSize where focalVi increments and an adjacent item's
+    // size crosses 0. Centre the sweep on a boundary deep in the middle cycle.
+    const boundary = 50 * engine.stepSize;
+    const from = boundary - engine.stepSize;
+    const to = boundary + engine.stepSize;
+
+    // Track every item that can be visible in the 3-slot window around focal.
+    for (let rel = -3; rel <= 3; rel++) {
+      const vi = 50 + rel;
+      const jump = maxJump(engine, from, to, 1, vi);
+      // Smooth motion ~= 1px/step. The old binary gap injected an 8px jump.
+      // Allow generous slack (3px) for size-interpolation curvature while
+      // still failing hard on any gap-sized discontinuity.
+      expect(jump).toBeLessThan(3);
+    }
+  });
+
+  it("hero (focalSlot 0): on-screen offsets continuous through a flip with gap", () => {
+    const gap = 12;
+    const engine = createLayoutEngine({
+      slots: [0.8, 0.2],
+      focalSlot: 0,
+      containerSize: 800,
+      gap,
+    });
+
+    const boundary = 50 * engine.stepSize;
+    const from = boundary - engine.stepSize;
+    const to = boundary + engine.stepSize;
+
+    for (let rel = -1; rel <= 2; rel++) {
+      const vi = 50 + rel;
+      const jump = maxJump(engine, from, to, 1, vi);
+      expect(jump).toBeLessThan(3);
+    }
+  });
+
+  it("rest layout is unchanged by the gap taper (visible items >= gap at rest)", () => {
+    const gap = 8;
+    const engine = createLayoutEngine({
+      slots: [0.15, 0.7, 0.15],
+      focalSlot: 1,
+      containerSize: 692,
+      gap,
+    });
+
+    // At rest (frac = 0) the gap taper is a no-op: every visible slot width is
+    // >= gap, so gapFor returns the full gap. Focal sits one peek + one gap in.
+    const restPos = 50 * engine.stepSize;
+    const focalLeft = onScreenLeft(engine, restPos, 50);
+    const peek = engine.slotWidths[0]!;
+    expect(focalLeft).toBeCloseTo(peek + gap, 5);
+  });
+});

--- a/test/plugins/carousel/plugin.test.ts
+++ b/test/plugins/carousel/plugin.test.ts
@@ -2120,3 +2120,172 @@ describeCarousel("carousel — goTo single item", () => {
     cleanup();
   });
 });
+
+// =============================================================================
+// Variable-width (multi-aspect) — per-item step sizes
+// =============================================================================
+
+describeCarousel("carousel — Variable-width (multi-aspect)", () => {
+  const WIDTHS = [300, 200, 400, 150, 250];
+
+  function createVariableWidthContext() {
+    const items = createTestItems(5);
+    const mockCtx = createPluginMockContext<TestItem>(items, {
+      containerWidth: 800,
+      containerHeight: 400,
+      itemSize: (index: number) => WIDTHS[index % WIDTHS.length]!,
+      isX: true,
+    });
+    return mockCtx;
+  }
+
+  it("should accept multi-aspect variant", () => {
+    const { ctx, methods, cleanup } = createVariableWidthContext();
+
+    carousel({ variant: "multi-aspect" }).setup!(ctx);
+
+    const getState = methods.get("getCarouselState") as Function;
+    expect(getState().index).toBe(0);
+
+    cleanup();
+  });
+
+  it("sizeCache.getSize should return per-item step sizes", () => {
+    const { ctx, cleanup } = createVariableWidthContext();
+
+    carousel({ variant: "multi-aspect", gap: 8 }).setup!(ctx);
+
+    for (let i = 0; i < 5; i++) {
+      expect(ctx.sizeCache.getSize(i)).toBe(WIDTHS[i]! + 8);
+    }
+
+    cleanup();
+  });
+
+  it("sizeCache.getSize should wrap for virtual indices", () => {
+    const { ctx, cleanup } = createVariableWidthContext();
+
+    carousel({ variant: "multi-aspect", gap: 8 }).setup!(ctx);
+
+    expect(ctx.sizeCache.getSize(5)).toBe(WIDTHS[0]! + 8);
+    expect(ctx.sizeCache.getSize(6)).toBe(WIDTHS[1]! + 8);
+
+    cleanup();
+  });
+
+  it("sizeCache.getOffset should use prefix sums", () => {
+    const { ctx, cleanup } = createVariableWidthContext();
+    const gap = 8;
+
+    carousel({ variant: "multi-aspect", gap }).setup!(ctx);
+
+    expect(ctx.sizeCache.getOffset(0)).toBe(0);
+    expect(ctx.sizeCache.getOffset(1)).toBe(WIDTHS[0]! + gap);
+    expect(ctx.sizeCache.getOffset(2)).toBe(WIDTHS[0]! + WIDTHS[1]! + gap * 2);
+
+    cleanup();
+  });
+
+  it("next/prev should cycle correctly with variable widths", () => {
+    const { ctx, methods, cleanup } = createVariableWidthContext();
+
+    carousel({ variant: "multi-aspect" }).setup!(ctx);
+
+    const next = methods.get("next") as Function;
+    const prev = methods.get("prev") as Function;
+    const getState = methods.get("getCarouselState") as Function;
+
+    const fwd: number[] = [];
+    for (let i = 0; i < 7; i++) {
+      fwd.push(getState().index);
+      next();
+    }
+    expect(fwd).toEqual([0, 1, 2, 3, 4, 0, 1]);
+
+    const bwd: number[] = [];
+    for (let i = 0; i < 4; i++) {
+      bwd.push(getState().index);
+      prev();
+    }
+    expect(bwd).toEqual([2, 1, 0, 4]);
+
+    cleanup();
+  });
+
+  it("goTo should work with variable widths", () => {
+    const { ctx, methods, cleanup } = createVariableWidthContext();
+
+    carousel({ variant: "multi-aspect" }).setup!(ctx);
+
+    const goTo = methods.get("goTo") as Function;
+    const getState = methods.get("getCarouselState") as Function;
+
+    goTo(3);
+    expect(getState().index).toBe(3);
+
+    goTo(0, { direction: "forward" });
+    expect(getState().index).toBe(0);
+
+    cleanup();
+  });
+
+  it("indexAtOffset should binary-search for variable widths", () => {
+    const { ctx, cleanup } = createVariableWidthContext();
+    const gap = 8;
+
+    carousel({ variant: "multi-aspect", gap }).setup!(ctx);
+
+    expect(ctx.sizeCache.indexAtOffset(0)).toBe(0);
+    expect(ctx.sizeCache.indexAtOffset(WIDTHS[0]! + gap)).toBe(1);
+    expect(ctx.sizeCache.indexAtOffset(WIDTHS[0]! + WIDTHS[1]! + gap * 2)).toBe(2);
+
+    cleanup();
+  });
+
+  it("updateItemLayout should set per-item widths in natural-width mode", () => {
+    const { ctx, dom, cleanup } = createVariableWidthContext();
+    const gap = 8;
+
+    const plugin = carousel({ variant: "multi-aspect", gap });
+    plugin.setup!(ctx);
+    if (plugin.hooks?.onCommit) plugin.hooks.onCommit();
+
+    const els = addRenderedItems(dom.content, [0, 1, 2]);
+    const es = ctx.getState();
+
+    const totalLap = WIDTHS.reduce((a, b) => a + b, 0) + gap * 5;
+    es.scrollPosition = 50 * totalLap;
+    plugin.hooks!.onAfterScroll!(es.scrollPosition);
+
+    const w0 = parseInt(els[0].style.width);
+    const w1 = parseInt(els[1].style.width);
+    const w2 = parseInt(els[2].style.width);
+
+    expect(w0).toBe(WIDTHS[0]!);
+    expect(w1).toBe(WIDTHS[1]!);
+    expect(w2).toBe(WIDTHS[2]!);
+
+    cleanup();
+  });
+
+  it("uniform preset still works after refactor (backward compat)", () => {
+    const items = createTestItems(5);
+    const { ctx, cleanup } = createPluginMockContext<TestItem>(items, {
+      containerWidth: 800,
+      containerHeight: 400,
+      itemSize: 400,
+      isX: true,
+    });
+
+    carousel({ variant: "hero", peek: 56 }).setup!(ctx);
+
+    const stepSz = 800 - 56;
+    expect(ctx.sizeCache.getSize(0)).toBe(stepSz);
+    expect(ctx.sizeCache.getSize(1)).toBe(stepSz);
+    expect(ctx.sizeCache.getOffset(0)).toBe(0);
+    expect(ctx.sizeCache.getOffset(1)).toBe(stepSz);
+    expect(ctx.sizeCache.getOffset(3)).toBe(stepSz * 3);
+
+    cleanup();
+  });
+});

--- a/test/plugins/carousel/plugin.test.ts
+++ b/test/plugins/carousel/plugin.test.ts
@@ -1708,6 +1708,28 @@ describeCarousel("carousel — Presets", () => {
 });
 
 // =============================================================================
+// normalizeVariant — SlotConfig object branch
+// =============================================================================
+
+describeCarousel("carousel — normalizeVariant SlotConfig object", () => {
+  it("carousel accepts a SlotConfig object and uses the layout engine", () => {
+    const items = createTestItems(10);
+    const { ctx, methods, cleanup } = createPluginMockContext<TestItem>(items, {
+      containerWidth: 800,
+      containerHeight: 400,
+      itemSize: 400,
+      isX: true,
+    });
+
+    carousel({ variant: { slots: [0.7, 0.3], focalSlot: 0 } }).setup!(ctx);
+    const getState = methods.get("getCarouselState") as Function;
+    expect(getState().index).toBe(0);
+
+    cleanup();
+  });
+});
+
+// =============================================================================
 // syncItemCount — item mutations trigger resync on scroll
 // =============================================================================
 
@@ -1755,6 +1777,33 @@ describeCarousel("carousel — syncItemCount", () => {
     plugin.hooks!.onAfterScroll!(ctx.getState().scrollPosition);
 
     const getState = methods.get("getCarouselState") as Function;
+    expect(getState().index).toBe(0);
+
+    cleanup();
+  });
+
+  it("syncItemCount rebuilds variable-width step cache when items are added", () => {
+    const items = createTestItems(5);
+    const widths = [200, 300, 250, 180, 220, 350, 280];
+    const { ctx, methods, cleanup } = createPluginMockContext<TestItem>(items, {
+      containerWidth: 800,
+      containerHeight: 400,
+      itemSize: (i: number) => widths[i % widths.length],
+      isX: true,
+    });
+
+    const plugin = carousel({ variant: "multi-aspect" });
+    plugin.setup!(ctx);
+    if (plugin.hooks?.onCommit) plugin.hooks.onCommit();
+
+    const getState = methods.get("getCarouselState") as Function;
+    expect(getState().index).toBe(0);
+
+    items.push({ id: 5, name: "Item 5" });
+    items.push({ id: 6, name: "Item 6" });
+    plugin.hooks!.onAfterScroll!(ctx.getState().scrollPosition);
+
+    expect(ctx.getItems().length).toBe(7);
     expect(getState().index).toBe(0);
 
     cleanup();

--- a/test/plugins/carousel/plugin.test.ts
+++ b/test/plugins/carousel/plugin.test.ts
@@ -16,7 +16,8 @@ import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import type { VListItem } from "../../../src/types";
 import { createPluginMockContext } from "../../helpers/plugin-context";
-import { resolvePreset, multi, uncontained } from "../../../src/plugins/carousel/presets";
+import { resolvePreset, registerPreset, getPreset, multi, uncontained } from "../../../src/plugins/carousel/presets";
+import type { SlotConfigResolver } from "../../../src/plugins/carousel/presets";
 
 // Import will fail until plugin is created — that's expected for TDD
 let carousel: any;
@@ -1568,7 +1569,7 @@ describeCarousel("carousel — Normalized Scroll", () => {
 
 describeCarousel("carousel — Presets", () => {
   it("multi() returns 4 slots summing to 1.0", () => {
-    const cfg = multi();
+    const cfg = multi(800, 56)!;
     expect(cfg.slots).toHaveLength(4);
     const sum = cfg.slots.reduce((a, b) => a + b, 0);
     expect(Math.abs(sum - 1.0)).toBeLessThan(1e-10);
@@ -1576,7 +1577,7 @@ describeCarousel("carousel — Presets", () => {
   });
 
   it("uncontained() derives slot count from container size", () => {
-    const cfg = uncontained(900);
+    const cfg = uncontained(900, 0)!;
     expect(cfg.slots.length).toBeGreaterThanOrEqual(2);
     const sum = cfg.slots.reduce((a, b) => a + b, 0);
     expect(Math.abs(sum - 1.0)).toBeLessThan(1e-10);
@@ -1622,6 +1623,83 @@ describeCarousel("carousel — Presets", () => {
     });
 
     carousel({ variant: "uncontained" }).setup!(ctx);
+    const getState = methods.get("getCarouselState") as Function;
+    expect(getState().index).toBe(0);
+
+    cleanup();
+  });
+
+  it("registerPreset adds a custom preset accessible via resolvePreset", () => {
+    const custom: SlotConfigResolver = (containerSize) => ({
+      slots: [0.6, 0.4],
+      focalSlot: 0,
+    });
+    registerPreset("my-custom", custom);
+    const result = resolvePreset("my-custom", 800, 56);
+    expect(result).not.toBeNull();
+    expect(result!.slots).toEqual([0.6, 0.4]);
+  });
+
+  it("getPreset returns the registered resolver", () => {
+    const resolver = getPreset("hero");
+    expect(resolver).toBeDefined();
+    expect(typeof resolver).toBe("function");
+    const result = resolver!(800, 56);
+    expect(result).not.toBeNull();
+    expect(result!.focalSlot).toBe(0);
+  });
+
+  it("getPreset returns undefined for unregistered names", () => {
+    expect(getPreset("nonexistent-preset")).toBeUndefined();
+  });
+
+  it("registerPreset can override built-in presets", () => {
+    const original = resolvePreset("full", 800, 56);
+    expect(original!.slots).toEqual([1.0]);
+
+    registerPreset("full", () => ({ slots: [0.5, 0.5], focalSlot: 0 }));
+    const overridden = resolvePreset("full", 800, 56);
+    expect(overridden!.slots).toEqual([0.5, 0.5]);
+
+    // Restore
+    registerPreset("full", () => ({ slots: [1.0], focalSlot: 0 }));
+  });
+
+  it("carousel accepts a SlotConfigResolver function as variant", () => {
+    const items = createTestItems(10);
+    const { ctx, methods, cleanup } = createPluginMockContext<TestItem>(items, {
+      containerWidth: 800,
+      containerHeight: 400,
+      itemSize: 400,
+      isX: true,
+    });
+
+    const resolver: SlotConfigResolver = () => ({
+      slots: [0.7, 0.3],
+      focalSlot: 0,
+    });
+    carousel({ variant: resolver }).setup!(ctx);
+    const getState = methods.get("getCarouselState") as Function;
+    expect(getState().index).toBe(0);
+
+    cleanup();
+  });
+
+  it("carousel accepts an arbitrary string as variant via registerPreset", () => {
+    registerPreset("panorama", () => ({
+      slots: [0.8, 0.1, 0.1],
+      focalSlot: 0,
+    }));
+
+    const items = createTestItems(10);
+    const { ctx, methods, cleanup } = createPluginMockContext<TestItem>(items, {
+      containerWidth: 800,
+      containerHeight: 400,
+      itemSize: 400,
+      isX: true,
+    });
+
+    carousel({ variant: "panorama" }).setup!(ctx);
     const getState = methods.get("getCarouselState") as Function;
     expect(getState().index).toBe(0);
 


### PR DESCRIPTION
## Summary

- **Modular carousel preset registry** — replace hardcoded switch with `Map<string, SlotConfigResolver>`. `registerPreset()` / `getPreset()` / `resolvePreset()` public API. `variant` config accepts string, `SlotConfig`, or `SlotConfigResolver` function.
- **Carousel multi-aspect fixes** — per-item variable widths from native aspect ratios, focal centering, left-alignment per MD3 uncontained spec, gap fade at focal boundary.
- **Extensible `CarouselVariant` type** — accepts arbitrary strings via `(string & {})` for custom registered presets.
- **Exported built-in preset functions** — `full`, `hero`, `heroCenter`, `multi`, `uncontained` as named `SlotConfigResolver` exports.

## Test plan

- [x] Typecheck passes
- [x] 120 carousel tests pass (118 existing + 2 new)
- [x] Carousel plugin coverage: 99.78% lines, presets + engine 100%
- [x] Full suite: 3405 pass, 6 pre-existing failures (bounded scroll + groups integration)
- [x] Bundle sizes verified via `bun run size`