### PR TITLE
fix(carousel): static variant smooth scroll + concurrent test fixes

### DIFF
--- a/src/plugins/carousel/plugin.ts
+++ b/src/plugins/carousel/plugin.ts
@@ -241,7 +241,7 @@ export function carousel<T extends VListItem = VListItem>(
 
   function updateItemLayout(): void {
     if (!storedCtx || realTotal <= 0) return;
-    if (!layoutEngine && !isVariableWidth) return;
+    if (!layoutEngine && !isVariableWidth && realTotal <= 1) return;
 
     const content = storedCtx.dom.content;
     const children = content.children;

--- a/test/core/runway.test.ts
+++ b/test/core/runway.test.ts
@@ -91,6 +91,18 @@ function makeBounded(itemCount: number): VList<TestItem> {
   );
 }
 
+function makeBoundedIn(c: HTMLElement, itemCount: number): VList<TestItem> {
+  return createVList<TestItem>(
+    {
+      container: c,
+      items: createTestItems(itemCount),
+      item: { height: ITEM, template: simpleTemplate },
+      scroll: { mode: "bounded" },
+    },
+    [],
+  );
+}
+
 function transformPx(el: HTMLElement): number {
   const m = /translateY\(([-\d.]+)px\)/.exec(el.style.transform);
   return m ? parseFloat(m[1]!) : NaN;
@@ -430,7 +442,8 @@ describe("bounded scroll — wrap mode", () => {
 // =============================================================================
 
 describe("bounded scroll — resize", () => {
-  it("refreshes the runway when the container resizes", async () => {
+  it("refreshes the runway when the container resizes", () => {
+    const c = createContainer({ width: 300, height: VIEWPORT });
     const saved = globalThis.ResizeObserver;
     let cb: ResizeObserverCallback | null = null;
     // Capture the observer callback without auto-firing on observe.
@@ -441,11 +454,21 @@ describe("bounded scroll — resize", () => {
       disconnect(): void {}
     } as unknown as typeof ResizeObserver;
 
+    // Intercept setTimeout so we can flush the observer install synchronously,
+    // avoiding any yield where concurrent tests could see the mock.
+    const origSetTimeout = globalThis.setTimeout;
+    let pendingInit: (() => void) | null = null;
+    globalThis.setTimeout = ((fn: () => void) => { pendingInit = fn; return 0; }) as typeof setTimeout;
+
+    const l = makeBoundedIn(c, 1_000_000);
+
+    globalThis.setTimeout = origSetTimeout;
+    if (pendingInit) pendingInit();
+    // Restore immediately — the observer callback is captured, mock no longer needed.
+    globalThis.ResizeObserver = saved;
+
     try {
-      list = makeBounded(1_000_000);
-      // The observer is installed on a 0ms timer.
-      await new Promise((r) => setTimeout(r, 0));
-      expect(parseInt(getContent(container).style.height, 10)).toBe(RUNWAY); // 500 × 2
+      expect(parseInt(getContent(c).style.height, 10)).toBe(RUNWAY); // 500 × 2
 
       // Resize the viewport to 700px (vertical → contentRect.height is the main axis).
       cb!(
@@ -454,9 +477,10 @@ describe("bounded scroll — resize", () => {
       );
 
       // Runway tracks the new viewport: 700 × FACTOR, not the stale 1000.
-      expect(parseInt(getContent(container).style.height, 10)).toBe(700 * FACTOR);
+      expect(parseInt(getContent(c).style.height, 10)).toBe(700 * FACTOR);
     } finally {
-      globalThis.ResizeObserver = saved;
+      l.destroy();
+      c.remove();
     }
   });
 });
@@ -655,21 +679,27 @@ describe("bounded scroll — wheel", () => {
 
 describe("bounded scroll — idle detection", () => {
   it("resets scrollDirection to 0 after idle timeout", async () => {
-    list = makeBounded(1_000_000);
-    const viewport = getViewport(container);
+    const c = createContainer({ width: 300, height: VIEWPORT });
+    try {
+      const l = makeBoundedIn(c, 1_000_000);
+      const viewport = getViewport(c);
 
-    fireWheel(viewport, 100);
-    // scrollDirection should be set after wheel
-    const state = (list as any)._test?.engineState;
+      fireWheel(viewport, 100);
+      // scrollDirection should be set after wheel
+      const state = (l as any)._test?.engineState;
 
-    // Wait for the idle timeout (150ms default) + buffer
-    await new Promise((r) => setTimeout(r, 250));
+      // Wait for the idle timeout (150ms default) + buffer
+      await new Promise((r) => setTimeout(r, 250));
 
-    // After idle, scrollDirection should be 0
-    // We verify via a second scroll — if idle fired, the direction was reset
-    const posBefore = list.getScrollPosition();
-    fireWheel(viewport, 50);
-    expect(list.getScrollPosition()).toBeGreaterThan(posBefore);
+      // After idle, scrollDirection should be 0
+      // We verify via a second scroll — if idle fired, the direction was reset
+      const posBefore = l.getScrollPosition();
+      fireWheel(viewport, 50);
+      expect(l.getScrollPosition()).toBeGreaterThan(posBefore);
+      l.destroy();
+    } finally {
+      c.remove();
+    }
   });
 });
 
@@ -679,18 +709,24 @@ describe("bounded scroll — idle detection", () => {
 
 describe("bounded scroll — smooth scroll", () => {
   it("scrollToIndex with smooth behavior animates to the target", async () => {
-    list = makeBounded(1_000_000);
-    const target = 500;
-    const targetOffset = target * ITEM; // 25000
+    const c = createContainer({ width: 300, height: VIEWPORT });
+    try {
+      const l = makeBoundedIn(c, 1_000_000);
+      const target = 500;
+      const targetOffset = target * ITEM; // 25000
 
-    list.scrollToIndex(target, { behavior: "smooth" });
+      l.scrollToIndex(target, { behavior: "smooth" });
 
-    // rAF is shimmed to setTimeout(0), so give it time to complete
-    await new Promise((r) => setTimeout(r, 600));
+      // rAF is shimmed to setTimeout(0), so give it time to complete
+      await new Promise((r) => setTimeout(r, 600));
 
-    // Should arrive near the target
-    const pos = list.getScrollPosition();
-    expect(Math.abs(pos - targetOffset)).toBeLessThan(ITEM);
+      // Should arrive near the target
+      const pos = l.getScrollPosition();
+      expect(Math.abs(pos - targetOffset)).toBeLessThan(ITEM);
+      l.destroy();
+    } finally {
+      c.remove();
+    }
   });
 
   it("scrollToIndex with auto behavior jumps instantly", () => {
@@ -704,19 +740,25 @@ describe("bounded scroll — smooth scroll", () => {
   });
 
   it("cancels an in-flight smooth scroll when a new one starts", async () => {
-    list = makeBounded(1_000_000);
+    const c = createContainer({ width: 300, height: VIEWPORT });
+    try {
+      const l = makeBoundedIn(c, 1_000_000);
 
-    list.scrollToIndex(100, { behavior: "smooth" });
-    // Immediately start a second animation — the first should be cancelled
-    await new Promise((r) => setTimeout(r, 50));
-    list.scrollToIndex(200, { behavior: "smooth" });
+      l.scrollToIndex(100, { behavior: "smooth" });
+      // Immediately start a second animation — the first should be cancelled
+      await new Promise((r) => setTimeout(r, 50));
+      l.scrollToIndex(200, { behavior: "smooth" });
 
-    await new Promise((r) => setTimeout(r, 600));
+      await new Promise((r) => setTimeout(r, 600));
 
-    // Should end near index 200, not 100
-    const pos = list.getScrollPosition();
-    const target200 = 200 * ITEM;
-    expect(Math.abs(pos - target200)).toBeLessThan(ITEM * 2);
+      // Should end near index 200, not 100
+      const pos = l.getScrollPosition();
+      const target200 = 200 * ITEM;
+      expect(Math.abs(pos - target200)).toBeLessThan(ITEM * 2);
+      l.destroy();
+    } finally {
+      c.remove();
+    }
   });
 
   it("handles smooth scroll to a position within 1px (instant jump, no animation)", () => {

--- a/test/integration/groups-table-data.test.ts
+++ b/test/integration/groups-table-data.test.ts
@@ -345,58 +345,65 @@ describe("groups + table + data", () => {
     it("should show correct groups after snapshot restore + data load", async () => {
       const adapter = createCityAdapter(100);
       const STORAGE_KEY = "test-gtd-snap-" + Math.random().toString(36).slice(2, 8);
+      const c1 = createContainer({ width: 300, height: 500 });
 
-      list = createList(
-        { container, item: { height: 36, template: () => "" } },
-        [
-          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
-          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
-          groups({
-            getGroupForIndex: getPopTier,
-            header: { height: 28, template: (key) => key },
-          }),
-          snapshots({ autoSave: STORAGE_KEY }),
-        ],
-      );
+      try {
+        const l1 = createList(
+          { container: c1, item: { height: 36, template: () => "" } },
+          [
+            dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+            table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+            groups({
+              getGroupForIndex: getPopTier,
+              header: { height: 28, template: (key) => key },
+            }),
+            snapshots({ autoSave: STORAGE_KEY }),
+          ],
+        );
 
-      await waitForLoad(list);
+        await waitForLoad(l1);
 
-      // Verify groups exist on first load
-      const headersFirstLoad = container.querySelectorAll(".vlist-table-group-header");
-      const firstLoadCount = headersFirstLoad.length;
+        // Verify groups exist on first load
+        const headersFirstLoad = c1.querySelectorAll(".vlist-table-group-header");
+        const firstLoadCount = headersFirstLoad.length;
 
-      // Save snapshot (simulates browser session)
-      const snap = (list as any).getScrollSnapshot();
-      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(snap));
+        // Save snapshot (simulates browser session)
+        const snap = (l1 as any).getScrollSnapshot();
+        sessionStorage.setItem(STORAGE_KEY, JSON.stringify(snap));
 
-      list.destroy();
-      list = null;
-      container.innerHTML = "";
-      ensureDimensions();
+        l1.destroy();
+        c1.innerHTML = "";
+        ensureDimensions();
 
-      list = createList(
-        { container, item: { height: 36, template: () => "" } },
-        [
-          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
-          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
-          groups({
-            getGroupForIndex: getPopTier,
-            header: { height: 28, template: (key) => key },
-          }),
-          snapshots({ autoSave: STORAGE_KEY }),
-        ],
-      );
+        const c2 = createContainer({ width: 300, height: 500 });
+        const l2 = createList(
+          { container: c2, item: { height: 36, template: () => "" } },
+          [
+            dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+            table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+            groups({
+              getGroupForIndex: getPopTier,
+              header: { height: 28, template: (key) => key },
+            }),
+            snapshots({ autoSave: STORAGE_KEY }),
+          ],
+        );
 
-      await waitForLoad(list);
+        await waitForLoad(l2);
 
-      // After snapshot restore + data load, groups must still be present
-      const headersAfterRestore = container.querySelectorAll(".vlist-table-group-header");
-      expect(headersAfterRestore.length).toBeGreaterThan(0);
+        // After snapshot restore + data load, groups must still be present
+        const headersAfterRestore = c2.querySelectorAll(".vlist-table-group-header");
+        expect(headersAfterRestore.length).toBeGreaterThan(0);
 
-      // Header count should be the same as first load
-      expect(headersAfterRestore.length).toBe(firstLoadCount);
+        // Header count should be the same as first load
+        expect(headersAfterRestore.length).toBe(firstLoadCount);
 
-      sessionStorage.removeItem(STORAGE_KEY);
+        l2.destroy();
+        c2.remove();
+      } finally {
+        sessionStorage.removeItem(STORAGE_KEY);
+        c1.remove();
+      }
     });
   });
 
@@ -437,53 +444,59 @@ describe("groups + table + data", () => {
       // NOTE: flaky under --concurrent — prototype override can be stomped
       // during async waits (reload, setTimeout). See snapshot test comment.
       const adapter = createCityAdapter(50);
-      list = createList(
-        { container, item: { height: 36, template: () => "" } },
-        [
-          dataPlugin({ adapter, storage: { chunkSize: 50 } }),
-          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
-          groups({
-            getGroupForIndex: getPopTier,
-            header: { height: 28, template: (key) => key },
-            sticky: true,
-          }),
-        ],
-      );
+      const c = createContainer({ width: 300, height: 500 });
+      try {
+        const l = createList(
+          { container: c, item: { height: 36, template: () => "" } },
+          [
+            dataPlugin({ adapter, storage: { chunkSize: 50 } }),
+            table({ columns: COLUMNS, rowHeight: 36, headerHeight: 36 }),
+            groups({
+              getGroupForIndex: getPopTier,
+              header: { height: 28, template: (key) => key },
+              sticky: true,
+            }),
+          ],
+        );
 
-      await waitForLoad(list);
+        await waitForLoad(l);
 
-      const sticky = container.querySelector(".vlist-sticky-header") as HTMLElement;
-      expect(sticky).not.toBeNull();
-      // With groups resolved, the sticky is shown with a label.
-      expect(getComputedStyle(sticky).visibility).not.toBe("hidden");
+        const sticky = c.querySelector(".vlist-sticky-header") as HTMLElement;
+        expect(sticky).not.toBeNull();
+        // With groups resolved, the sticky is shown with a label.
+        expect(getComputedStyle(sticky).visibility).not.toBe("hidden");
 
-      // Reload with a failing adapter → the new range is all placeholders →
-      // no resolvable groups. An enabled sticky header stays displayed but
-      // empty (it must NOT collapse or hide — it fills in on recovery without
-      // a layout shift).
-      (adapter.read as any).mockImplementation(async () => {
-        throw new Error("offline");
-      });
-      await (list as any).reload();
-      await new Promise((r) => setTimeout(r, 30));
+        // Reload with a failing adapter → the new range is all placeholders →
+        // no resolvable groups. An enabled sticky header stays displayed but
+        // empty (it must NOT collapse or hide — it fills in on recovery without
+        // a layout shift).
+        (adapter.read as any).mockImplementation(async () => {
+          throw new Error("offline");
+        });
+        await (l as any).reload();
+        await new Promise((r) => setTimeout(r, 30));
 
-      expect(container.querySelectorAll(".vlist-table-group-header").length).toBe(0);
-      expect(sticky.style.display).not.toBe("none"); // not collapsed
-      expect(sticky.style.visibility).not.toBe("hidden"); // shown, not hidden
-      expect((sticky.textContent ?? "").trim()).toBe(""); // empty
+        expect(c.querySelectorAll(".vlist-table-group-header").length).toBe(0);
+        expect(sticky.style.display).not.toBe("none"); // not collapsed
+        expect(sticky.style.visibility).not.toBe("hidden"); // shown, not hidden
+        expect((sticky.textContent ?? "").trim()).toBe(""); // empty
 
-      // Recover: data loads again → groups return → the label fills in.
-      (adapter.read as any).mockImplementation(async ({ offset, limit }: { offset: number; limit: number }) => {
-        const end = Math.min(offset + limit, 50);
-        const items = createCities(offset, end - offset);
-        return { items, total: 50, hasMore: end < 50 };
-      });
-      const reloaded = waitForLoad(list);
-      await (list as any).loadVisibleRange();
-      await reloaded;
+        // Recover: data loads again → groups return → the label fills in.
+        (adapter.read as any).mockImplementation(async ({ offset, limit }: { offset: number; limit: number }) => {
+          const end = Math.min(offset + limit, 50);
+          const items = createCities(offset, end - offset);
+          return { items, total: 50, hasMore: end < 50 };
+        });
+        const reloaded = waitForLoad(l);
+        await (l as any).loadVisibleRange();
+        await reloaded;
 
-      expect(getComputedStyle(sticky).visibility).not.toBe("hidden");
-      expect((sticky.textContent ?? "").trim().length).toBeGreaterThan(0);
+        expect(getComputedStyle(sticky).visibility).not.toBe("hidden");
+        expect((sticky.textContent ?? "").trim().length).toBeGreaterThan(0);
+        l.destroy();
+      } finally {
+        c.remove();
+      }
     });
   });
 

--- a/test/plugins/carousel/plugin.test.ts
+++ b/test/plugins/carousel/plugin.test.ts
@@ -2410,6 +2410,39 @@ describeCarousel("carousel — Variable-width (multi-aspect)", () => {
     cleanup();
   });
 
+  it("static variant repositions items on scroll (no layout engine)", () => {
+    const items = createTestItems(10);
+    const { ctx, dom, cleanup } = createPluginMockContext<TestItem>(items, {
+      containerWidth: 600,
+      containerHeight: 480,
+      itemSize: 480,
+    });
+
+    const plugin = carousel({ variant: "static", snap: true });
+    plugin.setup!(ctx);
+    if (plugin.hooks?.onCommit) plugin.hooks.onCommit();
+
+    const els = addRenderedItems(dom.content, [0, 1, 2]);
+    const es = ctx.getState();
+
+    const middleStart = 50 * 10;
+    es.scrollPosition = middleStart * 480;
+    es.baseOffset = es.scrollPosition - 240;
+    plugin.hooks!.onAfterScroll!(es.scrollPosition);
+
+    const t0 = els[0].style.transform;
+    expect(t0).toBeTruthy();
+
+    es.scrollPosition = middleStart * 480 + 240;
+    es.baseOffset = es.scrollPosition - 240;
+    plugin.hooks!.onAfterScroll!(es.scrollPosition);
+
+    const t0After = els[0].style.transform;
+    expect(t0After).not.toBe(t0);
+
+    cleanup();
+  });
+
   it("uniform preset still works after refactor (backward compat)", () => {
     const items = createTestItems(5);
     const { ctx, cleanup } = createPluginMockContext<TestItem>(items, {


### PR DESCRIPTION
## Summary
- Fix carousel `updateItemLayout()` early return that prevented DOM transform updates for static variant during smooth scroll
- Isolate shared file-level state in 6 async tests for stable `--concurrent` runs

## Test plan
- [x] All 487+ tests pass with `bun test --concurrent`
- [x] New test verifies static variant repositions items on scroll