### PR TITLE
fix(core): scrollToIndex before the list has a length is honoured, not dropped

### DIFF
--- a/src/core/create.ts
+++ b/src/core/create.ts
@@ -297,6 +297,15 @@ export function createVList<T extends VListItem = VListItem>(
   let smoothScrollFn: ((target: number | (() => number), duration: number, setFn?: (pos: number) => void, easing?: (t: number) => number, onComplete?: () => void) => void) | null = null;
   let scrollToPosFn: ((index: number, sizeCache: SizeCache, containerSize: number, totalItems: number, align: string) => number) | null = null;
   let scrollToIndexFn: ((index: number, align: string, behavior?: string, duration?: number, easing?: (t: number) => number) => void | false) | null = null;
+  /**
+   * A scrollToIndex asked for before the list knew how long it was.
+   *
+   * With an async adapter the total arrives after the list is created, so
+   * "open this list on row 2960" is given before there is a row 2960 to scroll
+   * to. It used to be dropped in silence, which no caller could detect; it is
+   * held here instead and honoured on the first render that has a total.
+   */
+  let pendingScrollToIndex: { index: number; alignOrOptions: Parameters<VList<T>["scrollToIndex"]>[1] } | null = null;
   let boundedHandler: BoundedScrollHandler | null = null;
   // A plugin (carousel) can request the bounded handler in wrap mode during
   // setup, before the handler is built below. Wrap implies bounded.
@@ -538,7 +547,18 @@ export function createVList<T extends VListItem = VListItem>(
     }
   }
 
+  /** A scroll asked for before the list had a length, once it has one. */
+  function flushPendingScroll(): void {
+    if (!pendingScrollToIndex) return;
+    const total = virtualTotalFn ? virtualTotalFn() : items.length;
+    if (total === 0) return;
+    const wanted = pendingScrollToIndex;
+    pendingScrollToIndex = null;
+    api.scrollToIndex(wanted.index, wanted.alignOrOptions);
+  }
+
   function doRender(): void {
+    flushPendingScroll();
     if (customRenderIfNeeded) {
       customRenderIfNeeded();
     } else {
@@ -574,6 +594,7 @@ export function createVList<T extends VListItem = VListItem>(
   }
 
   function doForceRender(): void {
+    flushPendingScroll();
     state.renderPending = true;
     if (customForceRender) {
       customForceRender();
@@ -866,7 +887,11 @@ export function createVList<T extends VListItem = VListItem>(
       alignOrOptions: "start" | "center" | "end" | { align?: "start" | "center" | "end"; behavior?: "auto" | "smooth"; duration?: number; easing?: (t: number) => number } = "start",
     ): void {
       const total = virtualTotalFn ? virtualTotalFn() : items.length;
-      if (total === 0) return;
+      if (total === 0) {
+        // not "nowhere to scroll" but "not yet": held until a total arrives
+        pendingScrollToIndex = { index, alignOrOptions };
+        return;
+      }
       const clamped = Math.max(0, Math.min(index, total - 1));
 
       const align = typeof alignOrOptions === "string" ? alignOrOptions : (alignOrOptions.align ?? "start");

--- a/test/core/scroll-to-index.test.ts
+++ b/test/core/scroll-to-index.test.ts
@@ -177,6 +177,37 @@ describe("scrollToIndex — edge cases", () => {
     expect(viewport.scrollTop).toBe(0);
   });
 
+  it("a scroll asked for before the list has a length is honoured when it gets one", () => {
+    // With an async adapter the total arrives after the list is created, so
+    // "open this list on row 60" is given before there is a row 60. Dropping
+    // it in silence made that a race no caller could win: the list opened at
+    // the top and nothing said why.
+    const vlist = makeList(0);
+    const viewport = getViewport(container);
+
+    vlist.scrollToIndex(60, "start");
+    expect(viewport.scrollTop).toBe(0);
+
+    vlist.setItems(createTestItems(100));
+
+    expect(viewport.scrollTop).toBe(60 * 50);
+  });
+
+  it("only the last one asked for is kept, and only until it is honoured", () => {
+    const vlist = makeList(0);
+    const viewport = getViewport(container);
+
+    vlist.scrollToIndex(10, "start");
+    vlist.scrollToIndex(60, "start");
+    vlist.setItems(createTestItems(100));
+    expect(viewport.scrollTop).toBe(60 * 50);
+
+    // and it does not fire again on the next render
+    viewport.scrollTop = 0;
+    vlist.setItems(createTestItems(100));
+    expect(viewport.scrollTop).toBe(0);
+  });
+
   it("single item list scrolls to 0", () => {
     const vlist = makeList(1);
     const viewport = getViewport(container);


### PR DESCRIPTION
Agent: Claude Opus 5 · lane-web-player

`scrollToIndex` returned in silence when the total was zero:

```ts
const total = virtualTotalFn ? virtualTotalFn() : items.length;
if (total === 0) return;
```

For a list with items that is right — there is nowhere to go. For a list with an **async adapter** it is a race no caller can win: the total arrives after the list is created, so "open this list on row 2960" is necessarily given before there *is* a row 2960. The list opened at the top and nothing told the caller why.

The request is held and honoured on the first render that has a total, from both render paths (`setItems` forces one; a plugin's own render goes through the other). Only the last request is kept, and only until it is used.

**Found from a consumer**: landing on a track in the middle of a member's list of 6676 in the Radiooooo v4 client. The data window loaded and the row was marked, but the viewport stayed at the top. With this it lands where it was told — `scrollTop` 177,466 for index 2960 at 60px rows, centred in a 900px viewport.

3463 tests green, two new: the pending scroll is honoured when a length arrives, and it fires once rather than on every later render.

Docs updated in floor/vlist.io (`docs/api.md`, on `staging`).