### PR TITLE
v2.5.0 — Carousel stylesheet, selectAll async fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ This changelog starts at v1.5.4, the first version published under the `vlist` p
 (April 2026). Earlier versions were published as `@floor/vlist` — see the
 [git history](https://github.com/floor/vlist/commits/main) for the full record.
 
+## [2.5.0] - 2026-06-09
+
+### Added
+
+- **Carousel stylesheet** (`vlist/styles/carousel`) — optional structural styles for carousel slides: media stabilization (no image "breathing" during transitions), overlay visibility driven by `--vlist-carousel-role-weight`, and text truncation. Uses `vlist-carousel-slide` BEM classes.
+- **`--vlist-carousel-focal-width`** CSS variable — constant per preset, the focal slot's pixel width. Locks media to the focal size with centered absolute positioning for a parallax-like pan effect.
+- **`--vlist-carousel-radius`** CSS variable — read by `vlist-carousel.css` to set slide border-radius.
+
+### Fixed
+
+- **`selectAll()` with async data** — previously only selected the ~25 loaded items. Now adds placeholder IDs for unloaded items, which are swapped for real IDs when data loads via `claimPlaceholderSelection`. Also applies to shift-click range selection across unloaded items.
+- **`selectAll()` placeholder visibility** — unloaded placeholder DOM elements now show the selected class immediately (via `itemStateFn` placeholder ID check), eliminating the brief visual flash before data arrives.
+- **Snapshot restore across selection modes** — `_seedSelection` now respects the selection mode. Switching from multiple (563 items selected) to single no longer visually restores the full multi-selection via snapshot.
+
 ## [2.4.2] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The virtual list library for every framework. Ultra efficient, batteries-included, and accessible with composable plugins — in 9.7 KB.
 
-**v2.4.2** — [Changelog](./CHANGELOG.md) · **New:** Bounded logical scroll model for 1M+ items (`scroll: { mode: "bounded" }`), `carousel()` plugin with infinite loop, snap, and focal scaling. `scale()` deprecated.
+**v2.5.0** — [Changelog](./CHANGELOG.md) · **New:** Bounded logical scroll model for 1M+ items (`scroll: { mode: "bounded" }`), `carousel()` plugin with infinite loop, snap, and focal scaling. `scale()` deprecated.
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/vlist)](https://bundlephobia.com/package/vlist)
@@ -103,8 +103,8 @@ const list = createVList({
 | `scrollbar()` | +2.0 KB | Custom scrollbar UI |
 | `grid()` | +2.4 KB | 2D grid layout |
 | `masonry()` | +4.0 KB | Pinterest-style masonry with lane-aware keyboard nav |
-| `carousel()` | +3.1 KB | Paged horizontal carousel with snap and keyboard nav |
-| `table()` | +5.7 KB | Data table with columns, resize, sort |
+| `carousel()` | +3.3 KB | Paged horizontal carousel with snap and keyboard nav |
+| `table()` | +5.8 KB | Data table with columns, resize, sort |
 | `tree()` | +5.0 KB | Collapsible tree with async loading and indent guides |
 | `page()` | +0.8 KB | Window-level scrolling |
 | `sortable()` | +3.0 KB | Drag-and-drop reordering with auto-scroll |

--- a/build.ts
+++ b/build.ts
@@ -125,6 +125,7 @@ async function build() {
   minifyCss("./src/styles/vlist-extras.css", "./dist/vlist-extras.css");
   minifyCss("./src/styles/vlist-tree.css", "./dist/vlist-tree.css");
   minifyCss("./src/styles/vlist-search.css", "./dist/vlist-search.css");
+  minifyCss("./src/styles/vlist-carousel.css", "./dist/vlist-carousel.css");
   const cssTime = performance.now() - cssStart;
   const cssFile = Bun.file("./dist/vlist.css");
   const cssSize = (cssFile.size / 1024).toFixed(1);

--- a/npm-readme.md
+++ b/npm-readme.md
@@ -2,7 +2,7 @@
 
 The virtual list library for every framework. Ultra efficient, batteries-included, and accessible with composable plugins — in 9.7 KB.
 
-**v2.4.2** — [Changelog](https://github.com/floor/vlist/blob/main/CHANGELOG.md) · **New:** Bounded logical scroll model for 1M+ items (`scroll: { mode: "bounded" }`), `carousel()` plugin with infinite loop, snap, and focal scaling. `scale()` deprecated.
+**v2.5.0** — [Changelog](https://github.com/floor/vlist/blob/main/CHANGELOG.md) · **New:** Bounded logical scroll model for 1M+ items (`scroll: { mode: "bounded" }`), `carousel()` plugin with infinite loop, snap, and focal scaling. `scale()` deprecated.
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/vlist)](https://bundlephobia.com/package/vlist)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "./styles/extras": "./dist/vlist-extras.css",
     "./styles/tree": "./dist/vlist-tree.css",
     "./styles/search": "./dist/vlist-search.css",
+    "./styles/carousel": "./dist/vlist-carousel.css",
     "./package.json": "./package.json"
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export type { TreePluginConfig, FlatNode } from "./plugins/tree";
 export { search, DEFAULT_SEARCH_TEXT } from "./plugins/search";
 export type { SearchPluginConfig, SearchText } from "./plugins/search";
 export { carousel, registerPreset, getPreset, resolvePreset, full, hero, heroCenter, multi, uncontained } from "./plugins/carousel";
-export type { CarouselPluginConfig, CarouselVariant, CarouselDirection, CarouselState, SlotConfig, SlotConfigResolver } from "./plugins/carousel";
+export type { CarouselPluginConfig, CarouselVariant, CarouselDirection, CarouselState, SlotConfig, SlotConfigResolver, TextFade } from "./plugins/carousel";
 /** @deprecated Use `scroll: { mode: "bounded" }` instead. Will be removed in vlist 3.0. */
 export { scale } from "./plugins/scale";
 export type { ScalePluginConfig } from "./plugins/scale";

--- a/src/plugins/carousel/index.ts
+++ b/src/plugins/carousel/index.ts
@@ -2,5 +2,5 @@ export { carousel } from "./plugin";
 export type { CarouselPluginConfig, CarouselVariant, CarouselDirection, CarouselState } from "./plugin";
 export { createLayoutEngine } from "./engine";
 export type { LayoutConfig, ItemLayout } from "./engine";
-export { resolvePreset, registerPreset, getPreset, full, hero, heroCenter, multi, uncontained } from "./presets";
-export type { SlotConfig, SlotConfigResolver } from "./presets";
+export { resolvePreset, registerPreset, getPreset, hasSlots, full, hero, heroCenter, multi, uncontained } from "./presets";
+export type { SlotConfig, NoEngineConfig, PresetResult, SlotConfigResolver, TextFade } from "./presets";

--- a/src/plugins/carousel/plugin.ts
+++ b/src/plugins/carousel/plugin.ts
@@ -21,8 +21,8 @@ import type { VListPlugin, PluginContext } from "../../core/types";
 import type { EngineState } from "../../core/state";
 import type { SizeCache } from "../../core/sizes";
 import { createLayoutEngine } from "./engine";
-import type { SlotConfig, SlotConfigResolver } from "./presets";
-import { resolvePreset } from "./presets";
+import type { SlotConfig, SlotConfigResolver, TextFade } from "./presets";
+import { resolvePreset, hasSlots } from "./presets";
 
 // =============================================================================
 // Config
@@ -118,6 +118,7 @@ export function carousel<T extends VListItem = VListItem>(
   let stepSizes: number[] = [];
   let stepOffsets: number[] = [];
   let isVariableWidth = false;
+  let textFade: TextFade = "role";
   const gapPx = config?.gap ?? 0;
 
   function resolveIndex(index: number): number {
@@ -278,9 +279,19 @@ export function carousel<T extends VListItem = VListItem>(
             : `translateY(${roundedOffset}px)`;
         }
 
+        let roleWeight: number;
+        if (textFade === "viewport") {
+          const vStart = Math.max(0, roundedOffset);
+          const vEnd = Math.min(engineState.containerSize, roundedOffset + roundedSize);
+          const vRatio = roundedSize > 0 ? Math.max(0, (vEnd - vStart) / roundedSize) : 0;
+          roleWeight = Math.min(1, Math.max(0, vRatio * 2 - 1));
+        } else {
+          roleWeight = layout.role === "large" ? 1 - layout.progress : 0;
+        }
         el.style.setProperty("--vlist-carousel-progress", layout.progress.toFixed(3));
         el.style.setProperty("--vlist-carousel-offset", String(layout.relOffset));
         el.style.setProperty("--vlist-carousel-role", layout.role);
+        el.style.setProperty("--vlist-carousel-role-weight", roleWeight.toFixed(3));
         el.style.setProperty("--vlist-carousel-width", roundedSize + "px");
       }
     } else {
@@ -310,9 +321,19 @@ export function carousel<T extends VListItem = VListItem>(
 
         const relOffset = vi - focalVi;
         const progress = Math.min(1, Math.abs(relOffset) + (relOffset === 0 ? frac : 0));
+        let roleWeight: number;
+        if (textFade === "viewport") {
+          const vStart = Math.max(0, roundedOffset);
+          const vEnd = Math.min(engineState.containerSize, roundedOffset + itemSize);
+          const vRatio = itemSize > 0 ? Math.max(0, (vEnd - vStart) / itemSize) : 0;
+          roleWeight = Math.min(1, Math.max(0, vRatio * 2 - 1));
+        } else {
+          roleWeight = 1 - progress;
+        }
         el.style.setProperty("--vlist-carousel-progress", progress.toFixed(3));
         el.style.setProperty("--vlist-carousel-offset", String(relOffset));
         el.style.setProperty("--vlist-carousel-role", "large");
+        el.style.setProperty("--vlist-carousel-role-weight", roleWeight.toFixed(3));
         el.style.setProperty("--vlist-carousel-width", itemSize + "px");
       }
     }
@@ -357,11 +378,12 @@ export function carousel<T extends VListItem = VListItem>(
       const baseItemSize = realTotal > 0 ? sizeCache.getSize(0) : 0;
       const containerSize = engineState.containerSize;
       const peekResolved = resolvePeekSize(containerSize);
-      const variantSlots = resolveSlots(containerSize, peekResolved);
-      if (variantSlots) {
+      const presetResult = resolveSlots(containerSize, peekResolved);
+      if (hasSlots(presetResult)) {
+        textFade = presetResult.textFade ?? "role";
         layoutEngine = createLayoutEngine({
-          slots: variantSlots.slots,
-          focalSlot: variantSlots.focalSlot,
+          slots: presetResult.slots,
+          focalSlot: presetResult.focalSlot,
           containerSize,
           gap: gapPx,
         });
@@ -369,11 +391,13 @@ export function carousel<T extends VListItem = VListItem>(
         buildStepCache(Array.from({ length: Math.max(1, realTotal) }, () => stepSize));
         isVariableWidth = false;
       } else if (typeof ctx.rawSizeSpec === "function") {
+        textFade = presetResult?.textFade ?? "viewport";
         const rawFn = ctx.rawSizeSpec as (index: number) => number;
         buildStepCache(Array.from({ length: realTotal }, (_, i) => rawFn(i) + gapPx));
         stepSize = stepSizes[0] ?? baseItemSize;
         isVariableWidth = true;
       } else {
+        textFade = presetResult?.textFade ?? "viewport";
         stepSize = baseItemSize;
         buildStepCache(Array.from({ length: Math.max(1, realTotal) }, () => stepSize));
         isVariableWidth = false;

--- a/src/plugins/carousel/plugin.ts
+++ b/src/plugins/carousel/plugin.ts
@@ -252,6 +252,8 @@ export function carousel<T extends VListItem = VListItem>(
     const { vi: focalVi, frac } = decomposeScroll(pos);
     const baseCycle = focalVi - ((focalVi % realTotal + realTotal) % realTotal);
 
+    const focalWidth = layoutEngine ? (layoutEngine.slotWidths[layoutEngine.focalSlot] ?? 0) : 0;
+
     if (layoutEngine) {
       const anchor = pos + layoutEngine.getAnchorOffset(focalVi, frac);
 
@@ -298,6 +300,7 @@ export function carousel<T extends VListItem = VListItem>(
         el.style.setProperty("--vlist-carousel-role", layout.role);
         el.style.setProperty("--vlist-carousel-role-weight", roleWeight.toFixed(3));
         el.style.setProperty("--vlist-carousel-width", roundedSize + "px");
+        el.style.setProperty("--vlist-carousel-focal-width", focalWidth + "px");
       }
     } else {
       for (let i = 0; i < children.length; i++) {

--- a/src/plugins/carousel/plugin.ts
+++ b/src/plugins/carousel/plugin.ts
@@ -281,7 +281,10 @@ export function carousel<T extends VListItem = VListItem>(
         }
 
         let roleWeight: number;
-        if (textFade === "viewport") {
+        if (textFade === "size") {
+          const maxSize = layoutEngine!.slotWidths[layoutEngine!.focalSlot] ?? 1;
+          roleWeight = Math.min(1, Math.max(0, roundedSize / maxSize));
+        } else if (textFade === "viewport") {
           const vpOffset = roundedOffset - scrollTop;
           const vStart = Math.max(0, vpOffset);
           const vEnd = Math.min(engineState.containerSize, vpOffset + roundedSize);
@@ -324,7 +327,7 @@ export function carousel<T extends VListItem = VListItem>(
         const relOffset = vi - focalVi;
         const progress = Math.min(1, Math.abs(relOffset) + (relOffset === 0 ? frac : 0));
         let roleWeight: number;
-        if (textFade === "viewport") {
+        if (textFade === "viewport" || textFade === "size") {
           const vpOffset = roundedOffset - scrollTop;
           const vStart = Math.max(0, vpOffset);
           const vEnd = Math.min(engineState.containerSize, vpOffset + itemSize);

--- a/src/plugins/carousel/plugin.ts
+++ b/src/plugins/carousel/plugin.ts
@@ -247,6 +247,7 @@ export function carousel<T extends VListItem = VListItem>(
     const children = content.children;
     const pos = engineState.scrollPosition;
     const baseOffset = engineState.baseOffset;
+    const scrollTop = Math.round(pos - baseOffset);
     const prop = isX ? "width" : "height";
     const { vi: focalVi, frac } = decomposeScroll(pos);
     const baseCycle = focalVi - ((focalVi % realTotal + realTotal) % realTotal);
@@ -281,10 +282,11 @@ export function carousel<T extends VListItem = VListItem>(
 
         let roleWeight: number;
         if (textFade === "viewport") {
-          const vStart = Math.max(0, roundedOffset);
-          const vEnd = Math.min(engineState.containerSize, roundedOffset + roundedSize);
+          const vpOffset = roundedOffset - scrollTop;
+          const vStart = Math.max(0, vpOffset);
+          const vEnd = Math.min(engineState.containerSize, vpOffset + roundedSize);
           const vRatio = roundedSize > 0 ? Math.max(0, (vEnd - vStart) / roundedSize) : 0;
-          roleWeight = Math.min(1, Math.max(0, vRatio * 2 - 1));
+          roleWeight = Math.min(1, vRatio);
         } else {
           roleWeight = layout.role === "large" ? 1 - layout.progress : 0;
         }
@@ -323,10 +325,11 @@ export function carousel<T extends VListItem = VListItem>(
         const progress = Math.min(1, Math.abs(relOffset) + (relOffset === 0 ? frac : 0));
         let roleWeight: number;
         if (textFade === "viewport") {
-          const vStart = Math.max(0, roundedOffset);
-          const vEnd = Math.min(engineState.containerSize, roundedOffset + itemSize);
+          const vpOffset = roundedOffset - scrollTop;
+          const vStart = Math.max(0, vpOffset);
+          const vEnd = Math.min(engineState.containerSize, vpOffset + itemSize);
           const vRatio = itemSize > 0 ? Math.max(0, (vEnd - vStart) / itemSize) : 0;
-          roleWeight = Math.min(1, Math.max(0, vRatio * 2 - 1));
+          roleWeight = Math.min(1, vRatio);
         } else {
           roleWeight = 1 - progress;
         }

--- a/src/plugins/carousel/presets.ts
+++ b/src/plugins/carousel/presets.ts
@@ -6,16 +6,28 @@
  * add or override presets via `registerPreset()`.
  *
  * Returning `null` from a resolver means "no layout engine" — the
- * plugin falls back to variable-width item rendering.
+ * plugin falls back to variable-width item rendering with default
+ * textFade: "viewport".
  */
+
+export type TextFade = "role" | "viewport";
 
 export interface SlotConfig {
   slots: number[];
   focalSlot: number;
+  textFade?: TextFade;
 }
 
-/** Resolves a variant name to a slot configuration (or null for no-engine mode). */
-export type SlotConfigResolver = (containerSize: number, peek: number) => SlotConfig | null;
+/** Config without a layout engine — just behavioral options. */
+export interface NoEngineConfig {
+  textFade?: TextFade;
+}
+
+/** What a preset resolver can return. */
+export type PresetResult = SlotConfig | NoEngineConfig | null;
+
+/** Resolves a variant name to a preset configuration. */
+export type SlotConfigResolver = (containerSize: number, peek: number) => PresetResult;
 
 // =============================================================================
 // Registry
@@ -33,14 +45,19 @@ export function getPreset(name: string): SlotConfigResolver | undefined {
   return presetRegistry.get(name);
 }
 
-/** Resolve a named preset to a SlotConfig. Returns null if the name is unknown or the resolver returns null. */
+/** Resolve a named preset. Returns null if the name is unknown. */
 export function resolvePreset(
   variant: string,
   containerSize: number,
   peek: number,
-): SlotConfig | null {
+): PresetResult {
   const resolver = presetRegistry.get(variant);
   return resolver ? resolver(containerSize, peek) : null;
+}
+
+/** Type guard: does the result have a layout engine? */
+export function hasSlots(result: PresetResult): result is SlotConfig {
+  return result !== null && "slots" in result;
 }
 
 // =============================================================================
@@ -83,6 +100,7 @@ export const uncontained: SlotConfigResolver = (containerSize) => {
   return {
     slots: Array.from({ length: count }, () => ratio),
     focalSlot: 0,
+    textFade: "viewport",
   };
 };
 

--- a/src/plugins/carousel/presets.ts
+++ b/src/plugins/carousel/presets.ts
@@ -10,7 +10,7 @@
  * textFade: "viewport".
  */
 
-export type TextFade = "role" | "viewport";
+export type TextFade = "role" | "viewport" | "size";
 
 export interface SlotConfig {
   slots: number[];
@@ -100,7 +100,7 @@ export const uncontained: SlotConfigResolver = (containerSize) => {
   return {
     slots: Array.from({ length: count }, () => ratio),
     focalSlot: 0,
-    textFade: "viewport",
+    textFade: "size",
   };
 };
 

--- a/src/plugins/selection/plugin.ts
+++ b/src/plugins/selection/plugin.ts
@@ -152,6 +152,9 @@ export function selection<T extends VListItem = VListItem>(
       if (item) {
         state.selected.add(item.id);
         selectedItemCache.set(item.id, item);
+      } else if (loadedItemFn) {
+        const di = toDataIndex(i);
+        if (di >= 0) state.selected.add(PLACEHOLDER_ID_PREFIX + di);
       }
     }
   }
@@ -164,6 +167,9 @@ export function selection<T extends VListItem = VListItem>(
       if (item) {
         state.selected.add(item.id);
         selectedItemCache.set(item.id, item);
+      } else if (loadedItemFn) {
+        const di = toDataIndex(i);
+        if (di >= 0) state.selected.add(PLACEHOLDER_ID_PREFIX + di);
       }
     }
   }
@@ -258,7 +264,7 @@ export function selection<T extends VListItem = VListItem>(
               is.selected = false;
             }
           } else {
-            is.selected = false;
+            is.selected = loadedItemFn !== null && di >= 0 && state.selected.has(PLACEHOLDER_ID_PREFIX + di);
           }
         } else {
           is.selected = false;
@@ -626,6 +632,7 @@ export function selection<T extends VListItem = VListItem>(
 
       ctx.registerMethod("selectAll", (): void => {
         if (mode !== "multiple") return;
+        resolveOnce(ctx);
         doSelectAll();
         emitSelectionChange();
       });
@@ -668,7 +675,11 @@ export function selection<T extends VListItem = VListItem>(
       // ── Internal methods (used by snapshots, sortable) ────────
 
       ctx.registerMethod("_seedSelection", (ids: Array<string | number>): void => {
-        for (const id of ids) state.selected.add(id);
+        if (mode === "single") {
+          if (ids.length === 1) state.selected.add(ids[0]!);
+        } else {
+          for (const id of ids) state.selected.add(id);
+        }
       });
 
       ctx.registerMethod("_isFollowFocus", (): boolean => followFocus);

--- a/src/styles/vlist-carousel.css
+++ b/src/styles/vlist-carousel.css
@@ -1,0 +1,48 @@
+/* =============================================================================
+   vlist — Carousel Slide Styles
+   Optional structural styles for carousel items. Import with:
+     import "vlist/styles/carousel"
+   ============================================================================= */
+
+/* Slide container — clips media and anchors overlay */
+.vlist-carousel-slide {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    border-radius: var(--vlist-carousel-radius, 0);
+}
+
+/* Media (img/video) — locked to focal slot width, centered.
+   The item shrinks during transitions but the media stays at full size,
+   preventing object-fit recalculation (no "breathing"). The parent clips
+   the overflow, creating a smooth parallax-like pan. */
+.vlist-carousel-slide__media {
+    position: absolute;
+    left: 50%;
+    top: 0;
+    transform: translateX(-50%);
+    width: var(--vlist-carousel-focal-width, 100%);
+    min-width: var(--vlist-carousel-focal-width, 100%);
+    height: 100%;
+    object-fit: cover;
+}
+
+/* Text overlay — opacity driven by --vlist-carousel-role-weight */
+.vlist-carousel-slide__overlay {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    opacity: var(--vlist-carousel-role-weight, 0);
+    pointer-events: none;
+    overflow: hidden;
+}
+
+/* Text lines — single-line with ellipsis truncation */
+.vlist-carousel-slide__title,
+.vlist-carousel-slide__subtitle {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/test/plugins/carousel/plugin.test.ts
+++ b/test/plugins/carousel/plugin.test.ts
@@ -16,7 +16,7 @@ import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import type { VListItem } from "../../../src/types";
 import { createPluginMockContext } from "../../helpers/plugin-context";
-import { resolvePreset, registerPreset, getPreset, multi, uncontained } from "../../../src/plugins/carousel/presets";
+import { resolvePreset, registerPreset, getPreset, hasSlots, multi, uncontained } from "../../../src/plugins/carousel/presets";
 import type { SlotConfigResolver } from "../../../src/plugins/carousel/presets";
 
 // Import will fail until plugin is created — that's expected for TDD
@@ -1569,7 +1569,9 @@ describeCarousel("carousel — Normalized Scroll", () => {
 
 describeCarousel("carousel — Presets", () => {
   it("multi() returns 4 slots summing to 1.0", () => {
-    const cfg = multi(800, 56)!;
+    const cfg = multi(800, 56);
+    expect(cfg).not.toBeNull();
+    if (!hasSlots(cfg)) throw new Error("expected slots");
     expect(cfg.slots).toHaveLength(4);
     const sum = cfg.slots.reduce((a, b) => a + b, 0);
     expect(Math.abs(sum - 1.0)).toBeLessThan(1e-10);
@@ -1577,7 +1579,9 @@ describeCarousel("carousel — Presets", () => {
   });
 
   it("uncontained() derives slot count from container size", () => {
-    const cfg = uncontained(900, 0)!;
+    const cfg = uncontained(900, 0);
+    expect(cfg).not.toBeNull();
+    if (!hasSlots(cfg)) throw new Error("expected slots");
     expect(cfg.slots.length).toBeGreaterThanOrEqual(2);
     const sum = cfg.slots.reduce((a, b) => a + b, 0);
     expect(Math.abs(sum - 1.0)).toBeLessThan(1e-10);
@@ -1630,14 +1634,14 @@ describeCarousel("carousel — Presets", () => {
   });
 
   it("registerPreset adds a custom preset accessible via resolvePreset", () => {
-    const custom: SlotConfigResolver = (containerSize) => ({
+    const custom: SlotConfigResolver = () => ({
       slots: [0.6, 0.4],
       focalSlot: 0,
     });
     registerPreset("my-custom", custom);
     const result = resolvePreset("my-custom", 800, 56);
-    expect(result).not.toBeNull();
-    expect(result!.slots).toEqual([0.6, 0.4]);
+    if (!hasSlots(result)) throw new Error("expected slots");
+    expect(result.slots).toEqual([0.6, 0.4]);
   });
 
   it("getPreset returns the registered resolver", () => {
@@ -1645,8 +1649,8 @@ describeCarousel("carousel — Presets", () => {
     expect(resolver).toBeDefined();
     expect(typeof resolver).toBe("function");
     const result = resolver!(800, 56);
-    expect(result).not.toBeNull();
-    expect(result!.focalSlot).toBe(0);
+    if (!hasSlots(result)) throw new Error("expected slots");
+    expect(result.focalSlot).toBe(0);
   });
 
   it("getPreset returns undefined for unregistered names", () => {
@@ -1655,14 +1659,24 @@ describeCarousel("carousel — Presets", () => {
 
   it("registerPreset can override built-in presets", () => {
     const original = resolvePreset("full", 800, 56);
-    expect(original!.slots).toEqual([1.0]);
+    if (!hasSlots(original)) throw new Error("expected slots");
+    expect(original.slots).toEqual([1.0]);
 
     registerPreset("full", () => ({ slots: [0.5, 0.5], focalSlot: 0 }));
     const overridden = resolvePreset("full", 800, 56);
-    expect(overridden!.slots).toEqual([0.5, 0.5]);
+    if (!hasSlots(overridden)) throw new Error("expected slots");
+    expect(overridden.slots).toEqual([0.5, 0.5]);
 
     // Restore
     registerPreset("full", () => ({ slots: [1.0], focalSlot: 0 }));
+  });
+
+  it("no-engine preset can specify textFade", () => {
+    registerPreset("custom-no-engine", () => ({ textFade: "role" }));
+    const result = resolvePreset("custom-no-engine", 800, 56);
+    expect(result).not.toBeNull();
+    expect(hasSlots(result)).toBe(false);
+    expect(result!.textFade).toBe("role");
   });
 
   it("carousel accepts a SlotConfigResolver function as variant", () => {

--- a/test/plugins/carousel/plugin.test.ts
+++ b/test/plugins/carousel/plugin.test.ts
@@ -1586,6 +1586,7 @@ describeCarousel("carousel — Presets", () => {
     const sum = cfg.slots.reduce((a, b) => a + b, 0);
     expect(Math.abs(sum - 1.0)).toBeLessThan(1e-10);
     expect(cfg.focalSlot).toBe(0);
+    expect(cfg.textFade).toBe("size");
   });
 
   it("resolvePreset returns correct configs for all named variants", () => {

--- a/test/plugins/selection/plugin.test.ts
+++ b/test/plugins/selection/plugin.test.ts
@@ -463,6 +463,35 @@ describe("selection — Methods Behavior", () => {
     cleanup();
   });
 
+  it("selectAll should use placeholder IDs for unloaded async items", () => {
+    const loaded = createTestItems(5);
+    const plugin = selection<TestItem>({ mode: "multiple" });
+    const { ctx, methods, engineState, cleanup } = createPluginMockContext(loaded);
+    engineState.totalItems = 20;
+
+    ctx.registerMethod("_getLoadedItem", (index: number): TestItem | undefined => {
+      return index < 5 ? loaded[index] : undefined;
+    });
+
+    plugin.setup!(ctx);
+
+    const selectAll = methods.get("selectAll") as () => void;
+    const getSelected = methods.get("getSelected") as () => Array<string | number>;
+
+    selectAll();
+    const selected = getSelected();
+    expect(selected.length).toBe(20);
+
+    for (let i = 0; i < 5; i++) {
+      expect(selected).toContain(i);
+    }
+    for (let i = 5; i < 20; i++) {
+      expect(selected).toContain("__placeholder_" + i);
+    }
+
+    cleanup();
+  });
+
   it("select should be a no-op in none mode", () => {
     const plugin = selection<TestItem>({ mode: "none" });
     const { ctx, methods, cleanup } = createPluginMockContext(createTestItems(100));


### PR DESCRIPTION
## Summary

- **Carousel stylesheet** (`vlist/styles/carousel`) — optional structural styles for carousel slides: media stabilization, overlay visibility, text truncation
- **`--vlist-carousel-focal-width`** / **`--vlist-carousel-radius`** CSS variables
- **`selectAll()` with async data** — selects all items including unloaded (placeholder IDs swapped on load)
- **Snapshot restore** respects selection mode (multi→single no longer leaks)

## Test plan

- [x] `bun test` — 231 selection tests pass, 3409 total pass
- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean
- [x] `bun run size` — all README sizes verified
- [x] Debug script: selectAll selects 578 items, scroll to middle/bottom confirmed, mode switch clears