### PR TITLE
Release v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ This changelog starts at v1.5.4, the first version published under the `vlist` p
 (April 2026). Earlier versions were published as `@floor/vlist` — see the
 [git history](https://github.com/floor/vlist/commits/main) for the full record.
 
+## [2.5.1] - 2026-06-13
+
+### Added
+
+- **Carousel snap refinements** — direction-aware snapping, configurable snap easing, and snap enforced for the `full` variant.
+
+### Fixed
+
+- **Groups + bounded scroll** — the `groups()` plugin is now bounded-scroll aware: sticky headers and item transforms account for the runway origin (`baseOffset`), so grouped lists position correctly under `scroll: { mode: "bounded" }` (RFC-012).
+- **Carousel `snapEasing`** — now forwarded to `smoothScrollTo` as the easing argument, so a custom snap easing is actually applied.
+- **Carousel static variant** — repositions its items during smooth scroll instead of leaving them fixed.
+- **Async data on idle** — the visible range now reconciles on scroll idle regardless of any pending range request, avoiding a stale window after fast scrolling.
+- **Grouped tables** — publish data indices (not layout indices) to the data loader, so the correct rows are fetched in grouped table mode.
+
 ## [2.5.0] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The virtual list library for every framework. Ultra efficient, batteries-included, and accessible with composable plugins — in 9.7 KB.
 
-**v2.5.0** — [Changelog](./CHANGELOG.md) · **New:** Bounded logical scroll model for 1M+ items (`scroll: { mode: "bounded" }`), `carousel()` plugin with infinite loop, snap, and focal scaling. `scale()` deprecated.
+**v2.5.1** — [Changelog](./CHANGELOG.md) · Carousel snap refinements (direction-aware, configurable easing) plus fixes for groups under bounded scroll, grouped-table data loading, and async range reconciliation on idle.
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/vlist)](https://bundlephobia.com/package/vlist)
@@ -103,7 +103,7 @@ const list = createVList({
 | `scrollbar()` | +2.0 KB | Custom scrollbar UI |
 | `grid()` | +2.4 KB | 2D grid layout |
 | `masonry()` | +4.0 KB | Pinterest-style masonry with lane-aware keyboard nav |
-| `carousel()` | +3.3 KB | Paged horizontal carousel with snap and keyboard nav |
+| `carousel()` | +3.4 KB | Paged horizontal carousel with snap and keyboard nav |
 | `table()` | +5.8 KB | Data table with columns, resize, sort |
 | `tree()` | +5.0 KB | Collapsible tree with async loading and indent guides |
 | `page()` | +0.8 KB | Window-level scrolling |

--- a/npm-readme.md
+++ b/npm-readme.md
@@ -2,7 +2,7 @@
 
 The virtual list library for every framework. Ultra efficient, batteries-included, and accessible with composable plugins — in 9.7 KB.
 
-**v2.5.0** — [Changelog](https://github.com/floor/vlist/blob/main/CHANGELOG.md) · **New:** Bounded logical scroll model for 1M+ items (`scroll: { mode: "bounded" }`), `carousel()` plugin with infinite loop, snap, and focal scaling. `scale()` deprecated.
+**v2.5.1** — [Changelog](https://github.com/floor/vlist/blob/main/CHANGELOG.md) · Carousel snap refinements (direction-aware, configurable easing) plus fixes for groups under bounded scroll, grouped-table data loading, and async range reconciliation on idle.
 
 [![npm version](https://img.shields.io/npm/v/vlist.svg)](https://www.npmjs.com/package/vlist)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/vlist)](https://bundlephobia.com/package/vlist)
@@ -65,7 +65,7 @@ const list = createVList({ container: '#app', items, item: { height: 200, templa
 | `scrollbar()` | +2.0 KB | Custom scrollbar UI |
 | `grid()` | +2.4 KB | 2D grid layout |
 | `masonry()` | +4.0 KB | Pinterest-style masonry with lane-aware keyboard nav |
-| `carousel()` | +2.3 KB | Paged horizontal carousel with snap and keyboard nav |
+| `carousel()` | +3.4 KB | Paged horizontal carousel with snap and keyboard nav |
 | `table()` | +5.8 KB | Data table with columns, resize, sort |
 | `tree()` | +5.0 KB | Collapsible tree with async loading and indent guides |
 | `page()` | +0.8 KB | Window-level scrolling |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlist",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Lightweight, high-performance virtual list with zero dependencies",
   "author": {
     "name": "Floor IO",

--- a/src/plugins/carousel/plugin.ts
+++ b/src/plugins/carousel/plugin.ts
@@ -217,7 +217,7 @@ export function carousel<T extends VListItem = VListItem>(
   // smooth-scroll animation both live in the bounded scroll handler now — the
   // carousel only computes targets and lets the handler do the scrolling.
   function smoothScrollTo(target: number, duration: number): void {
-    storedCtx?.smoothScrollTo(target, duration, undefined, snapEasing);
+    storedCtx?.smoothScrollTo(target, duration, snapEasing);
   }
 
   let layoutEngine: ReturnType<typeof createLayoutEngine> | null = null;

--- a/src/plugins/carousel/plugin.ts
+++ b/src/plugins/carousel/plugin.ts
@@ -34,7 +34,11 @@ export type CarouselDirection = "auto" | "forward" | "backward";
 export interface CarouselPluginConfig {
   variant?: CarouselVariant | SlotConfig | SlotConfigResolver;
   snap?: boolean;
+  /** Snap in the user's scroll direction instead of to the nearest item. */
+  snapDirection?: boolean;
   snapDuration?: number;
+  /** Custom easing function for snap animation. Receives t in [0,1], returns eased value. */
+  snapEasing?: (t: number) => number;
   peek?: number | string | "auto";
   largeItemMaxWidth?: number | "auto";
   parallax?: number;
@@ -95,8 +99,10 @@ export function carousel<T extends VListItem = VListItem>(
 ): VListPlugin<T> {
   const variantConfig = config?.variant ?? "full";
   const { variant, resolveSlots } = normalizeVariant(variantConfig);
-  const snapEnabled = config?.snap ?? (variant !== "free");
+  const snapEnabled = variant === "full" || (config?.snap ?? (variant !== "free"));
+  const snapDirectional = config?.snapDirection ?? true;
   const snapDuration = config?.snapDuration ?? 400;
+  const snapEasing = config?.snapEasing;
   const initialIndex = config?.initialIndex ?? 0;
   const peekConfig = config?.peek ?? "auto";
 
@@ -114,6 +120,7 @@ export function carousel<T extends VListItem = VListItem>(
   let initialScrollPending = false;
   let prefix = "vlist";
   let intendedVi = -1;
+  let lastDirection = 0;
 
   let stepSizes: number[] = [];
   let stepOffsets: number[] = [];
@@ -210,7 +217,7 @@ export function carousel<T extends VListItem = VListItem>(
   // smooth-scroll animation both live in the bounded scroll handler now — the
   // carousel only computes targets and lets the handler do the scrolling.
   function smoothScrollTo(target: number, duration: number): void {
-    storedCtx?.smoothScrollTo(target, duration);
+    storedCtx?.smoothScrollTo(target, duration, undefined, snapEasing);
   }
 
   let layoutEngine: ReturnType<typeof createLayoutEngine> | null = null;
@@ -672,6 +679,8 @@ export function carousel<T extends VListItem = VListItem>(
         syncItemCount();
         if (realTotal <= 1) return;
 
+        if (engineState.scrollDirection !== 0) lastDirection = engineState.scrollDirection;
+
         if (intendedVi < 0) {
           const pos = engineState.scrollPosition;
           const vi = virtualIndexAtScroll(pos);
@@ -689,16 +698,24 @@ export function carousel<T extends VListItem = VListItem>(
         updateItemLayout();
       },
 
-      // Snap-to-item once scrolling stops. The bounded handler fires onIdle
-      // after the idle timeout, replacing the old setTimeout(200) dance.
       onIdle(): void {
+        const dir = lastDirection;
         intendedVi = -1;
+        lastDirection = 0;
         if (!snapEnabled || !storedCtx || realTotal <= 1) return;
         const p = engineState.scrollPosition;
-        const nearestVi = virtualIndexAtScroll(p);
-        const snapTarget = scrollPositionForVirtual(nearestVi);
+        const { vi, frac } = decomposeScroll(p);
+
+        let snapVi: number;
+        if (snapDirectional && dir !== 0 && frac > 0.02 && frac < 0.98) {
+          snapVi = dir > 0 ? vi + 1 : vi;
+        } else {
+          snapVi = frac >= 0.5 ? vi + 1 : vi;
+        }
+
+        const snapTarget = scrollPositionForVirtual(snapVi);
         if (Math.abs(p - snapTarget) > 1) {
-          currentIndex = logicalIndexOf(nearestVi);
+          currentIndex = logicalIndexOf(snapVi);
           smoothScrollTo(snapTarget, snapDuration);
         }
       },

--- a/src/plugins/data/plugin.ts
+++ b/src/plugins/data/plugin.ts
@@ -143,9 +143,13 @@ export function data<T extends VListItem = VListItem>(
   };
 
   const loadPendingRange = (): void => {
-    if (!pendingRange) {
-      return;
-    }
+    // Always reconcile the *currently visible* range when scrolling settles —
+    // not only when a pendingRange flag is set. During a momentum (flick)
+    // scroll the final onAfterScroll can land in the slow path, which calls
+    // resetDeceleration() → pendingRange = null and only re-ensures on a chunk
+    // change. When the settled chunk index is unchanged, nothing reloads it and
+    // the viewport is stuck on placeholders. ensure() dedupes against
+    // loaded/in-flight chunks, so this is a cheap no-op when already loaded.
     pendingRange = null;
 
     const currentRange = {

--- a/src/plugins/groups/plugin.ts
+++ b/src/plugins/groups/plugin.ts
@@ -64,6 +64,11 @@ export function groups<T extends VListItem = VListItem>(
   let engineState: EngineState;
   let pool: ElementPool;
   let contentElement: HTMLElement;
+  // Bounded-mode (RFC-012): route content sizing through ctx.updateContentSize so
+  // the bounded scroll handler keeps vlist-content at the runway size instead of
+  // the full virtual height (which would blow the browser's element cap on huge
+  // lists). Null until setup; in native mode it just sets the style height.
+  let updateContentSize: ((size: number) => void) | null = null;
   let rootElement: HTMLElement;
   let userTemplate: ItemTemplate<T>;
   let ctxGetItem: (index: number) => T | undefined;
@@ -92,6 +97,11 @@ export function groups<T extends VListItem = VListItem>(
   const detached = new Map<string, HTMLElement>();
   let lastScrollPosition = -1;
   let lastContainerSize = -1;
+  // Bounded mode (RFC-012): item transforms are `offset - baseOffset`. baseOffset
+  // shifts when the runway rebases, so on a change every already-rendered item
+  // must be repositioned — not just newly added ones. Tracks the last rendered
+  // baseOffset to detect that. Stays 0 in native mode (no extra work).
+  let lastRenderBaseOffset = 0;
   let forceNextRender = true;
   let lastDataCount = -1;
   let lastRebuildLoadedCount = 0;
@@ -119,7 +129,7 @@ export function groups<T extends VListItem = VListItem>(
     origSizeCacheRebuild(layout.totalEntries);
     rebuildGridPositions();
     const totalSize = gridItemPositions ? getGridContentSize() : sizeCache.getTotalSize();
-    contentElement.style[isX ? "width" : "height"] = (totalSize + mainAxisPadding) + "px";
+    updateContentSize?.(totalSize);
     if (stickyHeader) {
       stickyHeader.refresh();
       stickyHeader.update(engineState.scrollPosition);
@@ -266,17 +276,20 @@ export function groups<T extends VListItem = VListItem>(
   }
 
   function buildTransform(layoutIndex: number): string {
+    // RFC-012: subtract baseOffset so absolute virtual offsets map into the
+    // bounded runway. baseOffset is 0 in native mode (byte-identical).
+    const base = engineState.baseOffset;
     if (gridItemPositions) {
       const pos = gridItemPositions.get(layoutIndex);
       if (pos) {
         const x = pos.col < 0 ? 0 : gridCrossPadStart + pos.col * (gridColWidth + gridGap);
-        const y = pos.rowY;
+        const y = pos.rowY - base;
         if (isX) return `translate(${Math.round(y)}px, ${Math.round(x)}px)`;
         return `translate(${Math.round(x)}px, ${Math.round(y)}px)`;
       }
     }
 
-    const offset = sizeCache.getOffset(layoutIndex);
+    const offset = sizeCache.getOffset(layoutIndex) - base;
     if (isX) {
       return `translate(${Math.round(offset)}px, 0)`;
     }
@@ -429,7 +442,7 @@ export function groups<T extends VListItem = VListItem>(
     lastCrossSize = cross;
     rebuildGridPositions();
     const totalSize = getGridContentSize();
-    contentElement.style[isX ? "width" : "height"] = (totalSize + mainAxisPadding) + "px";
+    updateContentSize?.(totalSize);
     if (stickyHeader) {
       stickyHeader.refresh();
       stickyHeader.update(engineState.scrollPosition);
@@ -445,8 +458,10 @@ export function groups<T extends VListItem = VListItem>(
 
     const scrollPos = engineState.scrollPosition;
     const cs = engineState.containerSize;
+    const baseOffset = engineState.baseOffset;
+    const baseChanged = baseOffset !== lastRenderBaseOffset;
 
-    if (!forceNextRender && scrollPos === lastScrollPosition && cs === lastContainerSize) {
+    if (!forceNextRender && scrollPos === lastScrollPosition && cs === lastContainerSize && !baseChanged) {
       return;
     }
     lastScrollPosition = scrollPos;
@@ -510,9 +525,10 @@ export function groups<T extends VListItem = VListItem>(
       renderEnd = Math.min(totalItems - 1, visEnd + overscan);
     }
 
-    if (renderStart === engineState.prevRangeStart && renderEnd === engineState.prevRangeEnd && !engineState.renderPending) {
+    if (renderStart === engineState.prevRangeStart && renderEnd === engineState.prevRangeEnd && !engineState.renderPending && !baseChanged) {
       return;
     }
+    lastRenderBaseOffset = baseOffset;
 
     // Recycle elements outside the new range
     rendered.forEach((element, idx) => {
@@ -586,6 +602,10 @@ export function groups<T extends VListItem = VListItem>(
         if (isForced) {
           applySizeStyles(element, i);
           element.style.transform = buildTransform(i);
+        } else if (baseChanged) {
+          // Bounded mode (RFC-012): the runway rebased, so reposition the item
+          // at its new offset - baseOffset (native mode never reaches here).
+          element.style.transform = buildTransform(i);
         }
       }
 
@@ -605,7 +625,7 @@ export function groups<T extends VListItem = VListItem>(
     drainDetached();
 
     const totalSize = gridItemPositions ? getGridContentSize() : sizeCache.getTotalSize();
-    contentElement.style[isX ? "width" : "height"] = (totalSize + mainAxisPadding) + "px";
+    updateContentSize?.(totalSize);
 
     engineState.prevRangeStart = renderStart;
     engineState.prevRangeEnd = renderEnd;
@@ -665,7 +685,7 @@ export function groups<T extends VListItem = VListItem>(
         origSizeCacheRebuild(layout.totalEntries);
         rebuildGridPositions();
         const totalSize = gridItemPositions ? getGridContentSize() : sizeCache.getTotalSize();
-        contentElement.style[isX ? "width" : "height"] = totalSize + "px";
+        updateContentSize?.(totalSize);
         if (stickyHeader) {
           stickyHeader.refresh();
           stickyHeader.update(engineState.scrollPosition);
@@ -716,6 +736,7 @@ export function groups<T extends VListItem = VListItem>(
       engineState = ctx.getState();
       pool = ctx.pool;
       contentElement = ctx.dom.content;
+      updateContentSize = ctx.updateContentSize.bind(ctx);
       rootElement = ctx.dom.root;
       userTemplate = ctx.template;
       isX = ctx.config.axis.primary === "x";
@@ -1063,7 +1084,7 @@ export function groups<T extends VListItem = VListItem>(
         lastCrossSize = engineState.crossSize;
         rebuildGridPositions();
         const totalSize = getGridContentSize();
-        contentElement.style[isX ? "width" : "height"] = (totalSize + mainAxisPadding) + "px";
+        updateContentSize?.(totalSize);
         if (stickyHeader) {
           stickyHeader.refresh();
           stickyHeader.update(engineState.scrollPosition);

--- a/src/plugins/snapshots/plugin.ts
+++ b/src/plugins/snapshots/plugin.ts
@@ -43,9 +43,8 @@ export function snapshots<T extends VListItem = VListItem>(
 ): VListPlugin<T> {
   const autoSaveKey = config?.autoSave;
 
-  const restoreSnapshot = autoSaveKey
-    ? readSnapshot(autoSaveKey)
-    : config?.restore;
+  const restoreSnapshot = config?.restore
+    ?? (autoSaveKey ? readSnapshot(autoSaveKey) : undefined);
 
   let disposed = false;
   let saveToStorage: (() => void) | null = null;

--- a/src/plugins/table/plugin.ts
+++ b/src/plugins/table/plugin.ts
@@ -66,6 +66,14 @@ export function table<T extends VListItem = VListItem>(
   let lastAriaRowCount = -1;
   let lastContentTotalSize = -1;
 
+  // Resolved once on first render: when the groups plugin is active it runs the
+  // table in LAYOUT-index space (header pseudo-entries interleaved with data
+  // rows) and exposes _layoutToDataIndex to translate back. Stays null for a
+  // plain table (layout space == data space). All plugin setups complete before
+  // the first render, so a one-shot resolve is safe regardless of plugin order.
+  let layoutToDataFn: ((layoutIndex: number) => number) | null = null;
+  let layoutToDataResolved = false;
+
   function resolveSelectionMethods(): void {
     if (selectionResolved || !storedCtx) return;
     selectionResolved = true;
@@ -138,14 +146,40 @@ export function table<T extends VListItem = VListItem>(
     engineState.prevRangeEnd = renderEnd;
     engineState.renderPending = false;
 
-    const count = renderEnd - renderStart + 1;
-    engineState.visibleCount = Math.min(count, engineState.capacity);
-    engineState.startIndex = renderStart;
-    for (let i = 0; i < engineState.visibleCount; i++) {
-      const idx = renderStart + i;
-      engineState.visibleIndices[i] = idx;
-      engineState.visibleOffsets[i] = sizeCache.getOffset(idx);
-      engineState.visibleSizes[i] = sizeCache.getSize(idx);
+    // Publish the visible DATA range for the async data plugin's load hooks.
+    // They read startIndex + visibleCount as a CONTIGUOUS data range (group
+    // headers interrupt layout space, not data space) and are the only consumer
+    // of these in table mode — the per-row visible* arrays are read solely by
+    // the default render pipeline, which the table replaces, so we don't touch
+    // them. When grouped, renderStart/renderEnd are layout indices; translate
+    // the first and last data rows of the (overscanned) window via
+    // _layoutToDataIndex (−1 for header pseudo-entries). Without this the loader
+    // gets layout indices, requests a data-shifted range, and the top of the
+    // viewport stays stuck on placeholders.
+    if (!layoutToDataResolved) {
+      layoutToDataResolved = true;
+      layoutToDataFn =
+        (storedCtx.getMethod?.("_layoutToDataIndex") as ((i: number) => number) | undefined) ?? null;
+    }
+
+    if (layoutToDataFn) {
+      const toData = layoutToDataFn;
+      let firstDataIndex = -1;
+      for (let i = renderStart; i <= renderEnd; i++) {
+        const di = toData(i);
+        if (di >= 0) { firstDataIndex = di; break; }
+      }
+      let lastDataIndex = -1;
+      for (let i = renderEnd; i >= renderStart; i--) {
+        const di = toData(i);
+        if (di >= 0) { lastDataIndex = di; break; }
+      }
+      engineState.startIndex = firstDataIndex < 0 ? renderStart : firstDataIndex;
+      engineState.visibleCount = firstDataIndex < 0 ? 0 : lastDataIndex - firstDataIndex + 1;
+    } else {
+      // Plain table (no groups): layout space == data space.
+      engineState.startIndex = renderStart;
+      engineState.visibleCount = renderEnd - renderStart + 1;
     }
 
     // Route content sizing through the engine so bounded mode (RFC-013) caps the

--- a/src/utils/rebuild.ts
+++ b/src/utils/rebuild.ts
@@ -52,38 +52,22 @@ export async function rebuild<T extends VListItem = VListItem>(
   const key = options?.key;
 
   // Capture scroll snapshot from old list
-  let snapshot: ScrollSnapshot | undefined;
-  if (previous) {
-    const getSnapshot = previous.getScrollSnapshot as
-      | (() => ScrollSnapshot)
-      | undefined;
-    if (typeof getSnapshot === "function") {
-      snapshot = getSnapshot();
-    }
-  }
+  const getSnapshot = previous?.getScrollSnapshot as
+    | (() => ScrollSnapshot)
+    | undefined;
+  const snapshot = typeof getSnapshot === "function" ? getSnapshot() : undefined;
 
-  // Persist to sessionStorage so snapshots plugin auto-restores
-  if (snapshot && key) {
-    try {
-      sessionStorage.setItem(key, JSON.stringify(snapshot));
-    } catch { /* sessionStorage full or unavailable */ }
-  }
-
-  // Pre-configured snapshots plugin: autoSave for persistence, restore for one-shot
+  // Snapshots plugin: direct restore (no sessionStorage round-trip) + optional auto-save
   const snapshotPlugin = snapshots<T>(
-    key
-      ? { autoSave: key }
-      : snapshot
-        ? { restore: snapshot }
-        : undefined,
+    snapshot
+      ? key ? { restore: snapshot, autoSave: key } : { restore: snapshot }
+      : key ? { autoSave: key } : undefined,
   );
 
-  // Create new list in the same container — old DOM stays visible
   const newList = create(snapshotPlugin);
   const newRoot = newList.element;
 
-  // Hide new list behind old (overlay, invisible, but renders for layout).
-  // The container must have position: relative for this to work.
+  // Hide new list behind old (overlay, invisible, but renders for layout)
   newRoot.style.position = "absolute";
   newRoot.style.inset = "0";
   newRoot.style.visibility = "hidden";
@@ -92,22 +76,20 @@ export async function rebuild<T extends VListItem = VListItem>(
   if (options?.ready) {
     await options.ready(newList);
   } else {
-    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
   }
 
-  // Optional settle delay
-  const delay = options?.delay;
-  if (delay && delay > 0) {
-    await new Promise<void>((resolve) => setTimeout(resolve, delay));
+  if (options?.delay && options.delay > 0) {
+    await new Promise<void>((r) => setTimeout(r, options.delay));
   }
 
+  // Crossfade
   const raw = options?.transition;
   const fadeIn = typeof raw === "number" ? raw : raw?.fadeIn ?? 0;
   const fadeOut = typeof raw === "number" ? raw : raw?.fadeOut ?? 0;
   const fadeOutDelay = typeof raw === "object" ? raw?.fadeOutDelay ?? 0 : 0;
-  const longest = Math.max(fadeIn, fadeOut + fadeOutDelay);
 
-  if (longest > 0 && previous) {
+  if (previous && (fadeIn > 0 || fadeOut > 0)) {
     const oldRoot = previous.element;
 
     newRoot.style.visibility = "";
@@ -119,9 +101,9 @@ export async function rebuild<T extends VListItem = VListItem>(
     newRoot.style.opacity = "1";
     oldRoot.style.opacity = "0";
 
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, longest + 50);
-    });
+    await new Promise<void>((r) =>
+      setTimeout(r, Math.max(fadeIn, fadeOut + fadeOutDelay) + 50),
+    );
 
     newRoot.style.transition = "";
     newRoot.style.opacity = "";

--- a/test/integration/groups-bounded.test.ts
+++ b/test/integration/groups-bounded.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Groups + Data + bounded scroll (RFC-012) integration test.
+ *
+ * Regression guard for the groups plugin's bounded-mode awareness. The bounded
+ * scroll model keeps `vlist-content` at the runway size (a small multiple of the
+ * viewport) and positions items at `getOffset(index) - baseOffset`. The groups
+ * plugin originally sized content to the full virtual height and positioned items
+ * at their raw absolute offset — so in bounded mode the content blew past the
+ * browser's element cap and every item rendered far outside the viewport (blank
+ * list on scroll). This is the scenario behind the desk accounts list (868k rows
+ * × 100px ≈ 87M px, well over the ~16-33M browser cap).
+ */
+
+import { describe, it, expect, mock, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { createVList } from "../../src/core/create";
+import type { VList } from "../../src/core/types";
+import { createContainer, type TestItem } from "../helpers/factory";
+import { data as dataPlugin } from "../../src/plugins/data/plugin";
+import { groups } from "../../src/plugins/groups/plugin";
+import { grid } from "../../src/plugins/grid/plugin";
+import type { VListAdapter } from "../../src/types";
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", { get() { return 500; }, configurable: true });
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", { get() { return 300; }, configurable: true });
+});
+afterAll(() => { GlobalRegistrator.unregister(); });
+
+interface UserItem extends TestItem {
+  day: number;
+}
+
+const TOTAL = 500_000;
+const ITEM_H = 100;
+const CHUNK = 50;
+
+function createUserAdapter(): VListAdapter<UserItem> {
+  return {
+    read: mock(async ({ offset, limit }: { offset: number; limit: number }) => {
+      const end = Math.min(offset + limit, TOTAL);
+      const items: UserItem[] = [];
+      for (let i = offset; i < end; i++) {
+        items.push({ id: i + 1, name: `User ${i + 1}`, value: i, day: Math.floor(i / 20) });
+      }
+      return { items, total: TOTAL, hasMore: end < TOTAL };
+    }),
+  };
+}
+
+const dayGroup = (_index: number, item?: any): string => (item ? `day-${item.day}` : "loading");
+
+function translateMain(el: HTMLElement): number {
+  // groups buildTransform emits `translate(0, Ypx)` (vertical) — grab the Y.
+  const m = /,\s*([-\d.]+)px/.exec(el.style.transform || "");
+  return m ? parseFloat(m[1]) : NaN;
+}
+
+let container: HTMLElement;
+let list: VList<UserItem> | null = null;
+
+beforeEach(() => { container = createContainer({ width: 300, height: 500 }); });
+afterEach(() => { list?.destroy(); list = null; container.remove(); });
+
+describe("groups + data + bounded scroll", () => {
+  it("keeps content viewport-sized and renders items in-viewport when scrolled deep", async () => {
+    const adapter = createUserAdapter();
+    list = createVList(
+      { container, item: { height: ITEM_H, template: (it: any) => (it ? it.name : "") }, scroll: { mode: "bounded" } } as any,
+      [
+        dataPlugin({ adapter, storage: { chunkSize: CHUNK, maxCachedItems: 100_000 } }),
+        groups({ getGroupForIndex: dayGroup, header: { height: 28, template: (k) => k } }),
+      ],
+    );
+    await new Promise((r) => setTimeout(r, 120));
+
+    // Scroll deep into the list (far past the browser element cap in raw pixels).
+    (list as any).scrollToIndex(200_000);
+    await (list as any).loadVisibleRange();
+    await new Promise((r) => setTimeout(r, 120));
+
+    const content = container.querySelector(".vlist-content") as HTMLElement;
+    const contentHeight = parseFloat(content.style.height) || 0;
+    const fullVirtual = TOTAL * ITEM_H; // ~50,000,000px
+
+    // Content stays bounded to the runway, not the full virtual height.
+    expect(contentHeight).toBeGreaterThan(0);
+    expect(contentHeight).toBeLessThan(fullVirtual / 100);
+
+    const items = Array.from(container.querySelectorAll(".vlist-item")) as HTMLElement[];
+    expect(items.length).toBeGreaterThan(0); // not blank
+
+    // Every rendered item sits within the runway (offset - baseOffset), not at
+    // its multi-million-pixel absolute offset.
+    const maxAbsY = Math.max(...items.map((el) => Math.abs(translateMain(el))).filter((n) => !isNaN(n)));
+    expect(maxAbsY).toBeLessThan(contentHeight + 5 * ITEM_H);
+  });
+
+  it("keeps items distinctly spaced during gradual scroll (rebase repositions all visible items)", async () => {
+    // Gradual (trackpad-style) scroll, unlike a scrollbar jump, keeps items in
+    // the visible range across frames — they hit the render's fast path. When
+    // the runway rebases (baseOffset shifts), those already-rendered items must
+    // be repositioned; otherwise they keep a stale transform and pile up at the
+    // same Y. A larger runway (matches the desk config) makes rebasing happen
+    // mid-scroll, exercising exactly that path.
+    const adapter = createUserAdapter();
+    list = createVList(
+      { container, item: { height: ITEM_H, template: (it: any) => (it ? it.name : "") }, scroll: { mode: "bounded", runway: 12 } } as any,
+      [
+        dataPlugin({ adapter, storage: { chunkSize: CHUNK, maxCachedItems: 100_000 } }),
+        groups({ getGroupForIndex: dayGroup, header: { height: 28, template: (k) => k } }),
+      ],
+    );
+    await new Promise((r) => setTimeout(r, 120));
+
+    const vp = container.querySelector(".vlist-viewport") as HTMLElement;
+    const content = container.querySelector(".vlist-content") as HTMLElement;
+    const maxTop = () => parseFloat(content.style.height) - 500;
+
+    // Small (trackpad-like) steps keep items in the visible range across frames,
+    // so they hit the render's fast path while the runway rebases under them.
+    // Check overlap on EVERY step, not just the end — a coarse jump would turn
+    // the whole range over and mask the bug.
+    let maxRendered = 0;
+    let worstOverlap = 0;
+    for (let k = 0; k < 200; k++) {
+      vp.scrollTop = Math.min(vp.scrollTop + 35, maxTop());
+      vp.dispatchEvent(new Event("scroll", { bubbles: true }));
+      const items = Array.from(container.querySelectorAll(".vlist-item")) as HTMLElement[];
+      const ys = items.map(translateMain).filter((n) => !isNaN(n));
+      const distinct = new Set(ys.map((y) => Math.round(y))).size;
+      maxRendered = Math.max(maxRendered, ys.length);
+      worstOverlap = Math.max(worstOverlap, ys.length - distinct);
+    }
+
+    expect(maxRendered).toBeGreaterThan(3);   // items actually rendered
+    expect(worstOverlap).toBe(0);             // no item ever shares another's Y
+  });
+
+  it("grouped GRID renders items in-viewport when scrolled deep (bounded)", () => {
+    // Covers buildTransform's grid branch (pos.rowY - baseOffset), which the
+    // desk tracks grid view uses. Static items keep it synchronous/deterministic.
+    const COLS = 4;
+    const items = Array.from({ length: 5000 }, (_, i) => ({ id: i + 1, name: `U${i + 1}`, value: i, day: Math.floor(i / 40) }));
+    list = createVList(
+      { container, items, item: { height: ITEM_H, template: (it: any) => (it ? it.name : "") }, scroll: { mode: "bounded", runway: 12 } } as any,
+      [
+        grid({ columns: COLS, gap: 8 }),
+        groups({ getGroupForIndex: dayGroup, header: { height: 28, template: (k) => k } }),
+      ],
+    );
+
+    // Scroll deep — row offset is far past the runway, so baseOffset is large.
+    (list as any).scrollToIndex(2000);
+
+    const content = container.querySelector(".vlist-content") as HTMLElement;
+    const contentHeight = parseFloat(content.style.height) || 0;
+    const rows = 5000 / COLS;
+    const fullVirtual = rows * ITEM_H; // grid: ~125,000px
+
+    // Content bounded to the runway, not the full grid height.
+    expect(contentHeight).toBeGreaterThan(0);
+    expect(contentHeight).toBeLessThan(fullVirtual / 10);
+
+    const els = Array.from(container.querySelectorAll(".vlist-item")) as HTMLElement[];
+    expect(els.length).toBeGreaterThan(0);
+
+    // Main-axis (Y) transforms land in the runway, not at the absolute rowY.
+    const maxAbsY = Math.max(...els.map((el) => Math.abs(translateMain(el))).filter((n) => !isNaN(n)));
+    expect(maxAbsY).toBeLessThan(contentHeight + 5 * ITEM_H);
+
+    // Grid is actually laying out columns: data rows occupy >1 distinct X.
+    const xs = new Set(
+      els
+        .map((el) => /translate\(\s*([-\d.]+)px/.exec(el.style.transform || ""))
+        .filter(Boolean)
+        .map((m) => Math.round(parseFloat(m![1]))),
+    );
+    expect(xs.size).toBeGreaterThan(1);
+  });
+});

--- a/test/integration/groups-table-data.test.ts
+++ b/test/integration/groups-table-data.test.ts
@@ -675,4 +675,83 @@ describe("groups + table + data", () => {
       expect(dataRows.length).toBeGreaterThan(0);
     });
   });
+
+  // ── Scrolled load uses DATA indices, not layout indices ─────────────
+  //
+  // Regression: in grouped TABLE mode the engine runs in layout-index space
+  // (header pseudo-rows interleaved with data rows). The table render must
+  // translate the visible window back to DATA indices before the data plugin
+  // loads it. Before the fix it published raw layout indices, so the loader
+  // requested a range shifted by the header count above the viewport — at the
+  // bottom that range overshoots past the dataset and the last rows never load;
+  // mid-list it loads the bottom of the viewport and leaves the top stuck on
+  // placeholders. This is table-only: list/grid translate via the groups/grid
+  // render's entry.dataIndex fill.
+  describe("scrolled load uses data indices (table-mode regression)", () => {
+    // One group per item → header count equals the loaded-item count, so layout
+    // indices diverge sharply from data indices: any off-by-headers bug pushes
+    // the requested range clean past the dataset.
+    const eachIdGroup = (_index: number, item?: any): string =>
+      item ? `g-${item.id}` : "loading";
+
+    const TOTAL = 500;
+    const CHUNK = 20;
+    const LAST = TOTAL - 1;
+
+    function scrollToBottom(l: VList<CityItem>): void {
+      const vp = (l as unknown as { element: HTMLElement }).element
+        .querySelector(".vlist-viewport") as HTMLElement;
+      vp.scrollTop = 10_000_000; // clamped to max scroll by the runway
+      vp.dispatchEvent(new Event("scroll", { bubbles: true }));
+    }
+
+    function readParams(adapter: VListAdapter<CityItem>): Array<{ offset: number; limit: number }> {
+      return (adapter.read as any).mock.calls.map((c: any[]) => c[0] as { offset: number; limit: number });
+    }
+
+    it("loads the chunk covering the last row when scrolled to the bottom (grouped)", async () => {
+      const adapter = createCityAdapter(TOTAL);
+      list = createList(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: CHUNK, maxCachedItems: 100_000 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 28 }),
+          groups({ getGroupForIndex: eachIdGroup, header: { height: 28, template: (k) => k } }),
+        ],
+      );
+      await waitForLoad(list);
+
+      (adapter.read as any).mockClear();
+      scrollToBottom(list);
+      await new Promise((r) => setTimeout(r, 300)); // scroll idle (150ms) + chunk load
+
+      const reads = readParams(adapter);
+      expect(reads.length).toBeGreaterThan(0);
+      // The chunk containing the LAST data row must be fetched...
+      expect(reads.some((p) => p.offset <= LAST && LAST < p.offset + p.limit)).toBe(true);
+      // ...and nothing may be requested past the dataset (the bug's signature:
+      // a layout index used as a data offset, shifted beyond `total`).
+      expect(reads.every((p) => p.offset < TOTAL)).toBe(true);
+    });
+
+    it("loads the chunk covering the last row at the bottom (plain table baseline)", async () => {
+      // Guards the non-grouped branch (layout space == data space).
+      const adapter = createCityAdapter(TOTAL);
+      list = createList(
+        { container, item: { height: 36, template: () => "" } },
+        [
+          dataPlugin({ adapter, storage: { chunkSize: CHUNK, maxCachedItems: 100_000 } }),
+          table({ columns: COLUMNS, rowHeight: 36, headerHeight: 28 }),
+        ],
+      );
+      await waitForLoad(list);
+
+      (adapter.read as any).mockClear();
+      scrollToBottom(list);
+      await new Promise((r) => setTimeout(r, 300));
+
+      const reads = readParams(adapter);
+      expect(reads.some((p) => p.offset <= LAST && LAST < p.offset + p.limit)).toBe(true);
+    });
+  });
 });

--- a/test/plugins/carousel/plugin.test.ts
+++ b/test/plugins/carousel/plugin.test.ts
@@ -1994,6 +1994,93 @@ describeCarousel("carousel — onIdle snap", () => {
 
     cleanup();
   });
+
+  it("snaps forward when scrollDirection is positive", () => {
+    const items = createTestItems(5);
+    const { ctx, scrollCalls, cleanup } = createPluginMockContext<TestItem>(items, {
+      containerHeight: 400,
+      itemSize: 400,
+    });
+
+    const plugin = carousel({ snap: true, snapDirection: true });
+    plugin.setup!(ctx);
+    if (plugin.hooks?.onCommit) plugin.hooks.onCommit();
+
+    const es = ctx.getState();
+    // Position slightly past item boundary (frac ~0.1 — would round backward without direction)
+    const misaligned = 50 * 5 * 400 + 40;
+    es.scrollPosition = misaligned;
+    es.scrollDirection = 1;
+    scrollCalls.length = 0;
+    plugin.hooks!.onAfterScroll!(es.scrollPosition);
+
+    es.scrollDirection = 0;
+    plugin.hooks!.onIdle!();
+
+    // Should have snapped forward (to next item) despite small frac
+    const lastSnap = scrollCalls[scrollCalls.length - 1]!;
+    expect(lastSnap).toBeGreaterThan(misaligned);
+
+    cleanup();
+  });
+
+  it("snaps backward when scrollDirection is negative", () => {
+    const items = createTestItems(5);
+    const { ctx, scrollCalls, cleanup } = createPluginMockContext<TestItem>(items, {
+      containerHeight: 400,
+      itemSize: 400,
+    });
+
+    const plugin = carousel({ snap: true, snapDirection: true });
+    plugin.setup!(ctx);
+    if (plugin.hooks?.onCommit) plugin.hooks.onCommit();
+
+    const es = ctx.getState();
+    // Position mostly through item (frac ~0.9 — would round forward without direction)
+    const misaligned = 50 * 5 * 400 + 360;
+    es.scrollPosition = misaligned;
+    es.scrollDirection = -1;
+    scrollCalls.length = 0;
+    plugin.hooks!.onAfterScroll!(es.scrollPosition);
+
+    es.scrollDirection = 0;
+    plugin.hooks!.onIdle!();
+
+    // Should have snapped backward despite high frac
+    const lastSnap = scrollCalls[scrollCalls.length - 1]!;
+    expect(lastSnap).toBeLessThan(misaligned);
+
+    cleanup();
+  });
+
+  it("falls back to nearest when snapDirection is false", () => {
+    const items = createTestItems(5);
+    const { ctx, scrollCalls, cleanup } = createPluginMockContext<TestItem>(items, {
+      containerHeight: 400,
+      itemSize: 400,
+    });
+
+    const plugin = carousel({ snap: true, snapDirection: false });
+    plugin.setup!(ctx);
+    if (plugin.hooks?.onCommit) plugin.hooks.onCommit();
+
+    const es = ctx.getState();
+    // Small forward offset — nearest-snap rounds backward
+    const misaligned = 50 * 5 * 400 + 40;
+    es.scrollPosition = misaligned;
+    es.scrollDirection = 1;
+    scrollCalls.length = 0;
+    plugin.hooks!.onAfterScroll!(es.scrollPosition);
+
+    es.scrollDirection = 0;
+    plugin.hooks!.onIdle!();
+
+    // Nearest snap: frac ~0.1, rounds backward
+    const lastSnap = scrollCalls[scrollCalls.length - 1]!;
+    expect(lastSnap).toBeLessThan(misaligned);
+
+    cleanup();
+  });
 });
 
 // =============================================================================

--- a/test/plugins/carousel/plugin.test.ts
+++ b/test/plugins/carousel/plugin.test.ts
@@ -2551,3 +2551,47 @@ describeCarousel("carousel — Variable-width (multi-aspect)", () => {
     cleanup();
   });
 });
+
+// =============================================================================
+// snapEasing wiring
+// =============================================================================
+
+describeCarousel("carousel — snapEasing", () => {
+  it("forwards the configured snapEasing to smoothScrollTo as the easing argument", () => {
+    // Regression: the carousel called smoothScrollTo(target, duration, undefined,
+    // snapEasing), parking snapEasing in the onComplete slot — so a configured
+    // snapEasing was silently ignored and snaps used the default easing. It must
+    // be forwarded as the easing (3rd) argument.
+    const items = createTestItems(5);
+    const { ctx, methods, cleanup } = createPluginMockContext<TestItem>(items, {
+      containerHeight: 400,
+      itemSize: 400,
+    });
+
+    const snapEasing = (t: number): number => t; // marker (linear) easing
+    let smoothCalled = false;
+    let capturedEasing: ((t: number) => number) | undefined;
+    const realSmooth = ctx.smoothScrollTo;
+    ctx.smoothScrollTo = ((
+      target: number | (() => number),
+      duration: number,
+      easing?: (t: number) => number,
+      onComplete?: () => void,
+    ) => {
+      smoothCalled = true;
+      capturedEasing = easing;
+      return realSmooth(target, duration, easing, onComplete);
+    }) as typeof ctx.smoothScrollTo;
+
+    carousel({ snapEasing }).setup!(ctx);
+
+    const goTo = methods.get("goTo") as (index: number, options?: Record<string, unknown>) => void;
+    // A smooth programmatic navigation triggers a snap animation.
+    goTo(2, { behavior: "smooth", direction: "forward" });
+
+    expect(smoothCalled).toBe(true);
+    expect(capturedEasing).toBe(snapEasing);
+
+    cleanup();
+  });
+});

--- a/test/plugins/data/lifecycle.test.ts
+++ b/test/plugins/data/lifecycle.test.ts
@@ -156,6 +156,34 @@ describe("async lifecycle — velocity-gated loading", () => {
     expect(adapter.read).toHaveBeenCalled();
   });
 
+  it("reconciles the visible range on idle even with no pending range queued", async () => {
+    // Regression: a momentum (flick) scroll can settle with its final
+    // onAfterScroll in the slow path, which calls resetDeceleration() →
+    // pendingRange = null without re-ensuring the settled chunk. Idle must then
+    // still load the currently-visible range; otherwise the viewport is left
+    // stuck on placeholders. So onIdle reconciles the visible range
+    // unconditionally — not only when a pendingRange flag was set.
+    const adapter = createMockAdapter(1000);
+    const plugin = dataPlugin({ adapter, autoLoad: false, total: 1000 });
+    const { ctx, engineState } = createContextWithEmitter({
+      visibleCount: 10,
+      startIndex: 100,
+    });
+
+    plugin.setup(ctx);
+    engineState.initialized = true;
+    await flush();
+
+    // Idle with NO prior onAfterScroll → pendingRange is null.
+    plugin.hooks!.onIdle!();
+    await flush();
+
+    expect(adapter.read).toHaveBeenCalled();
+    // It loaded the chunk covering the visible range [100..109], not the top.
+    const calls = (adapter.read as any).mock.calls.map((c: any[]) => c[0] as { offset: number; limit: number });
+    expect(calls.some((p) => p.offset <= 100 && 100 < p.offset + p.limit)).toBe(true);
+  });
+
   it("does not load on afterScroll when destroyed", async () => {
     const adapter = createMockAdapter(1000);
     const plugin = dataPlugin({ adapter, autoLoad: false, total: 1000 });


### PR DESCRIPTION
## v2.5.1

Carousel snap refinements + targeted fixes.

### Added
- Carousel snap: direction-aware, configurable easing, enforced for the `full` variant

### Fixed
- Groups plugin bounded-scroll aware (sticky headers + transforms honor `baseOffset`)
- Carousel `snapEasing` forwarded to `smoothScrollTo`
- Carousel static variant repositions during smooth scroll
- Async data: visible range reconciles on idle regardless of pending range
- Grouped tables publish data indices to the loader

### Release housekeeping
- Version 2.5.0 → 2.5.1
- Corrected carousel size in both READMEs (+3.4 KB; npm-readme was stale at +2.3)

Verified: typecheck clean · 3426 tests pass · build clean (base 9.7 KB gz).